### PR TITLE
ZMI: Inverted the foldout of action context menu for edit/select and insert objects

### DIFF
--- a/Products/zms/_zmi_actions_util.py
+++ b/Products/zms/_zmi_actions_util.py
@@ -33,10 +33,10 @@ def zmi_actions(container, context, attr_id='e'):
     objPath = context.id+'/'
   
   #-- Action: Separator.
+  actions.extend(zmi_insert_actions(container, context, objAttr, objChildren, objPath))
   actions.append(('----- %s -----'%container.getZMILangStr('ACTION_SELECT')%container.getZMILangStr('ATTR_ACTION'), 'select-action'))
   actions.extend(zmi_basic_actions(container, context, objAttr, objChildren, objPath))
-  actions.extend(zmi_insert_actions(container, context, objAttr, objChildren, objPath))
-  
+
   # Return action list.
   return actions
 
@@ -217,7 +217,7 @@ def zmi_insert_actions(container, context, objAttr, objChildren, objPath=''):
   
   #-- Headline.
   if len(actions) > 0:
-    actions.insert(0, ('----- %s -----'%container.getZMILangStr('ACTION_INSERT')%container.display_type(REQUEST), 'insert-action'))
+    actions.insert(0, ('----- %s -----'%container.getZMILangStr('CAPTION_INSERT')%container.getZMILangStr('ATTR_OBJECT'), 'insert-action'))
   
   # Return action list.
   return actions

--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -1510,7 +1510,7 @@ ZMIActionList.prototype.over = function(el, e, cb) {
 	// Expandable headers.
 	$button.click(function() {
 		var $right = $(this).parents(".right");
-		var selected = $("input:checkbox",$right).length?$("input:checkbox",$right).prop("checked"):false;
+		var selected = false;
 		$(".dropdown-header",$right).each(function(index) {
 				var actualCollapsed = $("i",this).hasClass("fa-caret-right");
 				var expectedCollapsed = (index == 0 && !selected) || (index > 0 && selected);
@@ -1588,9 +1588,6 @@ ZMIActionList.prototype.over = function(el, e, cb) {
 			$("button.split-left",el).html(opticon+' '+optlabel);
 		}
 		for (var i = o; i < actions.length; i++) {
-			if (o==0 && i==1) {
-				$ul.append('<a class="dropdown-item" href="javascript:zmiToggleSelectionButtonClick($(\'li.zmi-item' + (id==''?':first':'#zmi_item_'+id) + '\'))"><i class="fas fa-check-square"></i> '+getZMILangStr('BTN_SLCTALL')+'/'+getZMILangStr('BTN_SLCTNONE')+'</a>');
-			}
 			var action = actions[i];
 			var optlabel = action[0];
 			var optvalue = action[1];
@@ -1602,6 +1599,9 @@ ZMIActionList.prototype.over = function(el, e, cb) {
 				optlabel = optlabel.substr(0,optlabel.lastIndexOf("-----"));
 				optlabel = optlabel.basicTrim();
 				$ul.append('<div class="dropdown-header '+optvalue+'">'+opticon+' '+optlabel+'</div>');
+				if (optvalue=='select-action') {
+					$ul.append('<a class="dropdown-item" href="javascript:zmiToggleSelectionButtonClick($(\'li.zmi-item' + (id==''?':first':'#zmi_item_'+id) + '\'))"><i class="fas fa-check-square"></i> '+getZMILangStr('BTN_SLCTALL')+'/'+getZMILangStr('BTN_SLCTNONE')+'</a>');
+				}
 			}
 			else {
 				if (opticon.indexOf('<')!=0) {


### PR DESCRIPTION
### Proposal

Streamline the ZMI action context menu regarding

- foldout inverted: objects first folded, actions second folded out
- caption changed: _Insert Object_ instead of _Add to WWW-site etc._

![Screen Shot 2021-10-19 at 10 53 56](https://user-images.githubusercontent.com/9883510/137882339-aef0b833-e5bf-4b2d-a281-08621902a114.png)