### PR TITLE
fix empty user-attr and utf-8 encode of query-string in http-import

### DIFF
--- a/Products/zms/_accessmanager.py
+++ b/Products/zms/_accessmanager.py
@@ -916,7 +916,7 @@ class AccessManager(AccessableContainer):
         del d[user]
         root.setConfProperty('ZMS.security.users', d)
       except:
-        standard.writeError(root, '[delUserAttr]: user=%s not deleted!'%user)
+        standard.writeError(root, '[delUserAttr]: user=%s not deleted!'%str(user))
 
 
     # --------------------------------------------------------------------------

--- a/Products/zms/standard.py
+++ b/Products/zms/standard.py
@@ -873,7 +873,7 @@ def http_import(context, url, method='GET', auth=None, parse_qs=0, timeout=10, h
   scheme = u[0]
   netloc = u[1]
   path = u[2]
-  query = u[4].encode('utf-8')
+  query = u[4]
 
   # Get Proxy.
   useproxy = True
@@ -906,6 +906,8 @@ def http_import(context, url, method='GET', auth=None, parse_qs=0, timeout=10, h
   if method == 'GET' and query:
     path += '?' + query
     query = ''
+  else:
+    query = query.encode('utf-8')
   conn.request(method, path, query, headers)
   response = conn.getresponse()
   reply_code = response.status

--- a/tests/test_accessmanager.py
+++ b/tests/test_accessmanager.py
@@ -1,0 +1,31 @@
+# encoding: utf-8
+
+from OFS.Folder import Folder
+import sys
+import time
+import unittest
+
+# Product imports.
+from .zms_test_util import *
+from Products.zms import zms
+
+# /ZMS> python3 -m unittest discover -s tests
+# /ZMS> python3 -m unittest tests.test_accessmanager.AccessManagerTest
+class AccessManagerTest(ZMSTestCase):
+
+  temp_title = 'temp-test'
+
+  def setUp(self):
+    folder = Folder('myzmsx')
+    folder.REQUEST = HTTPRequest({'lang':'eng','preview':'preview'})
+    zmscontext = zms.initZMS(folder, 'content', 'titlealt', 'title', 'eng', 'eng', folder.REQUEST)
+    self.context = zmscontext
+
+  def test_user_attr(self):
+    context = self.context
+    request = context.REQUEST
+    expected = 'bar'
+    context.setUserAttr('johndoe','foo',expected)
+    v = context.getUserAttr('johndoe','foo')
+    self.assertEqual(expected,v)
+

--- a/tests/test_standard.py
+++ b/tests/test_standard.py
@@ -12,7 +12,9 @@
 #
 ##############################################################################
 import unittest
+from unittest.mock import Mock, MagicMock, patch
 from Products.zms import standard
+from Products.zms import zms
 
 class StandardTests(unittest.TestCase):
 
@@ -28,3 +30,27 @@ class StandardTests(unittest.TestCase):
         expected = 'index.html?a=b&c=d&e=1&f:list=1&f:list=2&f:list=3'
         v = standard.url_append_params('index.html?a=b',{'c':'d','e':1,'f':[1,2,3]})
         self.assertEqual(expected,v)
+
+    class FakeHTTPConnection:
+        def __init__(self, status=200, reason='OK'):
+            self.status = status
+            self.reason = reason
+        def request(self, *args):
+            # If you need to do any logic to change what is returned, you can do it in this class
+            pass
+        def getresponse(self):
+            class FakeHTTPResponse:
+                def __init__(self, status, reason):
+                    self.status = status
+                    self.reason = reason
+                def read(self):
+                    return ''
+            return FakeHTTPResponse(self.status, self.reason)
+
+    @patch('http.client.HTTPConnection', new=MagicMock(return_value=FakeHTTPConnection(200)))
+    def test_httpimport(self):
+        context = Mock(spec=zms.ZMS)
+        context.getConfProperty.side_effect = (lambda x, y: y)
+        url = "http://foo/bar?john=doe"
+        v = standard.http_import(context,url)
+


### PR DESCRIPTION
fix empty user-attr and utf-8 encode of query-string in http-import