### PR TITLE
ZMSRepoManager: Added support for langdict ex-/import

### DIFF
--- a/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/JSONEditor.py
+++ b/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/JSONEditor.py
@@ -62,7 +62,7 @@ class JSONEditor_class:
         self.JSONDict['properties'][var]                     = {}
         self.JSONDict['properties'][var]['type']             = item.type == 'float' and 'number' or item.type == 'mailattachment' and 'object' or item.type
         self.JSONDict['properties'][var]['title']            = item.title + (item.mandatory and ' *' or '')
-        self.JSONDict['properties'][var]['description']      = item.description + (item.type == 'multiselect' and obj.this.getLangStr('ZMSFORMULATOR_HINT_MULTISELECT',obj.this.REQUEST.get('lang')) or '')
+        self.JSONDict['properties'][var]['description']      = item.description + (item.type == 'multiselect' and obj.this.getLangStr('zms.formulator.lib.HINT_MULTISELECT',obj.this.REQUEST.get('lang')) or '')
         self.JSONDict['properties'][var]['propertyOrder']    = i
         self.JSONDict['properties'][var]['options']          = {}
         
@@ -193,8 +193,8 @@ class JSONEditor_class:
     langstr = ''
 
     for item in obj.this.getLangDict():
-      if item['key'].startswith('ZMSFORMULATOR_'):
-        langstr += '\n%s: "%s",'%(item['key'].replace('ZMSFORMULATOR_','').lower(), item[lang])
+      if item['key'].startswith('zms.formulator.lib.'):
+        langstr += '\n%s: "%s",'%(item['key'].replace('zms.formulator.lib.','').lower(), item[lang])
     
     return """JSONEditor.defaults.languages.%s = { %s };\nJSONEditor.defaults.language = "%s";
     """%(lang, langstr, lang)

--- a/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/__init__.py
+++ b/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/__init__.py
@@ -52,7 +52,7 @@ class zms_formulator_lib:
 			,"keys":[]
 			,"mandatory":0
 			,"multilang":0
-			,"name":"Importfile Lang-Dict.xml"
+			,"name":"langdict.xml"
 			,"repetitive":0
 			,"type":"resource"}
 

--- a/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/getJSONEditor.py
+++ b/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/getJSONEditor.py
@@ -11,7 +11,7 @@ def getJSONEditor(self):
       <span id="valid_indicator"></span>
       <input id="captcha" type="hidden" />
       <br />
-    '''%(self.getLangStr('ZMSFORMULATOR_BUTTON_SUBMIT',self.REQUEST.get('lang')), self.getLangStr('ZMSFORMULATOR_BUTTON_RESTORE',self.REQUEST.get('lang')))
+    '''%(self.getLangStr('zms.formulator.lib.BUTTON_SUBMIT',self.REQUEST.get('lang')), self.getLangStr('zms.formulator.lib.BUTTON_RESTORE',self.REQUEST.get('lang')))
   else:
     output = '''
       <div id="editor_holder"></div>
@@ -30,7 +30,7 @@ def getJSONEditor(self):
         function validate_or_submit(){if (grecaptcha.getResponse() ==""){grecaptcha.execute()}else{$('#submit').trigger('click')}}
       </script> 
       <br />
-    '''%(frmu.GoogleAPIKey,self.getLangStr('ZMSFORMULATOR_BUTTON_SUBMIT',self.REQUEST.get('lang')),self.getLangStr('ZMSFORMULATOR_BUTTON_RESTORE',self.REQUEST.get('lang')))
+    '''%(frmu.GoogleAPIKey,self.getLangStr('zms.formulator.lib.BUTTON_SUBMIT',self.REQUEST.get('lang')),self.getLangStr('zms.formulator.lib.BUTTON_RESTORE',self.REQUEST.get('lang')))
 
   if (frmu.feedbackMsg!=''):
     feedback = '''
@@ -47,7 +47,7 @@ def getJSONEditor(self):
           <div class="modal-content" style="padding:1em;">%s</div>
         </div>
       </div>
-      '''%(self.getLangStr('ZMSFORMULATOR_FEEDBACK_MSG',self.REQUEST.get('lang')).replace('\n','<br />'))
+      '''%(self.getLangStr('zms.formulator.lib.FEEDBACK_MSG',self.REQUEST.get('lang')).replace('\n','<br />'))
 
   self.REQUEST.RESPONSE.setHeader('Cache-Control', 'no-cache')
   self.REQUEST.RESPONSE.setHeader('Pragma', 'no-cache')

