### PR TITLE
ZMI: modif action menu title for inserting content

### DIFF
--- a/Products/zms/_zmi_actions_util.py
+++ b/Products/zms/_zmi_actions_util.py
@@ -217,7 +217,7 @@ def zmi_insert_actions(container, context, objAttr, objChildren, objPath=''):
   
   #-- Headline.
   if len(actions) > 0:
-    actions.insert(0, ('----- %s -----'%container.getZMILangStr('ACTION_INSERT')%container.display_type(REQUEST), 'insert-action'))
+    actions.insert(0, ('----- %s -----'%container.getZMILangStr('CAPTION_INSERT')%container.getZMILangStr('ATTR_CONTENT'), 'insert-action'))
   
   # Return action list.
   return actions


### PR DESCRIPTION
Generalised ZMI Action Menu header titel to "Insert Content" instead of "Add to $contenttype"

![inhalt_einfügen](https://user-images.githubusercontent.com/29705216/137914204-ac75d118-67fd-4b72-ba28-931cad41ac92.gif)

![inhalt_einfügen2](https://user-images.githubusercontent.com/29705216/137914236-eea3673b-267f-478d-b9c5-78a8b9abf60b.gif)

