### PR TITLE
http_import: fixed query encoding

### DIFF
--- a/Products/zms/standard.py
+++ b/Products/zms/standard.py
@@ -873,7 +873,8 @@ def http_import(context, url, method='GET', auth=None, parse_qs=0, timeout=10, h
   scheme = u[0]
   netloc = u[1]
   path = u[2]
-  query = u[4].encode('utf-8')
+  # query = u[4].encode('utf-8') ## REVOKE SOLR https://github.com/zms-publishing/ZMS/commit/49e0a89b8b1f21ea373354d231e6efa42f51b27f#diff-ca03d9475057635974de854d31d24453143a9f2ad23fa25454d1f371a584a002L814
+  query = u[4]
 
   # Get Proxy.
   useproxy = True

--- a/Products/zms/standard.py
+++ b/Products/zms/standard.py
@@ -873,7 +873,6 @@ def http_import(context, url, method='GET', auth=None, parse_qs=0, timeout=10, h
   scheme = u[0]
   netloc = u[1]
   path = u[2]
-  # query = u[4].encode('utf-8') ## REVOKE SOLR https://github.com/zms-publishing/ZMS/commit/49e0a89b8b1f21ea373354d231e6efa42f51b27f#diff-ca03d9475057635974de854d31d24453143a9f2ad23fa25454d1f371a584a002L814
   query = u[4]
 
   # Get Proxy.
@@ -907,6 +906,8 @@ def http_import(context, url, method='GET', auth=None, parse_qs=0, timeout=10, h
   if method == 'GET' and query:
     path += '?' + query
     query = ''
+  else:
+    query = query.encode('utf-8')
   conn.request(method, path, query, headers)
   response = conn.getresponse()
   reply_code = response.status


### PR DESCRIPTION
@zmsdev 
Products/zms/standard.py L 908 
`path += '?' + query`
works only with str, not bytes.
Why _query_ should be encoded to utf8.bytes is not evident!?
https://github.com/zms-publishing/ZMS/commit/6d46cf21bb6ad10c8f3b36f2dcf5834efc091c7d#diff-ca03d9475057635974de854d31d24453143a9f2ad23fa25454d1f371a584a002

The change was introduced in 
https://github.com/zms-publishing/ZMS/commit/49e0a89b8b1f21ea373354d231e6efa42f51b27f#diffca03d9475057635974de854d31d24453143a9f2ad23fa25454d1f371a584a002L8

How can it work with SOLR communication?