--- a/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/langdict.xml
+++ b/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/langdict.xml
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<?zms version='ZMS5-5.0.218'?>
+<?xml version="1.0" encoding="utf-8"?>
+<?zms version='ZMS5-5.1.0
+'?>
 <list>
   <item type="dictionary">
     <dictionary>
@@ -7,7 +8,7 @@
       <item key="fra">Restaurer</item>
       <item key="ger">Zurücksetzen</item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_BUTTON_RESTORE</item>
+      <item key="key">zms.formulator.lib.BUTTON_RESTORE</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -16,7 +17,7 @@
       <item key="fra">Soumettre</item>
       <item key="ger">Absenden</item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_BUTTON_SUBMIT</item>
+      <item key="key">zms.formulator.lib.BUTTON_SUBMIT</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -25,7 +26,7 @@
       <item key="fra"><![CDATA[No additional items allowed in this array]]></item>
       <item key="ger"><![CDATA[Keine weiteren Elemente in diesem Array erlaubt!]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_ADDITIONALITEMS</item>
+      <item key="key">zms.formulator.lib.ERROR_ADDITIONALITEMS</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -34,7 +35,7 @@
       <item key="fra"><![CDATA[No additional properties allowed, but property {{0}} is set]]></item>
       <item key="ger"><![CDATA[Keine weiteren Eigenschaften sind erlaubt; die Eigenschaft {{0}} ist gesetzt]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_ADDITIONAL_PROPERTIES</item>
+      <item key="key">zms.formulator.lib.ERROR_ADDITIONAL_PROPERTIES</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -43,7 +44,7 @@
       <item key="fra"><![CDATA[Value must validate against at least one of the provided schemas]]></item>
       <item key="ger"><![CDATA[Value must validate against at least one of the provided schemas]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_ANYOF</item>
+      <item key="key">zms.formulator.lib.ERROR_ANYOF</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -52,7 +53,7 @@
       <item key="fra"><![CDATA[Must have property {{0}}]]></item>
       <item key="ger"><![CDATA[Muss die Eigenschaft {0}} haben]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_DEPENDENCY</item>
+      <item key="key">zms.formulator.lib.ERROR_DEPENDENCY</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -61,7 +62,7 @@
       <item key="fra"><![CDATA[Value must not be of type {{0}}]]></item>
       <item key="ger"><![CDATA[Der Wert darf nicht dem Typen {{0}} entsprechen]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_DISALLOW</item>
+      <item key="key">zms.formulator.lib.ERROR_DISALLOW</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -70,7 +71,7 @@
       <item key="fra"><![CDATA[Value must not be one of the provided disallowed types]]></item>
       <item key="ger"><![CDATA[Der Wert darf nicht einem der unerlaubten Typen entsprechen]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_DISALLOW_UNION</item>
+      <item key="key">zms.formulator.lib.ERROR_DISALLOW_UNION</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -79,7 +80,7 @@
       <item key="fra"><![CDATA[Value must be one of the enumerated values]]></item>
       <item key="ger"><![CDATA[Der Wert muss einem der aufgezählten Werte entsprechen]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_ENUM</item>
+      <item key="key">zms.formulator.lib.ERROR_ENUM</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -88,7 +89,7 @@
       <item key="fra"><![CDATA[Value is mandatory]]></item>
       <item key="ger"><![CDATA[Der Wert ist eine Pflichtangabe]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_MANDATORY</item>
+      <item key="key">zms.formulator.lib.ERROR_MANDATORY</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -97,7 +98,7 @@
       <item key="fra"><![CDATA[Value must be less than {{0}}]]></item>
       <item key="ger"><![CDATA[Der Wert muss kleiner sein als {{0}}]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_MAXIMUM_EXCL</item>
+      <item key="key">zms.formulator.lib.ERROR_MAXIMUM_EXCL</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -106,7 +107,7 @@
       <item key="fra"><![CDATA[Value must be at most {{0}}]]></item>
       <item key="ger"><![CDATA[Der Wert muss maximal {{0}} sein]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_MAXIMUM_INCL</item>
+      <item key="key">zms.formulator.lib.ERROR_MAXIMUM_INCL</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -115,7 +116,7 @@
       <item key="fra"><![CDATA[Value must have at most {{0}} items]]></item>
       <item key="ger"><![CDATA[Der Wert darf maximal {{0}} Elemente enthalten]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_MAXITEMS</item>
+      <item key="key">zms.formulator.lib.ERROR_MAXITEMS</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -124,7 +125,7 @@
       <item key="fra"><![CDATA[Value must be at most {{0}} characters long]]></item>
       <item key="ger"><![CDATA[Der Wert darf maximal {{0}} Zeichen lang sein]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_MAXLENGTH</item>
+      <item key="key">zms.formulator.lib.ERROR_MAXLENGTH</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -133,7 +134,7 @@
       <item key="fra"><![CDATA[Object must have at most {{0}} properties]]></item>
       <item key="ger"><![CDATA[Das Objekt darf maximal {{0}} Eigenschaften haben]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_MAXPROPERTIES</item>
+      <item key="key">zms.formulator.lib.ERROR_MAXPROPERTIES</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -142,7 +143,7 @@
       <item key="fra"><![CDATA[Value must be greater than {{0}}]]></item>
       <item key="ger"><![CDATA[Der Wert muss grösser sein als {{0}}]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_MINIMUM_EXCL</item>
+      <item key="key">zms.formulator.lib.ERROR_MINIMUM_EXCL</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -151,7 +152,7 @@
       <item key="fra"><![CDATA[Value must be at least {{0}}]]></item>
       <item key="ger"><![CDATA[Der Wert muss mindestens {{0}} sein]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_MINIMUM_INCL</item>
+      <item key="key">zms.formulator.lib.ERROR_MINIMUM_INCL</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -160,7 +161,7 @@
       <item key="fra"><![CDATA[Value must have at least {{0}} items]]></item>
       <item key="ger"><![CDATA[Der Wert muss mindestens {{0}} Elemente enthalten]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_MINITEMS</item>
+      <item key="key">zms.formulator.lib.ERROR_MINITEMS</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -169,7 +170,7 @@
       <item key="fra"><![CDATA[Value must be at least {{0}} characters long]]></item>
       <item key="ger"><![CDATA[Der Wert muss mindestens {{0}} Zeichen lang sein]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_MINLENGTH</item>
+      <item key="key">zms.formulator.lib.ERROR_MINLENGTH</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -178,7 +179,7 @@
       <item key="fra"><![CDATA[Object must have at least {{0}} properties]]></item>
       <item key="ger"><![CDATA[Das Objekt muss mindestens {{0}} Eigenschaften haben]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_MINPROPERTIES</item>
+      <item key="key">zms.formulator.lib.ERROR_MINPROPERTIES</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -187,7 +188,7 @@
       <item key="fra"><![CDATA[Value must be a multiple of {{0}}]]></item>
       <item key="ger"><![CDATA[Der Wert muss ein Vielfaches von {{0}} sein]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_MULTIPLEOF</item>
+      <item key="key">zms.formulator.lib.ERROR_MULTIPLEOF</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -196,7 +197,7 @@
       <item key="fra"><![CDATA[Value must not validate against the provided schema]]></item>
       <item key="ger"><![CDATA[Value must not validate against the provided schema]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_NOT</item>
+      <item key="key">zms.formulator.lib.ERROR_NOT</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -205,7 +206,7 @@
       <item key="fra"><![CDATA[Value required]]></item>
       <item key="ger"><![CDATA[Es wird ein Wert benötigt]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_NOTEMPTY</item>
+      <item key="key">zms.formulator.lib.ERROR_NOTEMPTY</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -214,7 +215,7 @@
       <item key="fra"><![CDATA[Property must be set]]></item>
       <item key="ger"><![CDATA[Eigenschaft muss angegeben werden]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_NOTSET</item>
+      <item key="key">zms.formulator.lib.ERROR_NOTSET</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -223,7 +224,7 @@
       <item key="fra"><![CDATA[Value must validate against exactly one of the provided schemas. It currently validates against {{0}} of the schemas.]]></item>
       <item key="ger"><![CDATA[Value must validate against exactly one of the provided schemas. It currently validates against {{0}} of the schemas.]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_ONEOF</item>
+      <item key="key">zms.formulator.lib.ERROR_ONEOF</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -232,7 +233,7 @@
       <item key="fra"><![CDATA[Value must match the provided pattern]]></item>
       <item key="ger"><![CDATA[Der Wert muss dem vorgegebenen Muster entsprechen]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_PATTERN</item>
+      <item key="key">zms.formulator.lib.ERROR_PATTERN</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -241,7 +242,7 @@
       <item key="fra"><![CDATA[Object is missing the required property '{{0}}']]></item>
       <item key="ger"><![CDATA[Dem Objekt fehlt die benötigte Eigenschaft ’{{0}}]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_REQUIRED</item>
+      <item key="key">zms.formulator.lib.ERROR_REQUIRED</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -250,7 +251,7 @@
       <item key="fra"><![CDATA[Value must be of type {{0}}]]></item>
       <item key="ger"><![CDATA[Der Wert muss dem Typen {{0}} entsprechen]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_TYPE</item>
+      <item key="key">zms.formulator.lib.ERROR_TYPE</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -259,7 +260,7 @@
       <item key="fra"><![CDATA[Value must be one of the provided types]]></item>
       <item key="ger"><![CDATA[Der Wert muss dem vorgegebenen Typen entsprechen]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_TYPE_UNION</item>
+      <item key="key">zms.formulator.lib.ERROR_TYPE_UNION</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -268,7 +269,7 @@
       <item key="fra"><![CDATA[Array must have unique items]]></item>
       <item key="ger"><![CDATA[Das Feld darf nur eindeutige Elemente enthalten!]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_ERROR_UNIQUEITEMS</item>
+      <item key="key">zms.formulator.lib.ERROR_UNIQUEITEMS</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -277,7 +278,7 @@
       <item key="fra"><![CDATA[Thank you, we have received the data.]]></item>
       <item key="ger"><![CDATA[Vielen Dank, die Daten sind bei uns eingegangen.]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_FEEDBACK_MSG</item>
+      <item key="key">zms.formulator.lib.FEEDBACK_MSG</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -286,7 +287,7 @@
       <item key="fra"><![CDATA[Please check your input!]]></item>
       <item key="ger"><![CDATA[Bitte überprüfen Sie Ihre Eingabe!]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_HINT_CHECKINPUT</item>
+      <item key="key">zms.formulator.lib.HINT_CHECKINPUT</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -295,7 +296,7 @@
       <item key="fra"><![CDATA[Data was not sent. Are you a robot?]]></item>
       <item key="ger"><![CDATA[Daten wurden nicht übertragen! Bist du etwa ein Roboter?]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_HINT_DATANOTSENT</item>
+      <item key="key">zms.formulator.lib.HINT_DATANOTSENT</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -304,7 +305,7 @@
       <item key="fra"><![CDATA[Data was sent.]]></item>
       <item key="ger"><![CDATA[Die Daten wurden übertragen.]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_HINT_DATASENT</item>
+      <item key="key">zms.formulator.lib.HINT_DATASENT</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -313,7 +314,7 @@
       <item key="fra"><![CDATA[E-Mails expect a format like \"user@domain.tld\"]]></item>
       <item key="ger"><![CDATA[E-Mails erwarten ein Format wie \"user@domain.tld\"]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_HINT_EMAILSYNTAX</item>
+      <item key="key">zms.formulator.lib.HINT_EMAILSYNTAX</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -322,7 +323,7 @@
       <item key="fra"><![CDATA[An Error occurred!]]></item>
       <item key="ger"><![CDATA[Es ist ein Fehler aufgetreten!]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_HINT_ERROROCCURED</item>
+      <item key="key">zms.formulator.lib.HINT_ERROROCCURED</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -331,7 +332,7 @@
       <item key="fra"><![CDATA[File size:]]></item>
       <item key="ger">Dateigröße:</item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_HINT_FILESIZE</item>
+      <item key="key">zms.formulator.lib.HINT_FILESIZE</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -340,7 +341,7 @@
       <item key="fra"><![CDATA[File type:]]></item>
       <item key="ger">Dateityp:</item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_HINT_FILETYPE</item>
+      <item key="key">zms.formulator.lib.HINT_FILETYPE</item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -349,7 +350,7 @@
       <item key="fra"><![CDATA[Hint: Select multiple entries by holding cmd- or Ctrl-key.]]></item>
       <item key="ger"><![CDATA[Tipp: Sie können mehrere Einträge durch das Halten der cmd- bzw. Strg-Taste auswählen.]]></item>
       <item key="ita"></item>
-      <item key="key">ZMSFORMULATOR_HINT_MULTISELECT</item>
+      <item key="key">zms.formulator.lib.HINT_MULTISELECT</item>
     </dictionary>
   </item>
 </list>


### PR DESCRIPTION
Find enclosed a simple mechanism to export and import language dictionaries of a specific content class using the ZMSRepositoryManager.

Prerequisite is an attribute ‘langdict.xml’ of type resource, which has to be applied manually to the content class definition. If this attribute exists, all language entries of this content class (with its ID as prefix) will be exported as XML - and vice versa imported into the language dictionary.

As an example I revised the langdict.xml of zms.formulator and its used keys.