### PR TITLE
http_request: Revised method signature and added PURGE

### DIFF
--- a/Products/zms/standard.py
+++ b/Products/zms/standard.py
@@ -837,13 +837,15 @@ def unescape(s):
 
 
 security.declarePublic('http_request')
-def http_request(url, method='GET', data={}, auth=None, timeout=10, headers={'Accept':'*/*'}):
+def http_request(url, method='GET', **kwargs):
   import requests
   response = None
   if method == 'POST':
-    response = requests.post(url, files=data)
+    response = requests.post(url, **kwargs)
   elif method == 'GET':
-    response = requests.get( url, params=data)
+    response = requests.get(url, **kwargs)
+  elif method == 'PURGE':
+    response = requests.request('PURGE', url, **kwargs)
   return response
 
 


### PR DESCRIPTION
I propose a change of the signature of method `standard.http_request`.

IMHO the `headers` parameter has no effect on calling `requests` [api methods](https://docs.python-requests.org/en/latest/api/) at the moment. 

Using `**kwargs` introduces the most flexibility and should preserve the current usage in [metacmd_manager.manage_zcatalog_update_documents](https://github.com/zms-publishing/ZMS/blob/main/Products/zms/conf/metacmd_manager/manage_zcatalog_update_documents/manage_zcatalog_update_documents.py#L40) - but I think the parameter
`data=data` has to be changed into `files=data`...

Additionally I have added a new option for `method == PURGE`.