### PR TITLE
Added visual indication on deprecated objs/cmds

### DIFF
--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -1547,7 +1547,7 @@ ZMIActionList.prototype.over = function(el, e, cb) {
 				}
 				var html = '';
 				html += '<a class="dropdown-item" title="'+opttitle+'" href="javascript:$ZMI.actionList.exec($(\'li.zmi-item' + (id==''?':first':'#zmi_item_'+id) + '\'),\'' + optlabel + '\',\'' + optvalue + '\')">';
-				html += opticon+' '+optlabel;
+				html += opticon+' <span>'+optlabel+'</span>';
 				html += '</a>';
 				$ul.append(html);
 			}

--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -969,15 +969,24 @@ ZMI.prototype.initInputFields = function(container) {
 			// Icon-Class
 			$('input.zmi-input-icon-clazz',this).each(function() {
 				var $input = $(this);
+				var t = 'Use icon classes on https://fontawesome.com/v5/search?m=free \nand specifier classes like \'text-danger\' or \'deprecated\'';
 				$input.wrap( '<div class="input-group"></div>' );
 				$input.before('<span class="input-group-text"><i class="fas fa-invisible"></i></span>');
-				$input.parent().children('span.input-group-text').wrap( '<div class="input-group-prepend"></div>');
+				$input.parent().children('span.input-group-text').wrap( '<div class="input-group-prepend" style="cursor:pointer;" title="' + t + '"></div>');
 				var fn = function() {
 					var $container = $input.parents(".input-group");
 					var $i = $("i",$container);
 					$i.attr("class",$input.val());
 				};
 				$input.change(fn).keyup(fn).change();
+				$input.prev().on('click', function() {
+					// Show icon details on https://fontawesome.com/v5
+					var s = '';
+					if ( $input.val().split('fa-').length > 1 ) {
+						s = $input.val().split('fa-')[1];
+					};
+					window.open('https://fontawesome.com/v5/search?m=free&q=' + s,'Fontawesome-V5','toolbar=no,scrollbars=yes,resizable=yes,top=100,left=100,width=480,height=720');
+				});
 			});
 			// Url-Picker
 			$ZMI.initUrlInput(this);

--- a/Products/zms/plugins/www/zmi.core.css
+++ b/Products/zms/plugins/www/zmi.core.css
@@ -984,6 +984,24 @@ li.zmi-item span.zmi-ids {
 	text-align:center;
 	width:3em;
 }
+.zmi table#meta_commands.table td a > i.deprecated,
+.zmi table#meta_commands.table td a + i.deprecated,
+.zmi table#meta_types.table td > i.deprecated,
+.zmi table.repo-diff-files td a i.deprecated,
+.zmi-action.nav-metaobj button.btn.btn-default > i.deprecated {
+	color: #6c757d;
+	opacity: 0.5;
+}
+.zmi table#meta_overview.table td.meta-id span i.deprecated + a,
+.zmi table#meta_commands.table td a > i.deprecated + strong,
+.zmi table#meta_commands.table td a + i.deprecated + strong,
+.zmi table#meta_types.table td > i.deprecated + span,
+.zmi table.repo-diff-files td a i.deprecated + strong,
+.zmi-action.nav-metaobj button.btn.btn-default > i.deprecated + span {
+	color: #6c757d;
+	opacity: 0.5;
+	text-decoration: line-through;
+}
 .zmi table#meta_overview.table td.meta-id {
 	width: auto !important;
 }
@@ -1364,6 +1382,15 @@ div.pull-left div.single-line.input-append.zmi-nodes textarea {
 	margin-right:.4rem
 }
 
+.zmi-action .dropdown-menu i.deprecated,
+.zmi-action .btn.split-left i.deprecated {
+	opacity: 0.5;
+}
+.zmi-action .dropdown-menu i.deprecated + span,
+.zmi-action .btn.split-left i.deprecated + span {
+	opacity: 0.5;
+	text-decoration: line-through;
+}
 
 /* ZMS-Buttons */
 

