### PR TITLE
metamodeller shows ace editor on dblclick

### DIFF
--- a/Products/zms/plugins/www/common/zmi_ace_editor.js
+++ b/Products/zms/plugins/www/common/zmi_ace_editor.js
@@ -1,93 +1,111 @@
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-//+++ Ajax.org Cloud9 Editor
-//+++ http://ace.ajax.org
+//+++ ACE Cloud9 Editor
+//+++ https://ace.c9.io/
 //+++ @see $ZMS_HOME/plugins/www/ace.ajax.org
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-$(function(){
-	$(".zmi-ace-editor").each(function() {
-		var dom = ace.require("ace/lib/dom");
-		// add command to all new editor instances
-		ace.require("ace/commands/default_commands").commands.push({
-			name: "Toggle Fullscreen",
-			bindKey: "F10",
-			exec: function(editor) {
-				var fullScreen = dom.toggleCssClass(document.body, "fullScreen")
-				dom.setCssClass(editor.container, "fullScreen", fullScreen)
-				editor.setAutoScrollEditorIntoView(!fullScreen)
-				editor.resize()
+
+function show_ace_editor(e, toggle=false) {
+
+	if ( toggle == false ) {
+		var $textarea = $('textarea',$(e));
+		var editor_id = 'editor_' + $textarea.attr('id');
+	} else {
+		var $textarea = $(e);
+		var editor_id = 'editor_' + $textarea.attr('id');
+		var zopeurl = $(e).attr('data-zopeurl');
+		$textarea.addClass('form-control-ace-editor');
+		$textarea.parent().addClass('zmi-ace-editor')
+		$textarea.after('<div id="' + editor_id + '">ace editor text</div>');
+		$textarea.closest('td').append('<div class="control-label-ace-editor" title="Zope-Object-Editor"><a target="_blank" href="' + zopeurl + '">' + $textarea.attr('id').split('attr_custom_')[1] + '</a></div>');
+	}
+
+	var dom = ace.require("ace/lib/dom");
+	// add command to all new editor instances
+	ace.require("ace/commands/default_commands").commands.push({
+		name: "Toggle Fullscreen",
+		bindKey: "F10",
+		exec: function(editor) {
+			var fullScreen = dom.toggleCssClass(document.body, "fullScreen")
+			dom.setCssClass(editor.container, "fullScreen", fullScreen)
+			editor.setAutoScrollEditorIntoView(!fullScreen)
+			editor.resize()
+		}
+	});
+
+	// @see https://github.com/ajaxorg/ace/wiki/Embedding---API
+	if ($textarea.is(":visible")) {
+		$textarea.hide();
+		var value = $textarea.val();
+		var editor = ace.edit(editor_id);
+		var content_type = $("input#content_type",$(e).parent()).val();
+		if ( $textarea.attr('data-content_type') ) {
+			content_type = $textarea.attr('data-content_type');
+		}
+		if (typeof content_type == "undefined" || content_type == null || content_type == '' || content_type == 'text/x-unknown-content-type') {
+			var absolute_url = $(".control-label-ace-editor a",this).attr("href");
+			absolute_url = absolute_url.substr(0,absolute_url.lastIndexOf("/")); // strip manage_main
+			var id = absolute_url.substr(absolute_url.lastIndexOf("/")+1);
+			if (id.endsWith(".css")) {
+				content_type = "text/css";
 			}
-		});
-		// @see https://github.com/ajaxorg/ace/wiki/Embedding---API
-		var $textarea = $(".form-control-ace-editor",this);
-		if ($textarea.is(":visible")) {
-			$textarea.hide();
-			var name = $textarea.attr("name");
-			var value = $textarea.val();
-			var editor = ace.edit("editor_"+name);
-			var content_type = $("input#content_type",this).val();
-			if ( $textarea.attr('data-content_type') ) {
-				content_type = $textarea.attr('data-content_type');
+			else if (id.endsWith(".less")) {
+				content_type = "text/less";
 			}
-			if (typeof content_type == "undefined" || content_type == null || content_type == '' || content_type == 'text/x-unknown-content-type') {
-				var absolute_url = $(".control-label-ace-editor a",this).attr("href");
-				absolute_url = absolute_url.substr(0,absolute_url.lastIndexOf("/")); // strip manage_main
-				var id = absolute_url.substr(absolute_url.lastIndexOf("/")+1);
-				if (id.endsWith(".css")) {
-					content_type = "text/css";
-				}
-				else if (id.endsWith(".less")) {
-					content_type = "text/less";
-				}
-				else if (id.endsWith(".js")) {
-					content_type = "text/javascript";
-				}
-				else {
-					content_type = "text/html";
-				}
+			else if (id.endsWith(".js")) {
+				content_type = "text/javascript";
 			}
-			if ( 0 === value.indexOf("<html") && content_type != 'dtml') {
+			else {
 				content_type = "text/html";
 			}
-			if ( 0 === value.indexOf("<?xml") || value.indexOf("tal:") >= 0) {
-				content_type = "text/xml";
-			}
-			if ( 0 === value.indexOf("#!/usr/bin/python") || 0 === value.indexOf("## Script (Python)") ) {
-				content_type = "python";
-			}
-			var mode = "text";
-			if (content_type == "html" || content_type == "text/html") {
-				mode = "html";
-			}
-			else if (content_type == "text/css" || content_type == "application/css" || content_type == "application/x-css") {
-				mode = "css";
-			}
-			else if (content_type == "text/less") {
-				mode = "less";
-			}
-			else if (content_type == "text/javascript" || content_type == "application/javascript" || content_type == "application/x-javascript") {
-				mode = "javascript";
-			}
-			else if (content_type == "text/xml") {
-				mode = "xml";
-			}
-			else if (content_type == "python") {
-				mode = 'python';
-			}
-			else if (content_type == "sql") {
-				mode = 'sql';
-			}
-			else if (content_type == "json") {
-				mode = 'json';
-			}
-			else if (content_type == "dtml") {
-				mode = 'markdown';
-			}
-			editor.setTheme("ace/theme/eclipse");
-			editor.getSession().setMode('ace/mode/'+mode);
-			editor.getSession().setValue(value);
-			editor.getSession().on("change",function() {
-				$textarea.val(editor.getSession().getValue()).change();
-			});
 		}
+		if ( 0 === value.indexOf("<html") && content_type != 'dtml') {
+			content_type = "text/html";
+		}
+		if ( 0 === value.indexOf("<?xml") || value.indexOf("tal:") >= 0) {
+			content_type = "text/xml";
+		}
+		if ( 0 === value.indexOf("#!/usr/bin/python") || 0 === value.indexOf("## Script (Python)") ) {
+			content_type = "python";
+		}
+		var mode = "text";
+		if (content_type == "html" || content_type == "text/html") {
+			mode = "html";
+		}
+		else if (content_type == "text/css" || content_type == "application/css" || content_type == "application/x-css") {
+			mode = "css";
+		}
+		else if (content_type == "text/less") {
+			mode = "less";
+		}
+		else if (content_type == "text/javascript" || content_type == "application/javascript" || content_type == "application/x-javascript") {
+			mode = "javascript";
+		}
+		else if (content_type == "text/xml") {
+			mode = "xml";
+		}
+		else if (content_type == "python") {
+			mode = 'python';
+		}
+		else if (content_type == "sql") {
+			mode = 'sql';
+		}
+		else if (content_type == "json") {
+			mode = 'json';
+		}
+		else if (content_type == "dtml") {
+			mode = 'markdown';
+		}
+		editor.setTheme("ace/theme/eclipse");
+		editor.getSession().setMode('ace/mode/'+mode);
+		editor.getSession().setValue(value);
+		editor.getSession().on("change",function() {
+			$textarea.val(editor.getSession().getValue()).change();
+		});
+	}
+}
+
+$(function(){
+	$(".zmi-ace-editor").each(function() {
+		show_ace_editor( $(this), toggle=false );
 	});
 });

--- a/Products/zms/plugins/www/common/zmi_ace_editor.js
+++ b/Products/zms/plugins/www/common/zmi_ace_editor.js
@@ -114,8 +114,12 @@ function remove_ace_editor(id) {
 	$('.zmi-code', $ace_td).removeClass('zmi-ace-editor');
 	$('.control-label-ace-editor', $ace_td).remove();
 	ace.edit(id).destroy();
-	$('#' + id).remove();
-	$('.zmi-code textarea', $ace_td).show();
+	$('#' + id).animate({height: 0},600, 
+		function () {
+			$('#' + id).remove();
+			$('.zmi-code textarea', $ace_td).show();
+		}
+	);
 }
 
 $(function(){

--- a/Products/zms/plugins/www/common/zmi_ace_editor.js
+++ b/Products/zms/plugins/www/common/zmi_ace_editor.js
@@ -20,7 +20,7 @@ function show_ace_editor(e, toggle=false) {
 		$textarea.addClass('form-control-ace-editor');
 		$textarea.parent().addClass('zmi-ace-editor')
 		$textarea.after('<div id="' + editor_id + '">ace editor text</div>');
-		$textarea.closest('td').append('<div class="control-label-ace-editor"><a title="Zope-Object-Editor" target="_blank" href="' + zopeurl + '">' + $textarea.attr('id').split('attr_custom_')[1] + '</a> <i onclick="remove_ace_editor(\'' + editor_id + '\')" title="Close Editor" class="close fas fa-window-close"></i></div>');
+		$textarea.closest('td').append('<div class="control-label-ace-editor"><div><i onclick="remove_ace_editor(\'' + editor_id + '\')" title="Close Editor" class="close fas fa-chevron-up text-primary"></i></div><div><a title="Zope-Object-Editor" target="_blank" href="' + zopeurl + '">' + $textarea.attr('id').split('attr_custom_')[1] + '</a></div></div>');
 	}
 
 	var dom = ace.require("ace/lib/dom");

--- a/Products/zms/plugins/www/common/zmi_ace_editor.js
+++ b/Products/zms/plugins/www/common/zmi_ace_editor.js
@@ -12,11 +12,15 @@ function show_ace_editor(e, toggle=false) {
 	} else {
 		var $textarea = $(e);
 		var editor_id = 'editor_' + $textarea.attr('id');
+		if ( $(e).closest('td').find('#'+editor_id).length > 0 ) {
+			// Avoid stacking multiple editors 
+			return;
+		};
 		var zopeurl = $(e).attr('data-zopeurl');
 		$textarea.addClass('form-control-ace-editor');
 		$textarea.parent().addClass('zmi-ace-editor')
 		$textarea.after('<div id="' + editor_id + '">ace editor text</div>');
-		$textarea.closest('td').append('<div class="control-label-ace-editor" title="Zope-Object-Editor"><a target="_blank" href="' + zopeurl + '">' + $textarea.attr('id').split('attr_custom_')[1] + '</a></div>');
+		$textarea.closest('td').append('<div class="control-label-ace-editor"><a title="Zope-Object-Editor" target="_blank" href="' + zopeurl + '">' + $textarea.attr('id').split('attr_custom_')[1] + '</a> <i onclick="remove_ace_editor(\'' + editor_id + '\')" title="Close Editor" class="close fas fa-window-close"></i></div>');
 	}
 
 	var dom = ace.require("ace/lib/dom");
@@ -102,6 +106,16 @@ function show_ace_editor(e, toggle=false) {
 			$textarea.val(editor.getSession().getValue()).change();
 		});
 	}
+}
+
+function remove_ace_editor(id) {
+	var $ace = $('#' + id);
+	var $ace_td = $ace.closest('td');
+	$('.zmi-code', $ace_td).removeClass('zmi-ace-editor');
+	$('.control-label-ace-editor', $ace_td).remove();
+	ace.edit(id).destroy();
+	$('#' + id).remove();
+	$('.zmi-code textarea', $ace_td).show();
 }
 
 $(function(){

--- a/Products/zms/plugins/www/zmi.core.css
+++ b/Products/zms/plugins/www/zmi.core.css
@@ -1035,7 +1035,7 @@ input.btn.btn-file {
 
 /* Using ACE Editor*/
 .ace_editor {
-	min-height: 20rem;
+	height: 20rem;
 	line-height: 1.3;
 }
 .ace_editor.fullScreen {

--- a/Products/zms/plugins/www/zmi.core.css
+++ b/Products/zms/plugins/www/zmi.core.css
@@ -2011,15 +2011,18 @@ body.lazy_select_form footer .controls {
 	letter-spacing: .02rem;
 	line-height: 1.25rem;
 	float:left;
+	position:absolute;
 }
 .zmi .control-label-ace-editor {
 	font-size:12px;
 	text-align: right;
-	display: block;
-	padding: 0;
+	display: flex;
+	padding: 0.1rem 0 0 0;
 	float: right;
 	font-family:SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
 	color:#75A7C0;
+	width:50%;
+	justify-content: space-between;
 }
 .zmi .control-label-ace-editor a {
 	color:#75A7C0;
@@ -2039,9 +2042,9 @@ body.lazy_select_form footer .controls {
 	color:#e83e8c
 }
 .zmi .control-label-ace-editor .close {
-	color:#75A7C0;
-	margin-left:0.35rem;
+	margin:0 0 0 1rem;
 	opacity:1 !important;
+	cursor:pointer;
 }
 .zmi .control-label-ace-editor .close:hover {
 	color:#354f67;

--- a/Products/zms/plugins/www/zmi.core.css
+++ b/Products/zms/plugins/www/zmi.core.css
@@ -1034,6 +1034,10 @@ input.btn.btn-file {
 }
 
 /* Using ACE Editor*/
+.ace_editor {
+	min-height: 20rem;
+	line-height: 1.3;
+}
 .ace_editor.fullScreen {
 	position: fixed;
 	height: 100vh !important;
@@ -2005,6 +2009,17 @@ body.lazy_select_form footer .controls {
 	float: right;
 	font-family:SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
 }
+.zmi .meta-code .control-label-ace-editor {
+	display:inline-block;
+	z-index: 10;
+	right: 2rem;
+	padding: 0;
+	margin: 0 ;
+	margin-top: -1.25rem;
+	font-size: 10px;
+    letter-spacing: .02rem;
+    line-height: 1.25rem;
+}
 .zmi .control-label-ace-editor,
 .zmi .control-label-ace-editor a {
 	color:#75A7C0;
@@ -2023,6 +2038,7 @@ body.lazy_select_form footer .controls {
 .zmi .control-label-ace-editor:hover::before {
 	color:#e83e8c
 }
+
 .zmi.customize.config #zmi-tab #Manager.tab-pane .btn img {
 	margin: -.45rem .25rem 0 0;
 }

--- a/Products/zms/plugins/www/zmi.core.css
+++ b/Products/zms/plugins/www/zmi.core.css
@@ -2002,41 +2002,49 @@ body.lazy_select_form footer .controls {
 	letter-spacing: .02rem;
 	line-height: 1.25rem;
 }
+.zmi .meta-code .zmi-ace-editor:after {
+	content:"Please press F10 for full screen view";
+	display:block;
+	margin-top:0;
+	font-size:12px;
+	color:#999;
+	letter-spacing: .02rem;
+	line-height: 1.25rem;
+	float:left;
+}
 .zmi .control-label-ace-editor {
+	font-size:12px;
 	text-align: right;
-	display: inline-block;
-	padding: 0 .5em;
+	display: block;
+	padding: 0;
 	float: right;
 	font-family:SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
+	color:#75A7C0;
 }
-.zmi .meta-code .control-label-ace-editor {
-	display:inline-block;
-	z-index: 10;
-	right: 2rem;
-	padding: 0;
-	margin: 0 ;
-	margin-top: -1.25rem;
-	font-size: 10px;
-    letter-spacing: .02rem;
-    line-height: 1.25rem;
-}
-.zmi .control-label-ace-editor,
 .zmi .control-label-ace-editor a {
 	color:#75A7C0;
 	text-decoration:none;
 }
-.zmi .control-label-ace-editor:hover,
-.zmi .control-label-ace-editor:hover a {
+.zmi .control-label-ace-editor a:hover {
 	color:#007aff;
 }
-.zmi .control-label-ace-editor::before {
+.zmi .control-label-ace-editor a::before {
 	content:'\f35d';
 	font-family:'Font Awesome 5 Free',fontawesome;
 	font-weight:bold;
 	display:inline-block;
+	margin: 0 0.35rem 0 0;
 }
-.zmi .control-label-ace-editor:hover::before {
+.zmi .control-label-ace-editor a:hover::before {
 	color:#e83e8c
+}
+.zmi .control-label-ace-editor .close {
+	color:#75A7C0;
+	margin-left:0.35rem;
+	opacity:1 !important;
+}
+.zmi .control-label-ace-editor .close:hover {
+	color:#354f67;
 }
 
 .zmi.customize.config #zmi-tab #Manager.tab-pane .btn img {

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -235,110 +235,13 @@
 											tal:attributes="name python:'attr_custom_%s'%objAttr['id']; 
 												id  python:'attr_custom_%s'%objAttr['id'];
 												data-content_type python:objAttr['type'];
-												title python:['%s (%s) - Double-Click for Zope-Object-Editor'%(objAttr['id'],objAttr['type']),errors][len(errors)>0];
+												title python:['%s (%s) - Double-Click for Code-Editor'%(objAttr['id'],objAttr['type']),errors][len(errors)>0];
 												class python:' '.join(['form-control','form-control-sm']+objAttr['type'].lower().split(' ')+[[],['alert-danger']][len(errors)>0]);
 												style python:'\073'.join([[],['color:#a94442','background:#fee']][len(errors)>0]);
 												data-class python:'fas fa-cogs';
-												X-data-dblclickhandler python:'window.open(\'%s/manage\',\'%s\')'%(ob.absolute_url(),'%s (%s)'%(objAttr['id'],objAttr['type']));
-												data-dblclickhandler python:'set_ace_editor(\'attr_custom_%s\')'%(objAttr['id']);"
+												data-zopeurl python:'%s/manage'%(ob.absolute_url());
+												data-dblclickhandler python:'show_ace_editor(e=this, toggle=true)'"
 												tal:content="readData">ob.data</textarea>
-										<div tal:replace="nothing" 
-											tal:attributes="id python:'editor_attr_custom_%s'%objAttr['id'];" 
-											style="height:20rem;border:1px solid #ccc;border-radius:4px">
-											ace editor text
-										</div>
-										<style>
-											pre.ace_editor {
-												min-height: 20rem;
-												line-height: 1.3;
-											}
-										</style>
-										<script>
-										//<!--
-											function set_ace_editor(id) {
-												var $textarea = $('#'+id);
-												var value = $textarea.val();
-												content_type = $textarea.attr('data-content_type');
-												$textarea.addClass('form-control-ace-editor');
-												$textarea.parent().addClass('zmi-ace-editor');
-												console.log('content_type: ' +content_type);
-												var dom = ace.require("ace/lib/dom");
-												// add command to all new editor instances
-												ace.require("ace/commands/default_commands").commands.push({
-													name: "Toggle Fullscreen",
-													bindKey: "F10",
-													exec: function(editor) {
-														var fullScreen = dom.toggleCssClass(document.body, "fullScreen")
-														dom.setCssClass(editor.container, "fullScreen", fullScreen)
-														editor.setAutoScrollEditorIntoView(!fullScreen)
-														editor.resize()
-													}
-												});
-												var editor = ace.edit(id);
-												if (typeof content_type == "undefined" || content_type == null || content_type == '' || content_type == 'text/x-unknown-content-type') {
-													var absolute_url = $(".control-label-ace-editor a",this).attr("href");
-													absolute_url = absolute_url.substr(0,absolute_url.lastIndexOf("/")); // strip manage_main
-													var id = absolute_url.substr(absolute_url.lastIndexOf("/")+1);
-													if (id.endsWith(".css")) {
-														content_type = "text/css";
-													}
-													else if (id.endsWith(".less")) {
-														content_type = "text/less";
-													}
-													else if (id.endsWith(".js")) {
-														content_type = "text/javascript";
-													}
-													else {
-														content_type = "text/html";
-													}
-												}
-												if ( 0 === value.indexOf("<html") && content_type != 'dtml') {
-													content_type = "text/html";
-												}
-												if ( 0 === value.indexOf("<?xml") || value.indexOf("tal:") >= 0) {
-													content_type = "text/xml";
-												}
-												if ( 0 === value.indexOf("#!/usr/bin/python") || 0 === value.indexOf("## Script (Python)") ) {
-													content_type = "python";
-												}
-												var mode = "text";
-												if (content_type == "zpt" || content_type == "html" || content_type == "text/html") {
-													mode = "html";
-												}
-												else if (content_type == "css" || content_type == "text/css" || content_type == "application/css" || content_type == "application/x-css") {
-													mode = "css";
-												}
-												else if (content_type == "text/less") {
-													mode = "less";
-												}
-												else if (content_type == "text/javascript" || content_type == "application/javascript" || content_type == "application/x-javascript") {
-													mode = "javascript";
-												}
-												else if (content_type == "text/xml") {
-													mode = "xml";
-												}
-												else if (content_type == "python") {
-													mode = 'python';
-												}
-												else if (content_type == "sql") {
-													mode = 'sql';
-												}
-												else if (content_type == "json") {
-													mode = 'json';
-												}
-												else if (content_type == "dtml") {
-													mode = 'markdown';
-												}
-												editor.setTheme("ace/theme/eclipse");
-												editor.getSession().setMode('ace/mode/'+mode);
-												editor.getSession().setValue(value);
-												editor.getSession().on("change",function() {
-													$textarea.val(editor.getSession().getValue()).change();
-												});
-												
-											}
-										//-->
-										</script>
 								</div>
 							</tal:block>
 						</td>
@@ -763,13 +666,13 @@ $(function(){
 
 /**
  * ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- * EXPERIMENTAL: Generator for Default-ZPT-Code.
+ * Generator for Default-ZPT-Code.
  * Cave: ZPT Processing in Zope5 requires $$ 
- * for JS String Templates, but not Zope2 or Zope5
+ * for JS String Templates
  * ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  */
  function set_zmi_code_default(event) {
-	var confirmed = confirm("The Experimental Generator for Default-ZPT-Code asks:\nReally Reset to Default-Code?");
+	var confirmed = confirm("The Generator for Default-ZPT-Code asks:\nReally Reset to Default-Code?");
 	if (!confirmed == true) {
 		return false;
 	}
@@ -894,6 +797,8 @@ $(function(){
 });
 // -->
 </script>
+
+<script type="text/javascript" charset="UTF-8" src="/++resource++zms_/common/zmi_ace_editor.js"></script>
 
 </body>
 </html>

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -12,10 +12,10 @@
 <header tal:replace="structure python:here.zmi_body_header(here,request,options=here.customize_manage_options())">zmi_body_header</header>
 <div id="zmi-tab">
 <tal:block tal:define="
-		metaObjIds python:here.getMetaobjIds(sort=False);
-		metaObjs python:[here.getMetaobj(x,aq_attrs=['enabled']) for x in metaObjIds];
-		metaObjPackages python:standard.sort_list(['']+[x['id'] for x in metaObjs if x['type'] == 'ZMSPackage']);
-		metaObjPackages2 python:standard.distinct_list([x for x in [x.get('package') for x in metaObjs] if x not in metaObjPackages])">
+	metaObjIds python:here.getMetaobjIds(sort=False);
+	metaObjs python:[here.getMetaobj(x,aq_attrs=['enabled']) for x in metaObjIds];
+	metaObjPackages python:standard.sort_list(['']+[x['id'] for x in metaObjs if x['type'] == 'ZMSPackage']);
+	metaObjPackages2 python:standard.distinct_list([x for x in [x.get('package') for x in metaObjs] if x not in metaObjPackages])">
 <tal:block tal:content="structure python:here.zmi_breadcrumbs(here,request,extra=[here.manage_sub_options()[1]]+[{'action':'?id=%s'%x['id'],'label':x['name']} for x in metaObjs if x['id']==request.get('id')])">zmi_breadcrumbs</tal:block>
 
 <div class="d-none">
@@ -52,11 +52,11 @@
 
 <form tal:condition="python:request.get('id')" class="form-horizontal card" action="manage_changeProperties" method="post" enctype="multipart/form-data">
 <tal:block tal:define="
-		id request/id;
-		objAttrIds python:here.getMetaobjAttrIds(id);
-		metaObjAttrs python:[here.getMetaobjAttr(id,x) for x in objAttrIds];
-		metaObj python:here.getMetaobj(id,aq_attrs=['enabled']);
-		metaObjRecordSet python:metaObj['type']=='ZMSRecordSet'">
+	id request/id;
+	objAttrIds python:here.getMetaobjAttrIds(id);
+	metaObjAttrs python:[here.getMetaobjAttr(id,x) for x in objAttrIds];
+	metaObj python:here.getMetaobj(id,aq_attrs=['enabled']);
+	metaObjRecordSet python:metaObj['type']=='ZMSRecordSet'">
 	<legend tal:content="python:here.getZMILangStr('ZMSMetamodelProvider')">Content Model</legend>
 	<input type="hidden" name="key" value="all"/>
 	<input type="hidden" name="lang" tal:attributes="value request/lang"/>
@@ -184,7 +184,7 @@
 			<th class="meta-sort" tal:attributes="title python:here.getZMILangStr('ATTR_ATTR')" tal:content="python:here.getZMILangStr('ATTR_ATTR')">Attribute</th>
 			<th class="meta-id" tal:attributes="title python:here.getZMILangStr('ATTR_ID')" tal:content="python:here.getZMILangStr('ATTR_ID')">Id</th>
 			<th class="meta-name" tal:attributes="title python:here.getZMILangStr('ATTR_DISPLAY')" tal:content="python:here.getZMILangStr('ATTR_DISPLAY')">Display</th>
-			<th class="meta-type"  tal:attributes="title python:here.getZMILangStr('ATTR_TYPE')" tal:content="python:here.getZMILangStr('ATTR_TYPE')">Type</th>
+			<th class="meta-type" tal:attributes="title python:here.getZMILangStr('ATTR_TYPE')" tal:content="python:here.getZMILangStr('ATTR_TYPE')">Type</th>
 			<th class="meta-mandatory" tal:attributes="title python:here.getZMILangStr('ATTR_MANDATORY')"><i class="fas fa-exclamation-circle"></i></th>
 			<th class="meta-displaycol" tal:condition="metaObjRecordSet" colspan="2" tal:attributes="title python:'%s (%s)'%(here.getZMILangStr('ATTR_DISPLAY'),here.getZMILangStr('ATTR_COL'))"><i class="fas fa-columns"></i></th>
 			<th class="meta-multilang" tal:condition="not:metaObjRecordSet" tal:attributes="title python:here.getZMILangStr('ATTR_MULTILANG')"><i class="fas fa-globe"></i></th>
@@ -212,10 +212,11 @@
 						</div>
 					</td>
 					<td class="meta-id"><input type="text" tal:attributes="name python:'attr_id_%s'%objAttrId; value python:objAttr['id']; class python:['form-control form-control-sm','form-control form-control-sm zmi-element-disabled'][isMetaDictAttr]"/></td>
-					<td class="meta-name" tal:condition="not:python:objAttr['type'] in ['interface']"><input type="text" tal:attributes="name python:'attr_name_%s'%objAttrId; value python:objAttr['name']; class python:['form-control form-control-sm','form-control form-control-sm zmi-element-disabled'][isMetaDictAttr]"/></td>
+					<td class="meta-name"><input type="text" tal:attributes="name python:'attr_name_%s'%objAttrId; value python:objAttr['name']; class python:['form-control form-control-sm','form-control form-control-sm zmi-element-disabled'][isMetaDictAttr]"/></td>
 
 					<tal:block tal:condition="python:objAttr['type'] in ['interface','method','py','resource','zpt']+here.valid_zopetypes">
-						<td tal:attributes="colspan python:[5,6][objAttr['type'] in ['interface']]" class="meta-code" tal:condition="python:objAttr['type'] not in ['resource','File','Folder','Image'] and objAttr.get('ob') is not None"
+						<td colspan="5" class="meta-code" 
+							tal:condition="python:objAttr['type'] not in ['resource','File','Folder','Image'] and objAttr.get('ob') is not None"
 							><tal:block tal:define="
 									defaultData python:objAttr.get('custom','ERROR: Object not found!');
 									objectData python:zopeutil.readData(objAttr['ob'],default=None);
@@ -223,20 +224,121 @@
 									global errors python:['','ERROR: Object not found!'][int(objectData is None)]"
 								><tal:block tal:condition="python: readData.find('## Errors:') >= 0"
 									><tal:block tal:define="
-											lines python:[x.strip() for x in readData.split('\n')];
-											global errors python:lines[lines.index('## Errors:')+1][2:].strip()"></tal:block
+										lines python:[x.strip() for x in readData.split('\n')];
+										global errors python:lines[lines.index('## Errors:')+1][2:].strip()"></tal:block
 								></tal:block>
 								<input type="hidden" tal:attributes="name python:'attr_type_%s'%objAttr['id']; value python:[objAttr.get('type'),objAttr.get('meta_type')][objAttr.get('meta_type') in here.getMetadictAttrs()]" />
-								<div class="single-line zmi-code" tal:condition="python:objAttr.get('ob') is not None"
+								<div class="single-line zmi-code" 
+									tal:condition="python:objAttr.get('ob') is not None"
 									tal:define="zopetype python:objAttr['type'] in here.valid_zopetypes; ob python:objAttr.get('ob')">
-										<textarea class="form-control form-control-sm"
+										<textarea class="form-control-ace-editor form-control form-control-sm"
 											tal:attributes="name python:'attr_custom_%s'%objAttr['id']; 
+												id  python:'attr_custom_%s'%objAttr['id'];
+												data-content_type python:objAttr['type'];
 												title python:['%s (%s) - Double-Click for Zope-Object-Editor'%(objAttr['id'],objAttr['type']),errors][len(errors)>0];
 												class python:' '.join(['form-control','form-control-sm']+objAttr['type'].lower().split(' ')+[[],['alert-danger']][len(errors)>0]);
 												style python:'\073'.join([[],['color:#a94442','background:#fee']][len(errors)>0]);
 												data-class python:'fas fa-cogs';
-												data-dblclickhandler python:'window.open(\'%s/manage\',\'%s\')'%(ob.absolute_url(),'%s (%s)'%(objAttr['id'],objAttr['type']))"
-											tal:content="readData">ob.data</textarea>
+												X-data-dblclickhandler python:'window.open(\'%s/manage\',\'%s\')'%(ob.absolute_url(),'%s (%s)'%(objAttr['id'],objAttr['type']));
+												data-dblclickhandler python:'set_ace_editor(\'attr_custom_%s\')'%(objAttr['id']);"
+												tal:content="readData">ob.data</textarea>
+										<div tal:replace="nothing" 
+											tal:attributes="id python:'editor_attr_custom_%s'%objAttr['id'];" 
+											style="height:20rem;border:1px solid #ccc;border-radius:4px">
+											ace editor text
+										</div>
+										<style>
+											pre.ace_editor {
+												min-height: 20rem;
+												line-height: 1.3;
+											}
+										</style>
+										<script>
+										//<!--
+											function set_ace_editor(id) {
+												var $textarea = $('#'+id);
+												var value = $textarea.val();
+												content_type = $textarea.attr('data-content_type');
+												$textarea.addClass('form-control-ace-editor');
+												$textarea.parent().addClass('zmi-ace-editor');
+												console.log('content_type: ' +content_type);
+												var dom = ace.require("ace/lib/dom");
+												// add command to all new editor instances
+												ace.require("ace/commands/default_commands").commands.push({
+													name: "Toggle Fullscreen",
+													bindKey: "F10",
+													exec: function(editor) {
+														var fullScreen = dom.toggleCssClass(document.body, "fullScreen")
+														dom.setCssClass(editor.container, "fullScreen", fullScreen)
+														editor.setAutoScrollEditorIntoView(!fullScreen)
+														editor.resize()
+													}
+												});
+												var editor = ace.edit(id);
+												if (typeof content_type == "undefined" || content_type == null || content_type == '' || content_type == 'text/x-unknown-content-type') {
+													var absolute_url = $(".control-label-ace-editor a",this).attr("href");
+													absolute_url = absolute_url.substr(0,absolute_url.lastIndexOf("/")); // strip manage_main
+													var id = absolute_url.substr(absolute_url.lastIndexOf("/")+1);
+													if (id.endsWith(".css")) {
+														content_type = "text/css";
+													}
+													else if (id.endsWith(".less")) {
+														content_type = "text/less";
+													}
+													else if (id.endsWith(".js")) {
+														content_type = "text/javascript";
+													}
+													else {
+														content_type = "text/html";
+													}
+												}
+												if ( 0 === value.indexOf("<html") && content_type != 'dtml') {
+													content_type = "text/html";
+												}
+												if ( 0 === value.indexOf("<?xml") || value.indexOf("tal:") >= 0) {
+													content_type = "text/xml";
+												}
+												if ( 0 === value.indexOf("#!/usr/bin/python") || 0 === value.indexOf("## Script (Python)") ) {
+													content_type = "python";
+												}
+												var mode = "text";
+												if (content_type == "zpt" || content_type == "html" || content_type == "text/html") {
+													mode = "html";
+												}
+												else if (content_type == "css" || content_type == "text/css" || content_type == "application/css" || content_type == "application/x-css") {
+													mode = "css";
+												}
+												else if (content_type == "text/less") {
+													mode = "less";
+												}
+												else if (content_type == "text/javascript" || content_type == "application/javascript" || content_type == "application/x-javascript") {
+													mode = "javascript";
+												}
+												else if (content_type == "text/xml") {
+													mode = "xml";
+												}
+												else if (content_type == "python") {
+													mode = 'python';
+												}
+												else if (content_type == "sql") {
+													mode = 'sql';
+												}
+												else if (content_type == "json") {
+													mode = 'json';
+												}
+												else if (content_type == "dtml") {
+													mode = 'markdown';
+												}
+												editor.setTheme("ace/theme/eclipse");
+												editor.getSession().setMode('ace/mode/'+mode);
+												editor.getSession().setValue(value);
+												editor.getSession().on("change",function() {
+													$textarea.val(editor.getSession().getValue()).change();
+												});
+												
+											}
+										//-->
+										</script>
 								</div>
 							</tal:block>
 						</td>

--- a/Products/zms/zpt/common/zmi_ace_editor.zpt
+++ b/Products/zms/zpt/common/zmi_ace_editor.zpt
@@ -20,7 +20,7 @@
 			<tal:block tal:condition="python:text is not None">(<tal:block tal:content="python:here.getDataSizeStr(len(text))">the size</tal:block>)</tal:block>
 		</div>
 		<div>
-			<textarea class="form-control-ace-editor" tal:attributes="name name;data-content_type content_type" tal:content="text">the text</textarea>
+			<textarea class="form-control-ace-editor" tal:attributes="name name;id name;data-content_type content_type" tal:content="text">the text</textarea>
 		</div>
 		<div tal:attributes="id python:'editor_%s'%name" style="height:92%;width:100%;border:1px solid #ccc;border-radius:4px">
 			ace editor text

--- a/Products/zms/zpt/common/zmi_ace_editor.zpt
+++ b/Products/zms/zpt/common/zmi_ace_editor.zpt
@@ -16,8 +16,10 @@
 		class="form-group zmi-ace-editor" 
 		tal:attributes="style python:'height:%s'%height">
 		<div class="control-label-ace-editor">
-			<a tal:attributes="href python:'%s/manage_main'%ob.absolute_url(); title ob/meta_type" target="_blank" tal:content="python:ob.getId()">id</a>
-			<tal:block tal:condition="python:text is not None">(<tal:block tal:content="python:here.getDataSizeStr(len(text))">the size</tal:block>)</tal:block>
+			<a tal:attributes="href python:'%s/manage_main'%ob.absolute_url(); title ob/meta_type" target="_blank">
+				<tal:block tal:content="python:ob.getId()">id<</tal:block>
+				<tal:block tal:condition="python:text is not None">(<tal:block tal:content="python:here.getDataSizeStr(len(text))">the size</tal:block>)</tal:block>
+			</a> 
 		</div>
 		<div>
 			<textarea class="form-control-ace-editor" tal:attributes="name name;id name;data-content_type content_type" tal:content="text">the text</textarea>


### PR DESCRIPTION
This a feature mockup is a UX proposal: on dblclick the content modeller's code editor changes from the plain to the ACE code editor. A link to the Zope editor (which was reached by dblclick before) may be added.
The zmi-ace-editor JS should made more flexible and support multiple ACE instance on a page.

![ace4modeller](https://user-images.githubusercontent.com/29705216/161405834-9efd5535-5d33-4118-9687-c686cb7a186a.gif)

![ace4modeller2](https://user-images.githubusercontent.com/29705216/161439642-6b783c1a-8b1b-41e7-bcd4-9655bba47b58.gif)

