### PR TITLE
Fix ACE-Editor in ModalWin

### DIFF
--- a/Products/zms/zpt/ZMSFilterManager/manage_main.zpt
+++ b/Products/zms/zpt/ZMSFilterManager/manage_main.zpt
@@ -250,7 +250,8 @@ $(function(){
 						<tal:block tal:condition="python:filterProcess.get('file_filename',None)">
 							<input type="checkbox" checked="checked"/>
 							<a tal:attributes="href filterProcess/file_href; title python:'%s (%s)'%(filterProcess.get('file_filename',None),filterProcess.get('file_content_type',None))" 
-								target="_blank" tal:content="filterProcess/file_filename">FILENAME
+								target="_blank" data-turbolinks="false"
+								tal:content="filterProcess/file_filename">FILENAME
 							</a>
 						</tal:block>
 					</tal:block>

--- a/Products/zms/zpt/ZMSFilterManager/manage_main.zpt
+++ b/Products/zms/zpt/ZMSFilterManager/manage_main.zpt
@@ -1,12 +1,14 @@
 <tal:block tal:define="
 	dummy0 python:here.zmi_page_request(here,request); 
-	global standard modules/Products.zms/standard; 
-	global zopeutil modules/Products/zms/zopeutil;
-	global session python:standard.get_session(here);"></tal:block
-><tal:block tal:condition="python:standard.get_session_value(here,'zmi-manage-system',0)==1"><tal:block tal:content="structure python:here.manage_system(here,request)"></tal:block></tal:block
+	standard modules/Products.zms/standard; 
+	zopeutil modules/Products.zms/zopeutil;
+	session python:standard.get_session(here);"
+><tal:block tal:condition="python:standard.get_session_value(here,'zmi-manage-system',0)==1"
+	><tal:block tal:content="structure python:here.manage_system(here,request)"></tal:block
+></tal:block
 ><tal:block tal:condition="not:python:standard.get_session_value(here,'zmi-manage-system',0)==1"
 ><!DOCTYPE html>
-<html lang="en" tal:define="standard modules/Products.zms/standard">
+<html lang="en">
 <head tal:replace="structure python:here.zmi_html_head(here,request)">zmi_html_head</head>
 <body tal:attributes="class python:here.zmi_body_class(id='filter config')">
 <header tal:replace="structure python:here.zmi_body_header(here,request,options=here.customize_manage_options())">zmi_body_header</header>
@@ -302,21 +304,14 @@ $(function(){
 				</div><!-- .controls.save -->
 			</div><!-- .form-row -->
 			<div class="form-group row inpCommand">
-				<div class="col-md-12"><textarea class="form-control zmi-code" id="inpCommand" name="inpCommand" tal:content="process/command" cols="80" rows="25">the command</textarea></div>
-			</div><!-- .form-group -->
-
-<tal:block tal:replace="nothing">
-			<!-- ACE Editor -->
-			<div class="form-group row inpCommand">
 				<div class="col-md-12">
 					<input type="hidden" name="el_method" tal:attributes="value process/id" />
-					<tal:block tal:content="structure python:here.zmi_ace_editor(here,request,name='inpCommand',ob=process,text=process.get('command',''))">ACE Editor</tal:block>
+					<textarea tal:replace="structure python:here.zmi_ace_editor(here,request,name='inpCommand',id='filtercmd_%s'%(process.get('id')),ob=None,text=process.get('command',''))">
+						ACE Editor
+					</textarea>
 				</div>
 			</div><!-- .form-group -->
-			<!-- /ACE Editor -->
-</tal:block>
-
-</form>
+		</form>
 	</div><!-- .inner -->
 </div><!-- #updateProcess -->
 
@@ -425,7 +420,8 @@ $(function(){
 				<td>
 					<i tal:condition="python:filter.get('acquired')" class="icon-share fas fa-share mr-2" title="acquired"></i>
 					<a href="javascript:;" onclick="$('i',this).toggleClass('fa-chevron-right fa-chevron-down');$(this).siblings('.filterProcesses').toggle('normal');"><i class="fas fa-chevron-right"></i></a>
-					<a tal:attributes="href python:'?lang=%s&id=%s'%(request['lang'],filterId); title python:here.getZMILangStr('BTN_EDIT')+'...'">
+					<a tal:attributes="href python:'?lang=%s&id=%s'%(request['lang'],filterId); title python:here.getZMILangStr('BTN_EDIT')+'...'"
+						data-turbolinks="false">
 						<i class="fas fa-filter"></i>
 						<tal:block tal:content="python:filter.get('name','Missing filter name')">the filter-name</tal:block>
 					</a>
@@ -501,9 +497,10 @@ $(function(){
 				</td>
 				<td>
 					<i tal:condition="python:process.get('acquired')" class="icon-share fas fa-share mr-2" title="acquired"></i>
-					<a tal:attributes="href python:'?lang=%s&id=%s'%(request['lang'],processId); title python:here.getZMILangStr('BTN_EDIT')+'...'">
-						<tal:block tal:condition="python:standard.operator_getattr(here,process['id'],None) is not None"><i tal:on-error="nothing" tal:attributes="class python:getattr(here,process['id']).zmi_icon"></i></tal:block>
-						<tal:block tal:condition="python:standard.operator_getattr(here,process['id'],None) is None"><i class="fas fa-cog"></i></tal:block>
+					<a tal:attributes="href python:'?lang=%s&id=%s'%(request['lang'],processId); title python:here.getZMILangStr('BTN_EDIT')+'...'"
+						data-turbolinks="false">
+						<i tal:condition="python:standard.operator_getattr(here,process['id'],None) is not None" tal:on-error="nothing" tal:attributes="class python:getattr(here,process['id']).zmi_icon"></i>
+						<i tal:condition="python:standard.operator_getattr(here,process['id'],None) is None" class="fas fa-cog"></i>
 						<b class="ml-2 processId" tal:content="process/id">the id</b>
 					</a>
 					<span class="processName text-muted ml-2" tal:content="python:'%s'%(process.get('name','Name Missing!'))">the name</span>
@@ -521,4 +518,5 @@ $(function(){
 <footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>
+</tal:block>
 </tal:block>

--- a/Products/zms/zpt/ZMSMetacmdProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetacmdProvider/manage_main.zpt
@@ -9,8 +9,7 @@
 		action python:'manage_changeMetacmds';
 		metaCmdIds python:standard.sort_list(here.getMetaCmdIds());
 		metaCmds python:[here.getMetaCmd(x) for x in metaCmdIds];
-		packages python:standard.sort_list(standard.distinct_list([x.get('package','') for x in metaCmds]));
-		">
+		packages python:standard.sort_list(standard.distinct_list([x.get('package','') for x in metaCmds]));">
 
 <tal:block tal:content="structure python:here.zmi_breadcrumbs(here,request,extra=[here.manage_sub_options()[0]]+[{'action':'?id=%s'%x['id'],'label':x['name']} for x in metaCmds if x['id']==request.get('id')])">zmi_breadcrumbs</tal:block>
 
@@ -67,7 +66,7 @@
 			<tal:block tal:define="ob python:getattr(here,request['id'],None)"
 				><tal:block tal:condition="python:ob is not None"
 					><input type="hidden" name="el_method" tal:attributes="value ob/meta_type"
-					/><tal:block tal:content="structure python:here.zmi_ace_editor(here,request,name='el_data:text',ob=ob,text=metaCmd['data'])">ACE Editor</tal:block
+					/><textarea tal:replace="structure python:here.zmi_ace_editor(here,request,name='el_data',id='cmd_%s'%(ob.getId()),ob=ob,text=metaCmd['data'])">ACE Editor</textarea
 				></tal:block
 			></tal:block>
 			<!-- /ACE Editor -->
@@ -261,7 +260,7 @@
 				<td>
 					<tal:block tal:condition="python:ob is not None">
 						<tal:block tal:condition="python:metaCmd.get('acquired',False)">
-							<a target="_blank"
+							<a target="_blank" data-turbolinks="false"
 								tal:attributes="
 									href python:'%s/metacmd_manager/manage_main?lang=%s&id=%s'%(context.getRootElement().absolute_url(),request['lang'],metaCmd['id']);
 									title python:'acquired from: %s (%s)'%(context.getRootElement().getHome().id, context.getRootElement().attr('titlealt'))"
@@ -270,7 +269,8 @@
 							<strong tal:content="python:metaCmd['id']">the id</strong> ( <tal:block tal:content="python:here.getZMILangStr(metaCmd['name'])">Name</tal:block> )
 						</tal:block>
 						<tal:block tal:condition="not:python:metaCmd.get('acquired',False)">
-							<a tal:attributes="href python:'?lang=%s&id=%s'%(request['lang'],metaCmd['id']); title python:'%s (%s)'%(ob.id,ob.meta_type)">
+							<a data-turbolinks="false"
+								tal:attributes="href python:'?lang=%s&id=%s'%(request['lang'],metaCmd['id']); title python:'%s (%s)'%(ob.id,ob.meta_type)">
 								<i tal:condition="python:metaCmd.get('icon_clazz',False)" tal:attributes="class python:metaCmd.get('icon_clazz')"></i>
 								<strong tal:content="python:metaCmd['id']">the id</strong>
 								(<tal:block tal:content="python:here.getZMILangStr(metaCmd['name'])">the name</tal:block>)

--- a/Products/zms/zpt/ZMSWorkflowProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSWorkflowProvider/manage_main.zpt
@@ -311,7 +311,7 @@
 				</tal:block>
 				<tal:block tal:condition="python:ob is not None">
 					<input type="hidden" name="inpType" tal:attributes="value ob/meta_type"/>
-					<tal:block tal:content="structure python:here.zmi_ace_editor(here,request,name='inpData',ob=ob)">
+					<tal:block tal:content="structure python:here.zmi_ace_editor(here,request,name='inpData',id='wftransition_%s'%(ob.getId()),ob=ob)">
 						ACE Editor
 					</tal:block>
 				</tal:block>
@@ -506,8 +506,9 @@
 							<td>
 								<div tal:attributes="class python:' '.join(['transition']+[[],['state']][int(ob is None)]+[[],['action']][int(len(transition['from'])+len(transition['to'])==0)])">
 									<i tal:attributes="class python:transition.get('icon_clazz','far fa-square')"></i>
-									<a tal:attributes="href python:'?lang=%s&key=edit&id=%s'%(request['lang'],transition['id'])">
-										<tal:block tal:content="python:transition['name']">the name</tal:block>
+									<a tal:attributes="href python:'?lang=%s&key=edit&id=%s'%(request['lang'],transition['id'])"
+										tal:content="python:transition['name']" data-turbolinks="false">
+										the name<
 									</a>
 									<ul class="performer smaller" tal:condition="python:transition['performer']">
 										<li tal:repeat="performer python:transition['performer']" tal:content="python:performer">performer</li>

--- a/Products/zms/zpt/common/zmi_ace_editor.zpt
+++ b/Products/zms/zpt/common/zmi_ace_editor.zpt
@@ -4,19 +4,19 @@
 		id python:options.get('id') and options.get('id') or name;
 		ob python:options.get('ob');
 		text python:options.get('text');
+		text python:text is None and zopeutil.readObject(here,ob.getId()) or text;
 		height python:options.get('height','20em');
 		content_type python:options.get('content_type','dtml')">
-	<tal:block tal:condition="python:text is None"><tal:block tal:define="global text python:zopeutil.readObject(here,ob.getId())"></tal:block></tal:block>
 	<tal:block tal:on-error="structure string:<div class='alert alert-danger mx-0 alert-dismissible fade show' role='alert'>TypeError: a bytes-like object is required, not str</div>"
 		tal:condition="python:ob is not None and ob.meta_type in ['Script (Python)']" 
 		tal:define="errors python:[x.replace(' ','&nbsp\073') for x in text.split('##') if x.startswith(' ')][1:]">
 		<div class="alert alert-danger mx-0 alert-dismissible fade show" role="alert" tal:condition="python:len(errors)>0 and errors[0].find('Errors:')>=0" tal:content="structure python:'<br/>'.join(errors)">the errors</div>
 		<div class="alert alert-warning mx-0 alert-dismissible fade show" role="alert" tal:condition="python:len(errors)>0 and errors[0].find('Warnings:')>=0" tal:content="structure python:'<br/>'.join(errors)">the warnings</div>
 	</tal:block>
-	<div tal:condition="python:ob is not None" 
-		class="form-group zmi-ace-editor" 
+	<div class="form-group zmi-ace-editor" 
 		tal:attributes="style python:'height:%s'%height">
-		<div class="control-label-ace-editor">
+		<div tal:condition="python:ob is not None"  
+			class="control-label-ace-editor">
 			<a tal:attributes="href python:'%s/manage_main'%ob.absolute_url(); title ob/meta_type" target="_blank">
 				<tal:block tal:content="python:ob.getId()">id<</tal:block>
 				<tal:block tal:condition="python:text is not None">(<tal:block tal:content="python:here.getDataSizeStr(len(text))">the size</tal:block>)</tal:block>

--- a/Products/zms/zpt/common/zmi_ace_editor.zpt
+++ b/Products/zms/zpt/common/zmi_ace_editor.zpt
@@ -1,7 +1,8 @@
 <tal:block tal:define="global
 		zopeutil modules/Products.zms/zopeutil;
-		name python:options['name'];
-		ob python:options['ob'];
+		name python:options.get('name');
+		id python:options.get('id') and options.get('id') or name;
+		ob python:options.get('ob');
 		text python:options.get('text');
 		height python:options.get('height','20em');
 		content_type python:options.get('content_type','dtml')">
@@ -22,9 +23,9 @@
 			</a> 
 		</div>
 		<div>
-			<textarea class="form-control-ace-editor" tal:attributes="name name;id name;data-content_type content_type" tal:content="text">the text</textarea>
+			<textarea class="form-control-ace-editor" tal:attributes="name name;id id;data-content_type content_type" tal:content="text">the text</textarea>
 		</div>
-		<div tal:attributes="id python:'editor_%s'%name" style="height:92%;width:100%;border:1px solid #ccc;border-radius:4px">
+		<div tal:attributes="id python:'editor_%s'%id" style="height:92%;width:100%;border:1px solid #ccc;border-radius:4px">
 			ace editor text
 		</div>
 	</div><!-- .form-group -->


### PR DESCRIPTION
Turbolinks has some bad interferences with the zms-core JS libs. Mainly Turbolinks results in a 2x call if ACE is rendered in a modal-win:

![ACE_2x_construct](https://user-images.githubusercontent.com/29705216/166171637-deea535e-adfe-4963-a54b-d404b0f80704.gif)


The concepts are described here;
https://www.honeybadger.io/blog/turbolinks/
In Bootstrap-Modal-Win the ACE-Editor may not initialized correctly. In most cases the the atrtibute `data-turbolinks="false" `on  a-element will help. 
But not with the filter-methods Any ideas?