### PR TITLE
Repomanager-Diff: reduce encoding errors 

### DIFF
--- a/Products/zms/ZMSMetaobjManager.py
+++ b/Products/zms/ZMSMetaobjManager.py
@@ -875,7 +875,7 @@ class ZMSMetaobjManager(object):
       mapTypes = {'method':'DTML Method','py':'Script (Python)','zpt':'Page Template'}
       message = ''
       if newType in ['interface']:
-        newType = standard.dt_executable(self, newCustom)
+        newType = standard.dt_executable(self, standard.pystr(newCustom, encoding='utf-8', errors='replace'))
         if not newType:
           newType = 'method'
         newName = '%s: %s'%(newId, newType)

--- a/Products/zms/ZMSRepositoryManager.py
+++ b/Products/zms/ZMSRepositoryManager.py
@@ -237,6 +237,8 @@ class ZMSRepositoryManager(
           r['data'] = r['data'].replace('\r\n','\n')
         if l.get('data') != r.get('data'):
           data = l_data or r_data
+          if isinstance(data, str):
+            data = data.encode('utf-8')
           mt, enc = standard.guess_content_type(filename.split('/')[-1], data)
           diff.append((filename, mt, l.get('id', r.get('id', '?')), l, r))
       return diff

--- a/Products/zms/ZMSRepositoryManager.py
+++ b/Products/zms/ZMSRepositoryManager.py
@@ -217,15 +217,17 @@ class ZMSRepositoryManager(
           # if there are no references in model
           continue
         l = local.get(filename, {})
+        l_data = l.get('data')
         r = remote.get(filename, {})
-        if isinstance(l.get('data'), bytes):
+        r_data = r.get('data')
+        if isinstance(l_data, bytes):
           try:
-            l['data'] = l['data'].decode('utf-8')
+            l['data'] = l_data.decode('utf-8')
           except: # data is no text, but image etc.
             pass
-        if isinstance(r.get('data'), bytes):
+        if isinstance(r_data, bytes):
           try:
-            r['data'] = r['data'].decode('utf-8')
+            r['data'] = r_data.decode('utf-8')
           except:
             pass
         # Normalize Windows CR+LF line break to Unix LF in string objects
@@ -234,11 +236,8 @@ class ZMSRepositoryManager(
         if isinstance(r.get('data'), str):
           r['data'] = r['data'].replace('\r\n','\n')
         if l.get('data') != r.get('data'):
-          data = l.get('data', r.get('data'))
-          try:
-            mt, enc = standard.guess_content_type(filename.split('/')[-1], data.encode('utf-8'))
-          except:
-            mt, enc = standard.guess_content_type(filename.split('/')[-1], data)
+          data = l_data or r_data
+          mt, enc = standard.guess_content_type(filename.split('/')[-1], data)
           diff.append((filename, mt, l.get('id', r.get('id', '?')), l, r))
       return diff
 

--- a/Products/zms/ZMSRepositoryManager.py
+++ b/Products/zms/ZMSRepositoryManager.py
@@ -220,6 +220,7 @@ class ZMSRepositoryManager(
         l_data = l.get('data')
         r = remote.get(filename, {})
         r_data = r.get('data')
+        # Check whether any bytes data are decodeable as utf-8 text
         if isinstance(l_data, bytes):
           try:
             l['data'] = l_data.decode('utf-8')
@@ -230,11 +231,12 @@ class ZMSRepositoryManager(
             r['data'] = r_data.decode('utf-8')
           except:
             pass
-        # Normalize Windows CR+LF line break to Unix LF in string objects
+        # If text then normalize Windows CR+LF line break to Unix LF
         if isinstance(l.get('data'), str):
-          l['data'] = l['data'].replace('\r\n','\n')
+          l['data'] = l['data'].replace('\r','')
         if isinstance(r.get('data'), str):
-          r['data'] = r['data'].replace('\r\n','\n')
+          r['data'] = r['data'].replace('\r','')
+        # Only if text is not equal add to diff list
         if l.get('data') != r.get('data'):
           data = l_data or r_data
           if isinstance(data, str):

--- a/Products/zms/conf/metaobj_manager/com.zms.index/__init__.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.index/__init__.py
@@ -16,7 +16,7 @@ class com_zms_index:
 	package = ""
 
 	# Revision
-	revision = "2.1.2"
+	revision = "2.1.3"
 
 	# Type
 	type = "ZMSPackage"

--- a/Products/zms/standard.py
+++ b/Products/zms/standard.py
@@ -67,12 +67,12 @@ def is_bytes(v):
 
 security.declarePublic('pystr')
 pystr_ = str
-def pystr(v, encoding='utf-8', errors='ignore'):
-  if isinstance(v,bytes):
-    v = v.decode(encoding)
-  elif not isinstance(v,str):
+def pystr(v, encoding='utf-8', errors='strict'):
+  if isinstance(v, bytes):
+    v = v.decode(encoding, errors)
+  elif not isinstance(v, str):
     try:
-      v = str(v,encoding)
+      v = str(v, encoding, errors)
     except:
       v = str(v)
   return v

--- a/Products/zms/zopeutil.py
+++ b/Products/zms/zopeutil.py
@@ -84,6 +84,12 @@ def addObject(container, meta_type, id, title, data, permissions={}):
       data = data.encode('utf-8')
     addImage( container, id, title, data)
   elif meta_type == 'Page Template':
+    if not isinstance(data, str):
+      # Try a utf-8 encoding, otherwise simply force to utf-8
+      try:
+        bytes_is_utf8_encoded = str(data, encoding='utf-8')
+      except:
+        data = str(data, encoding='utf-8', errors='replace').encode('utf-8')
     addPageTemplate( container, id, title, data)
   elif meta_type == 'Script (Python)':
     addPythonScript( container, id, title, data)

--- a/Products/zms/zopeutil.py
+++ b/Products/zms/zopeutil.py
@@ -72,8 +72,14 @@ def addObject(container, meta_type, id, title, data, permissions={}):
   Add Zope-object to container.
   """
   if meta_type == 'DTML Document':
+    if not isinstance(data, str):
+      # Enforce to utf-8 text
+      data = standard.pystr(data, encoding='utf-8', errors='replace').encode('utf-8')
     addDTMLDocument( container, id, title, data)
   elif meta_type == 'DTML Method':
+    if not isinstance(data, str):
+      # Enforce to utf-8 text
+      data = standard.pystr(data, encoding='utf-8', errors='replace').encode('utf-8')
     addDTMLMethod( container, id, title, data)
   elif meta_type == 'External Method':
     addExternalMethod( container, id, title, data)
@@ -85,11 +91,8 @@ def addObject(container, meta_type, id, title, data, permissions={}):
     addImage( container, id, title, data)
   elif meta_type == 'Page Template':
     if not isinstance(data, str):
-      # Try a utf-8 encoding, otherwise simply force to utf-8
-      try:
-        bytes_is_utf8_encoded = str(data, encoding='utf-8')
-      except:
-        data = str(data, encoding='utf-8', errors='replace').encode('utf-8')
+      # Enforce to utf-8 text
+      data = standard.pystr(data, encoding='utf-8', errors='replace').encode('utf-8')
     addPageTemplate( container, id, title, data)
   elif meta_type == 'Script (Python)':
     addPythonScript( container, id, title, data)


### PR DESCRIPTION
Referring to Issue #34 there are imho 2 critical sections in ZMSRepositoryManager.getDiff():
 1. Checking whether the stream can considered as code stream or a not-comparible byte stream: https://github.com/zms-publishing/ZMS/blob/016e12b39b7eec4074cb86d9cd89700c5428a110/Products/zms/ZMSRepositoryManager.py#L221-L225
 2. and the file type guessing https://github.com/zms-publishing/ZMS/blob/016e12b39b7eec4074cb86d9cd89700c5428a110/Products/zms/ZMSRepositoryManager.py#L236-L242

I suggest to enter the filetype guessing (which should be applied only on files having confirmed diffs) with the original data (set as a variable) instead of try-ing to encode data back. 
https://github.com/zms-publishing/ZMS/blob/55373f789fbc5ce5205512a4e1847b16f2bca11c/Products/zms/ZMSRepositoryManager.py#L219-L222

The string case (e.g. DTML-Method) is now explicitly encoded
https://github.com/zms-publishing/ZMS/blob/584d5711e3d8130605abeac67ba10dc08c4a5c42/Products/zms/ZMSRepositoryManager.py#L238-L242