--- a/Products/zms/zmsobject.py
+++ b/Products/zms/zmsobject.py
@@ -565,7 +565,6 @@ class ZMSObject(ZMSItem.ZMSItem,
     # --------------------------------------------------------------------------
     def zmi_icon(self,*args, **kwargs):
       """ ZMSObject.zmi_icon """
-      clazz = 'fas fa-exclamation-triangle text-danger'
       if 'name' in kwargs:
         clazz = kwargs['name'].replace('icon-','fas fa-')
       else:
@@ -575,12 +574,20 @@ class ZMSObject(ZMSItem.ZMSItem,
         clazz = self.evalMetaobjAttr( '%s.%s'%(id, 'icon_clazz'))
         if not clazz:
           meta_obj = self.getMetaobj(id)
-          clazzes = {'ZMSResource':'fas fa-asterisk', \
-              'ZMSLibrary':'fas fa-flask', \
+          clazzes = {'ZMSResource':'fas fa-asterisk',
+              'ZMSLibrary':'fas fa-flask',
               'ZMSPackage':'fas fa-suitcase',
               'ZMSRecordSet':'far fa-list-alt',
               'ZMSReference':'fas fa-link'}
-          clazz = clazzes.get(meta_obj.get('type'), 'fas fa-exclamation-triangle text-danger')
+          clazz = clazzes.get(meta_obj.get('type'))
+        if not clazz:
+          meta_cmd = self.getMetaCmd(id)
+          if meta_cmd is not None:
+            clazz = meta_cmd.get('icon_clazz')
+          elif id == 'workflow':
+            clazz = 'fas fa-cog'
+        if not clazz:
+          clazz = 'fas fa-exclamation-triangle text-danger'
       return clazz
 
 
@@ -601,7 +608,7 @@ class ZMSObject(ZMSItem.ZMSItem,
         if not name:
           metaObj = self.getMetaobj(id)
           names = {'ZMSResource':'fas fa-asterisk icon-asterisk','ZMSLibrary':'fas fa-flask icon-beaker','ZMSPackage':'fas fa-suitcase icon-suitcase','ZMSRecordSet':'far fa-list-alt icon-list','ZMSReference':'fas fa-link icon-link','ZMSTrashcan':'fas fa-trash'}
-          name = names.get(metaObj.get('type'), 'icon-file-alt')
+          name = names.get(metaObj.get('type'), 'fas fa-file-alt icon-file-alt')
         if meta_type is None:
           constraints = self.attr('check_constraints')
           if isinstance(constraints, dict):

--- a/Products/zms/zpt/ZMSContainerObject/manage_main.zpt
+++ b/Products/zms/zpt/ZMSContainerObject/manage_main.zpt
@@ -44,7 +44,7 @@
 					<span class="d-none zmi-sort-id">0</span>
 					<button class="btn split-left">
 						<tal:block tal:content="structure python:childNode.display_icon(request)">the icon</tal:block>
-						<tal:block tal:content="python:childNode.display_type(request)">the child-node</tal:block>
+						<span tal:content="python:childNode.display_type(request)">the child-node</span>
 					</button>
 					<button class="btn split-right dropdown-toggle" data-toggle="dropdown">
 						<tal:block tal:content="structure python:childNode.display_icon(request)">the icon</tal:block>
@@ -72,7 +72,7 @@
 							<span class="d-none zmi-sort-id" tal:content="python:childNode.getSortId()">the sort-id</span>
 							<button class="btn btn-secondary split-left">
 								<i tal:attributes="class python:childNode.zmi_icon()"></i>
-								<tal:block tal:content="python:childNode.display_type(request)">the child-node</tal:block>
+								<span tal:content="python:childNode.display_type(request)">the child-node</span>
 							</button>
 							<button class="btn btn-secondary split-right dropdown-toggle" data-toggle="dropdown">
 								<i tal:attributes="class python:childNode.zmi_icon()"></i>

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -117,7 +117,7 @@
 							<tal:block tal:condition="python:metaObj['type']!='ZMSPackage' and metaObj.get('package')==metaObjPackage">
 								<a class="dropdown-item" tal:attributes="href python:'?lang=%s&id=%s'%(request['lang'],metaObj['id'])">
 									<i tal:on-error="string:ERROR icon" tal:attributes="class python:zmscontext.zmi_icon(metaObj['id'])"></i>
-									<span tal:on-error="string:ERROR Name" tal:replace="metaObj/name">name</span>
+									<span tal:on-error="string:ERROR Name" tal:content="metaObj/name">name</span>
 								</a>
 							</tal:block>
 						</tal:block>
@@ -533,6 +533,7 @@
 							><i class="fas fa-share"></i></a>
 						<a title="Enabled" href="javascript:;" onclick="zmiEnabledBtnClick(this)"><i tal:attributes="class python:' '.join(['enabled-toggle']+[['far fa-square'],['far fa-check-square']][metaObj.get('enabled',0) in [1,True]])"></i></a>
 						<a tal:attributes="href python:'manage_analyze?lang=%s&id=%s'%(request['lang'],metaObj['id']); title python:'%s - Click for content analysis...'%metaObj['id']" target="_blank"><i tal:on-error="string:ERROR icon" tal:attributes="class python:zmscontext.zmi_icon(metaObj['id'])"></i></a>
+						<i tal:on-error="string:ERROR icon" tal:attributes="class python:zmscontext.zmi_icon(metaObj['id'])" style="display:none;"></i>
 						<a tal:attributes="href python:'?lang=%s&id=%s'%(request['lang'],metaObj['id'])"><span tal:on-error="string:ERROR name" tal:replace="metaObj/name">the name</span></a>
 						<span class="meta-id-info">
 							<tal:block tal:content="revision">the revision</tal:block>

--- a/Products/zms/zpt/ZMSObject/input_fields.zpt
+++ b/Products/zms/zpt/ZMSObject/input_fields.zpt
@@ -271,7 +271,7 @@
 													<span class="d-none zmi-sort-id" tal:content="python:childNode.getSortId()">the sort-id</span>
 													<button class="btn btn-secondary split-left">
 														<tal:block tal:content="structure python:childNode.display_icon(request)">the icon</tal:block>
-														<tal:block tal:content="python:childNode.display_type(request)">the child-node</tal:block>
+														<span tal:content="python:childNode.display_type(request)">the child-node</span>
 													</button>
 													<button class="btn btn-secondary split-right dropdown-toggle" data-toggle="dropdown">
 														<tal:block tal:content="structure python:childNode.display_icon(request)">the icon</tal:block>

--- a/Products/zms/zpt/ZMSRepositoryManager/manage_main_diff.zpt
+++ b/Products/zms/zpt/ZMSRepositoryManager/manage_main_diff.zpt
@@ -21,14 +21,8 @@
 				<div tal:repeat="id ids">
 					<i class="fas fa-check-circle text-success"></i>
 					<a tal:attributes="href python:'%s/manage_%s?lang=%s&id=%s'%(provider.absolute_url(), id=='__metas__' and 'metas' or 'main',request['lang'],id)" target="_blank">
-						<tal:block tal:repeat="icon python:[x['__icon__'] for x in local_files if x['id']==id and '__icon__' in x and x['__icon__']]">
-							<i tal:attributes="class icon"></i>
-						</tal:block>
 						<tal:block tal:content="id">id</tal:block>
 					</a>
-					<tal:block tal:repeat="desc python:[x['__description__'] for x in local_files if x['id']==id and '__description__' in x and x['__description__']]">
-						( <tal:block tal:content="desc">the description</tal:block> )
-					</tal:block>
 				</div>
 			</div>
 		</div>
@@ -50,20 +44,15 @@
 			</a>
 		</label>
 		<div class="col-sm-10">
-			<table class="table repo-diff-files">
+			<table class="table repo-diff-files table-sm table-hover">
 			<tal:block tal:repeat="id ids">
 				<tr>
 					<td class="meta-ids"><input type="checkbox" name="ids:list" tal:attributes="value python:'%s:%s'%(provider.id,id)" checked="checked"></td>
 					<td>
-						<a tal:attributes="href python:'%s/manage_%s?lang=%s&id=%s'%(provider.absolute_url(), id=='__metas__' and 'metas' or 'main',request['lang'],id)" target="_blank"> 
-							<tal:block tal:repeat="icon python:[x['__icon__'] for x in local_files if x['id']==id and '__icon__' in x and x['__icon__']]">
-								<i tal:attributes="class icon"></i>
-							</tal:block>
+						<a tal:attributes="href python:'%s/manage_%s?lang=%s&id=%s'%(provider.absolute_url(), id=='__metas__' and 'metas' or 'main',request['lang'],id)" target="_blank">
+							<i tal:on-error="string:" style="text-align:center;width:2em;" tal:attributes="class python:zmscontext.zmi_icon(id)"></i>
 							<strong tal:content="id">the id</strong>
 						</a>
-						<tal:block tal:repeat="desc python:[x['__description__'] for x in local_files if x['id']==id and '__description__' in x and x['__description__']]">
-							( <tal:block tal:content="desc">the description</tal:block> )
-						</tal:block>
 					</td>
 					<td>
 					<div style="white-space: nowrap;" 


### PR DESCRIPTION
If 'deprecated' is added to the icon's stylesheet class, the item is displayed strikethrough in meta overviews and action lists.

![Screen Shot 2022-04-29 at 21 11 54](https://user-images.githubusercontent.com/9883510/166057472-21f166b6-2c89-453d-aa1a-482923cfcabe.png)

