### PR TITLE
avoid copy form trashcan (UniBE)

### DIFF
--- a/Products/zms/_zmi_actions_util.py
+++ b/Products/zms/_zmi_actions_util.py
@@ -96,7 +96,9 @@ def zmi_basic_actions(container, context, objAttr, objChildren, objPath=''):
         if can_cut:
           actions.append((container.getZMILangStr('BTN_CUT'), 'manage_cutObjects', 'fas fa-cut')) 
       #-- Action: Copy.
-      actions.append((container.getZMILangStr('BTN_COPY'), 'manage_copyObjects', 'fas fa-copy'))
+      can_copy = context.getParentByLevel(1).meta_id!='ZMSTrashcan'
+      if can_copy: 
+        actions.append((container.getZMILangStr('BTN_COPY'), 'manage_copyObjects', 'fas fa-copy'))
       #-- Actions: Move.
       can_move = objChildren > 1
       if can_move:


### PR DESCRIPTION
Added condition to suppress the menu item 'copy' for objects placed in the trashcan (Ref: IDCMS-335)

wthout fix
![trashcan1](https://user-images.githubusercontent.com/29705216/148208676-8d400ac4-dd6b-4714-a90f-420f89e778c6.gif)

with fix
![trashcan2](https://user-images.githubusercontent.com/29705216/148208696-f330e03b-00cf-40ef-899d-87c383ea08c9.gif)
 