### PR TITLE
added lastlogin date to user dict

### DIFF
--- a/Products/zms/zpt/common/zmi_html_head.zpt
+++ b/Products/zms/zpt/common/zmi_html_head.zpt
@@ -2,6 +2,7 @@
 
 <head tal:define="
 		standard modules/Products.zms/standard;
+		SESSION request/SESSION;
 		dummy0 python:here.zmi_page_request(here,request);
 		zmi_paths python:standard.zmi_paths(here);
 		zmshome python:here.getHome();
@@ -38,9 +39,15 @@
 			added_js_zmi_href python:added_js_zmi.replace('$ZMS_HOME/',ZMS_HOME).replace('$ZMS_THEME/',ZMS_THEME);"
 		tal:condition="python:added_js_zmi.find('.js')>-1"
 		tal:attributes="src added_js_zmi_href"></script>
-	<tal:block tal:condition="python:here.getUserAttr(request['AUTHENTICATED_USER'],'forceChangePassword',0)==1">
-		<script type="text/javascript">$(function(){$ZMI.forceChangePassword()});</script>
+	<tal:block tal:condition="python:not SESSION.get('did_updateUserdata')">
+		<tal:block tal:condition="python:here.getUserAttr(request['AUTHENTICATED_USER'],'forceChangePassword',0)==1">
+			<script type="text/javascript">$(function(){$ZMI.forceChangePassword()});</script>
+		</tal:block>
+		<tal:block tal:define="updateUserdata python:here.setUserAttr(request['AUTHENTICATED_USER'], 'login_date', context.ZopeTime().strftime('%Y-%m-%d'))"></tal:block>
+		<tal:block tal:define="updateUserdata python:SESSION.set('did_updateUserdata',True)"></tal:block>
 	</tal:block>
+
+		<tal:block tal:replace="python:here.getUserAttr(request['AUTHENTICATED_USER'],'login_date',0)"></tal:block>
 </head>
 
 <!-- /common/zmi_html_head -->


### PR DESCRIPTION
The _forceChangePassword_  happens on any ZMI request (on zpt/comon/zmi_html_head.zpt). 
https://github.com/zms-publishing/ZMS/blob/59c11a1a10126167c8d96651a47c47b30c6fbc1b/Products/zms/zpt/common/zmi_html_head.zpt#L41
It can be optimized by adding a session var _did_updateUserdata_ to avoid more checks on the user-dict 'and it can be used to save the login date once  a session (req by UniBE) 