### PR TITLE
added pythonic calendar content object

### DIFF
--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/__init__.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/__init__.py
@@ -16,7 +16,7 @@ class com_zms_calendar:
 	package = ""
 
 	# Revision
-	revision = "0.0.1"
+	revision = "0.0.2"
 
 	# Type
 	type = "ZMSPackage"

--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/__init__.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/__init__.py
@@ -1,0 +1,22 @@
+class com_zms_calendar:
+	"""
+	python-representation of com.zms.calendar
+	"""
+
+	# Enabled
+	enabled = 1
+
+	# Id
+	id = "com.zms.calendar"
+
+	# Name
+	name = "com.zms.calendar"
+
+	# Package
+	package = ""
+
+	# Revision
+	revision = "0.0.1"
+
+	# Type
+	type = "ZMSPackage"

--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/__init__.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/__init__.py
@@ -16,7 +16,7 @@ class com_zms_calendar:
 	package = ""
 
 	# Revision
-	revision = "0.0.2"
+	revision = "0.0.5"
 
 	# Type
 	type = "ZMSPackage"

--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/__init__.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/__init__.py
@@ -1,0 +1,104 @@
+class calendar:
+	"""
+	python-representation of calendar
+	"""
+
+	# Access
+	access = {"delete_custom":""
+		,"delete_deny":[""
+			,""
+			,""
+			,""
+			,""
+			,""]
+		,"insert_custom":"{$}"
+		,"insert_deny":[""
+			,""
+			,""
+			,""
+			,""
+			,""]}
+
+	# Enabled
+	enabled = 1
+
+	# Id
+	id = "calendar"
+
+	# Name
+	name = "Calendar"
+
+	# Package
+	package = "com.zms.calendar"
+
+	# Revision
+	revision = "0.0.2"
+
+	# Type
+	type = "ZMSObject"
+
+	# Attrs
+	class Attrs:
+		title = {"default":""
+			,"id":"title"
+			,"keys":[]
+			,"mandatory":0
+			,"multilang":1
+			,"name":"Title"
+			,"repetitive":0
+			,"type":"string"}
+
+		icon_clazz = {"custom":"fas fa-calendar text-info"
+			,"default":""
+			,"id":"icon_clazz"
+			,"keys":[]
+			,"mandatory":0
+			,"multilang":0
+			,"name":"Icon-Class (CSS)"
+			,"repetitive":0
+			,"type":"constant"}
+
+		events = {"default":""
+			,"id":"events"
+			,"keys":[]
+			,"mandatory":1
+			,"multilang":0
+			,"name":"Calendar-Items"
+			,"repetitive":0
+			,"type":"calendar_items"}
+
+		get_events = {"default":""
+			,"id":"get_events"
+			,"keys":[]
+			,"mandatory":0
+			,"multilang":0
+			,"name":"Process Events Data"
+			,"repetitive":0
+			,"type":"py"}
+
+		get_calendar = {"default":""
+			,"id":"get_calendar"
+			,"keys":[]
+			,"mandatory":0
+			,"multilang":0
+			,"name":"External Method"
+			,"repetitive":0
+			,"type":"External Method"}
+
+		test__calendar__get_events = {"default":""
+			,"id":"test__calendar__get_events"
+			,"keys":[]
+			,"mandatory":0
+			,"multilang":0
+			,"name":"TEST get_events"
+			,"repetitive":0
+			,"type":"Script (Python)"}
+
+		standard_html = {"default":""
+			,"id":"standard_html"
+			,"keys":[]
+			,"mandatory":0
+			,"multilang":0
+			,"name":"Standard-Template"
+			,"repetitive":0
+			,"type":"zpt"}

--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/__init__.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/__init__.py
@@ -32,7 +32,7 @@ class calendar:
 	package = "com.zms.calendar"
 
 	# Revision
-	revision = "0.0.2"
+	revision = "0.0.3"
 
 	# Type
 	type = "ZMSObject"
@@ -66,6 +66,16 @@ class calendar:
 			,"name":"Calendar-Items"
 			,"repetitive":0
 			,"type":"calendar_items"}
+
+		default_css = {"custom":".calendar table th.month-head {\r\n	background-color:#17a2b8;\r\n	color:white;\r\n}\r\n.calendar table td {\r\n	vertical-align:top;\r\n	width:6rem;\r\n}\r\n.calendar table td:hover {\r\n	background-color:#eee;\r\n}\r\n.calendar table td span.day {\r\n	color:#aaa;\r\n}\r\n.calendar table td p {\r\n	width:4rem;\r\n	white-space:nowrap;\r\n	overflow:hidden;\r\n	text-overflow:ellipsis;\r\n}"
+			,"default":""
+			,"id":"default_css"
+			,"keys":[]
+			,"mandatory":0
+			,"multilang":0
+			,"name":"CSS Defaults"
+			,"repetitive":0
+			,"type":"constant"}
 
 		get_events = {"default":""
 			,"id":"get_events"

--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/__init__.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/__init__.py
@@ -32,7 +32,7 @@ class calendar:
 	package = "com.zms.calendar"
 
 	# Revision
-	revision = "0.0.3"
+	revision = "0.0.5"
 
 	# Type
 	type = "ZMSObject"
@@ -67,7 +67,7 @@ class calendar:
 			,"repetitive":0
 			,"type":"calendar_items"}
 
-		default_css = {"custom":".calendar table th.month-head {\r\n	background-color:#17a2b8;\r\n	color:white;\r\n}\r\n.calendar table td {\r\n	vertical-align:top;\r\n	width:6rem;\r\n}\r\n.calendar table td:hover {\r\n	background-color:#eee;\r\n}\r\n.calendar table td span.day {\r\n	color:#aaa;\r\n}\r\n.calendar table td p {\r\n	width:4rem;\r\n	white-space:nowrap;\r\n	overflow:hidden;\r\n	text-overflow:ellipsis;\r\n}"
+		default_css = {"custom":".calendar nav {\r\n	display:flex;\r\n	flex-direction: row;\r\n	align-content: center;\r\n	justify-content: space-between;\r\n	margin:0 0 -3.5em 0;\r\n	padding:0 1em 0 1em;\r\n	z-index:100;\r\n	line-height:1;\r\n}\r\n.calendar nav a,\r\n.calendar nav a:hover {\r\n	text-decoration:none;\r\n	display:block;\r\n	padding-top:.5em;\r\n}\r\n.calendar nav i {\r\n	color:#b1d8de;\r\n	font-size:2em;\r\n	border:0px solid white;\r\n	line-height:1;\r\n	width:1.5em;\r\n	height:1.5em;\r\n	text-align:center;\r\n	padding-top:.275em;\r\n	border-radius:50%;\r\n	background:#00000033;\r\n}\r\n.calendar nav i.fa-chevron-left {\r\n	padding-right:.15em;\r\n}\r\n.calendar nav i.fa-chevron-right {\r\n	padding-left:.15em;\r\n}\r\n.calendar nav i:hover {\r\n	border-radius:50%;\r\n	background:#00000066;\r\n	color:white;\r\n}\r\n.calendar table th.month-head {\r\n	background-color:#17a2b8;\r\n	color:white;\r\n	font-size:2em;\r\n	padding: .2em .75rem;\r\n	font-weight:normal\r\n}\r\n.calendar table th.month-head:before {\r\n	content:\"\\f073\";\r\n	font-family: 'Font Awesome 5 Free';\r\n	font-weight: normal;\r\n	margin: 0 .5em 0 0;\r\n	-moz-osx-font-smoothing: grayscale;\r\n	-webkit-font-smoothing: antialiased;\r\n	display: inline-block;\r\n	font-style: normal;\r\n	font-variant: normal;\r\n	text-rendering: auto;\r\n	line-height: 1;\r\n	box-sizing: border-box;\r\n	display:inline-block;\r\n}\r\n.bs3 th.month-head:before {\r\n	content: \"\\e109\";\r\n	font-family \"Glyphicons Halflings\";\r\n}\r\n.calendar table td {\r\n	vertical-align:top;\r\n	width:6rem;\r\n}\r\n.calendar tr.hilight {\r\n    background:#d1ecf1 !important;\r\n}\r\n.calendar table td[data-toggle=\"tooltip\"]:hover {\r\n	background-color:#eee;\r\n	cursor:pointer;\r\n}\r\n.calendar table td span.day {\r\n	color:#aaa;\r\n}\r\n.calendar table td p {\r\n	width:6rem;\r\n	width: calc(842px / 7);\r\n	white-space:nowrap;\r\n	overflow:hidden;\r\n	text-overflow:ellipsis;\r\n	margin-top:.5em;\r\n}"
 			,"default":""
 			,"id":"default_css"
 			,"keys":[]

--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/get_calendar.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/get_calendar.py
@@ -1,4 +1,4 @@
-# Inspired by https://www.huiwenteo.com/normal/2018/07/24/django-calendar.html
+## Inspired by https://www.huiwenteo.com/normal/2018/07/24/django-calendar.html
 
 import locale
 ## IMPORTANT NOTE: first install your OS locale pack, e.g.
@@ -23,7 +23,7 @@ from calendar import HTMLCalendar
 # 		'title':'Exam of Economics 1st Semester Part 2',
 # 		'description':'Its gonna be hard and impossible',
 # 		'url':'https://exam.yeepa-formosa.net/',
-# 
+#
 # 	}
 # ]
 
@@ -45,8 +45,6 @@ class Calendar(HTMLCalendar):
 		self.year = year
 		self.month = month
 		self.events = events
-		self.td_style='vertical-align:top;width:6rem;'
-		self.e_style='width:4rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;'
 		super(Calendar, self).__init__()
 
 	# formats a day as a td
@@ -60,14 +58,21 @@ class Calendar(HTMLCalendar):
 			return '<td class="%s">&nbsp;</td>' % (self.cssclass_noday)
 		else:
 			events_dt = filter_events_by_date(self.events, self.year, self.month, day)
-			events_titles = [e.get('title','') for e in events_dt]
-			events_titles_long = ['%s : %s'%(e.get('title',''), e.get('description','')) for e in events_dt]
-			titles = '<br/>'.join(events_titles)
-			titles_long = '\n'.join(events_titles_long)
-			# return '<td class="%s">%d</td>' % (self.cssclasses[weekday], day)
-			return '<td style="%s" class="%s" data-toggle="tooltip" title="%s">%d <p style="%s">%s</p></td>' % (self.td_style, self.cssclasses[weekday], titles_long, day, self.e_style, titles)
+			t_short = ''
+			t_long = ''
+			if events_dt:
+				events_titles = [e.get('title','') for e in events_dt]
+				events_titles_long = ['%s : %s'%(e.get('title',''), e.get('description','')) for e in events_dt]
+				t_short = '<br/>'.join(events_titles)
+				t_long = '\n'.join(events_titles_long)
+		# return '<td class="%s">%d</td>' % (self.cssclasses[weekday], day)
+		return '<td class="%s" data-toggle="tooltip" title="%s"><span class="day">%d</span> %s</td>' % (self.cssclasses[weekday], t_long, day, '<p>%s</p>'%(t_short))
 
 
 def get_calendar(self,year=2000,month=1,events=[]):
 	htmlcal = Calendar(year=year,month=month,events=events)
+	htmlcal.cssclasses = [style + " text-nowrap" for style in HTMLCalendar.cssclasses]
+	htmlcal.cssclass_month = "month table table-bordered"
+	htmlcal.cssclass_month_head = "month-head"
+	# htmlcal.cssclass_year = "text-italic lead"
 	return htmlcal.formatmonth(htmlcal.year, htmlcal.month)

--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/get_calendar.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/get_calendar.py
@@ -60,19 +60,24 @@ class Calendar(HTMLCalendar):
 			events_dt = filter_events_by_date(self.events, self.year, self.month, day)
 			t_short = ''
 			t_long = ''
+			event_link = ''
+			has_events = False
 			if events_dt:
-				events_titles = [e.get('title','') for e in events_dt]
+				has_events = True
+				event_id = [e.get('col_id','') for e in events_dt][0]
+				event_link = 'onclick="document.getElementById(\'%s\').classList.add(\'hilight\');$(\'html,body\').animate({scrollTop:$(\'#%s\').offset().top}, 600)"'%(event_id,event_id)
+				events_titles = [(e.get('start_time','').split(' ')[-1] == '00:00' and e.get('title','') or '%s | %s'%(e.get('start_time','').split(' ')[-1], e.get('title',''))) for e in events_dt]
 				events_titles_long = ['%s : %s'%(e.get('title',''), e.get('description','')) for e in events_dt]
 				t_short = '<br/>'.join(events_titles)
 				t_long = '\n'.join(events_titles_long)
 		# return '<td class="%s">%d</td>' % (self.cssclasses[weekday], day)
-		return '<td class="%s" data-toggle="tooltip" title="%s"><span class="day">%d</span> %s</td>' % (self.cssclasses[weekday], t_long, day, '<p>%s</p>'%(t_short))
+		return '<td %s class="%s" %s title="%s"><span class="day">%d</span> %s</td>' % (event_link, self.cssclasses[weekday], has_events and 'data-toggle="tooltip"' or '',  t_long, day, has_events and '<p><i class="far fa-calendar text-info"></i> %s</p>'%(t_short) or '<p></p>')
 
 
 def get_calendar(self,year=2000,month=1,events=[]):
 	htmlcal = Calendar(year=year,month=month,events=events)
-	htmlcal.cssclasses = [style + " text-nowrap" for style in HTMLCalendar.cssclasses]
+	htmlcal.cssclasses = [style + ' text-nowrap' for style in HTMLCalendar.cssclasses]
 	htmlcal.cssclass_month = "month table table-bordered"
-	htmlcal.cssclass_month_head = "month-head"
+	htmlcal.cssclass_month_head = "month-head text-center"
 	# htmlcal.cssclass_year = "text-italic lead"
 	return htmlcal.formatmonth(htmlcal.year, htmlcal.month)

--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/get_calendar.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/get_calendar.py
@@ -1,0 +1,71 @@
+# Inspired by https://www.huiwenteo.com/normal/2018/07/24/django-calendar.html
+
+import locale
+## IMPORTANT NOTE: first install your OS locale pack, e.g.
+## sudo apt-get install language-pack-de-base
+
+from datetime import datetime, timedelta
+import dateutil.parser as dparser
+from calendar import HTMLCalendar
+
+## EVENT DATA MODEL
+# events = [
+# 	{
+# 		'start_time':'2022-05-18 15:00',
+# 		'end_time':'2022-05-18 18:00',
+# 		'title':'Exam of Economics 1st Semester Part 1',
+# 		'description':'Its gonna be hard, but not impossible',
+# 		'url':'https://exam.yeepa-formosa.net/',
+# 	},
+# 	{
+# 		'start_time':'2022-05-20 15:00',
+# 		'end_time':'2022-05-20 18:00',
+# 		'title':'Exam of Economics 1st Semester Part 2',
+# 		'description':'Its gonna be hard and impossible',
+# 		'url':'https://exam.yeepa-formosa.net/',
+# 
+# 	}
+# ]
+
+
+# SET LOCALE
+locale.setlocale(locale.LC_ALL, 'de_DE.UTF-8')
+
+# HELPERS
+def parse_dt(s='2022-05-20 18:00'):
+	return dparser.parse(s).date()
+
+def filter_events_by_date(events, year, month, day):
+	this_dt = datetime(year, month, day).date()
+	return [e for e in events if parse_dt(e.get('start_time',''))==this_dt]
+
+# FUNCTION OVERWRITE OF formatday()
+class Calendar(HTMLCalendar):
+	def __init__(self, year=None, month=None, events=[]):
+		self.year = year
+		self.month = month
+		self.events = events
+		self.td_style='vertical-align:top;width:6rem;'
+		self.e_style='width:4rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;'
+		super(Calendar, self).__init__()
+
+	# formats a day as a td
+	# filter events by day
+	def formatday(self, day, weekday):
+		"""
+		Return a day as a table cell.
+		"""
+		if day == 0:
+			# day outside month
+			return '<td class="%s">&nbsp;</td>' % (self.cssclass_noday)
+		else:
+			events_dt = filter_events_by_date(self.events, self.year, self.month, day)
+			events_titles = [e.get('title','') for e in events_dt]
+			s = '<br/>'.join(events_titles)
+			# return '<td class="%s">%d</td>' % (self.cssclasses[weekday], day)
+			return '<td style="%s" class="%s" title="%s">%d <p style="%s">%s</p></td>' % (self.td_style, self.cssclasses[weekday], s, day, self.e_style, s)
+
+
+def get_calendar(self,year=2000,month=1,events=[]):
+	htmlcal = Calendar(year=year,month=month,events=events)
+	return htmlcal.formatmonth(htmlcal.year, htmlcal.month)

--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/get_calendar.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/get_calendar.py
@@ -61,9 +61,11 @@ class Calendar(HTMLCalendar):
 		else:
 			events_dt = filter_events_by_date(self.events, self.year, self.month, day)
 			events_titles = [e.get('title','') for e in events_dt]
-			s = '<br/>'.join(events_titles)
+			events_titles_long = ['%s : %s'%(e.get('title',''), e.get('description','')) for e in events_dt]
+			titles = '<br/>'.join(events_titles)
+			titles_long = '\n'.join(events_titles_long)
 			# return '<td class="%s">%d</td>' % (self.cssclasses[weekday], day)
-			return '<td style="%s" class="%s" title="%s">%d <p style="%s">%s</p></td>' % (self.td_style, self.cssclasses[weekday], s, day, self.e_style, s)
+			return '<td style="%s" class="%s" data-toggle="tooltip" title="%s">%d <p style="%s">%s</p></td>' % (self.td_style, self.cssclasses[weekday], titles_long, day, self.e_style, titles)
 
 
 def get_calendar(self,year=2000,month=1,events=[]):

--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/get_events.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/get_events.py
@@ -12,7 +12,7 @@ from Products.zms import standard
 request = container.REQUEST
 RESPONSE =  request.RESPONSE
 
-fieldnames = ['start_time','end_time','title','description','url']
+fieldnames = ['col_id','start_time','end_time','title','description','location','url']
 events=[]
 res = zmscontext.events.attr('records')
 for e in res:

--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/get_events.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/get_events.py
@@ -1,0 +1,29 @@
+## Script (Python) "calendar.get_events"
+##bind container=container
+##bind context=context
+##bind namespace=
+##bind script=script
+##bind subpath=traverse_subpath
+##parameters=zmscontext=None,options=None
+##title=py: Process Events Data
+##
+# --// get_events //--
+from Products.zms import standard
+request = container.REQUEST
+RESPONSE =  request.RESPONSE
+
+fieldnames = ['start_time','end_time','title','description','url']
+events=[]
+res = zmscontext.events.attr('records')
+for e in res:
+    d={}
+    for k in fieldnames:
+        if "time" in k:
+            d[k] = zmscontext.getLangFmtDate(e[k], lang='eng', fmt_str='%Y-%m-%d %H:%M')
+        else:
+            d[k] = e[k]
+    events.append(d)
+
+return events
+
+# --// /get_events //--

--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/standard_html.zpt
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/standard_html.zpt
@@ -1,0 +1,13 @@
+<!-- calendar.standard_html -->
+<div title="Default-ZPT-Code" 
+		tal:define="zmscontext options/zmscontext;
+		id python:zmscontext.getId();
+		css_class python:zmscontext.meta_id;
+		year python:context.ZopeTime().year();
+		month python:context.ZopeTime().month();
+		get_events python:list(zmscontext.attr('get_events'));
+		get_calendar python:zmscontext.get_calendar(year=year, month=month, events=get_events);"
+	tal:attributes="id id; class css_class">
+	<div class="get_calendar" tal:content="structure get_calendar">get_calendar</div>
+</div>
+<!-- calendar.standard_html -->

--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/standard_html.zpt
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/standard_html.zpt
@@ -2,13 +2,23 @@
 <div tal:define="zmscontext options/zmscontext;
 		id python:zmscontext.getId();
 		css_class python:zmscontext.meta_id;
-		year python:context.ZopeTime().year();
-		month python:context.ZopeTime().month();
+		year python:request.get('year',None) and request.get('year',None) or context.ZopeTime().year();
+		month python:request.get('month',None) and request.get('month',None) or context.ZopeTime().month();
+		prev_month python:month - 1;
+		next_month python:month + 1;
 		get_events python:list(zmscontext.attr('get_events'));
 		css python:zmscontext.attr('default_css');
 		get_calendar python:zmscontext.get_calendar(year=year, month=month, events=get_events);"
 	tal:attributes="id id; class css_class">
-	<div class="get_calendar" tal:content="structure get_calendar">get_calendar</div>
+	<nav>
+		<a href="#" tal:attributes="href python:'?month:int=%d&year:int=%d'%(prev_month,year)"
+			title="Previous Month"><i class="fas fa-chevron-left"></i></a>
+		<a href="#" tal:attributes="href python:'?month:int=%d&year:int=%d'%(next_month,year)"
+			title="Next Month"><i class="fas fa-chevron-right"></i></a>
+	</nav>
+	<div class="calendar_grid" tal:content="structure get_calendar">Calendar Grid</div>
+	<div class="event_list mt-5" tal:content="structure python:zmscontext.events.getBodyContent(request)">Event List</div>
 	<style tal:content="css">Default CSS</style>
 </div>
+
 <!-- calendar.standard_html -->

--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/standard_html.zpt
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/standard_html.zpt
@@ -1,13 +1,14 @@
 <!-- calendar.standard_html -->
-<div title="Default-ZPT-Code" 
-		tal:define="zmscontext options/zmscontext;
+<div tal:define="zmscontext options/zmscontext;
 		id python:zmscontext.getId();
 		css_class python:zmscontext.meta_id;
 		year python:context.ZopeTime().year();
 		month python:context.ZopeTime().month();
 		get_events python:list(zmscontext.attr('get_events'));
+		css python:zmscontext.attr('default_css');
 		get_calendar python:zmscontext.get_calendar(year=year, month=month, events=get_events);"
 	tal:attributes="id id; class css_class">
 	<div class="get_calendar" tal:content="structure get_calendar">get_calendar</div>
+	<style tal:content="css">Default CSS</style>
 </div>
 <!-- calendar.standard_html -->

--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/test__calendar__get_events.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar/test__calendar__get_events.py
@@ -1,0 +1,19 @@
+## Script (Python) "test__calendar__get_events"
+##bind container=container
+##bind context=context
+##bind namespace=
+##bind script=script
+##bind subpath=traverse_subpath
+##parameters=
+##title=TEST get_events
+##
+# --// test__calendar__get_events //--
+from Products.zms import standard
+request = container.REQUEST
+RESPONSE =  request.RESPONSE
+zms = context.content
+nodes = zms.filteredChildNodes(request,'calendar')
+zmscontext = nodes[0]
+
+return zmscontext.attr('get_events')
+# --// /test__calendar__get_events //--

--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar_items/__init__.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar_items/__init__.py
@@ -32,7 +32,7 @@ class calendar_items:
 	package = "com.zms.calendar"
 
 	# Revision
-	revision = "0.0.2"
+	revision = "0.0.5"
 
 	# Type
 	type = "ZMSRecordSet"
@@ -48,7 +48,8 @@ class calendar_items:
 			,"repetitive":0
 			,"type":"list"}
 
-		col_id = {"default":""
+		col_id = {"custom":1
+			,"default":""
 			,"id":"col_id"
 			,"keys":[]
 			,"mandatory":1
@@ -77,13 +78,23 @@ class calendar_items:
 			,"repetitive":0
 			,"type":"datetime"}
 
+		all_day = {"custom":1
+			,"default":"0"
+			,"id":"all_day"
+			,"keys":[]
+			,"mandatory":0
+			,"multilang":0
+			,"name":"Ganztags"
+			,"repetitive":0
+			,"type":"boolean"}
+
 		title = {"custom":1
 			,"default":""
 			,"id":"title"
 			,"keys":[]
 			,"mandatory":0
 			,"multilang":0
-			,"name":"Title"
+			,"name":"Titel"
 			,"repetitive":0
 			,"type":"string"}
 
@@ -93,9 +104,27 @@ class calendar_items:
 			,"keys":[]
 			,"mandatory":0
 			,"multilang":0
-			,"name":"Description"
+			,"name":"Info-Text"
 			,"repetitive":0
 			,"type":"text"}
+
+		location = {"default":""
+			,"id":"location"
+			,"keys":[]
+			,"mandatory":0
+			,"multilang":0
+			,"name":"Ort"
+			,"repetitive":0
+			,"type":"string"}
+
+		contact = {"default":""
+			,"id":"contact"
+			,"keys":[]
+			,"mandatory":0
+			,"multilang":0
+			,"name":"Ansprechpartner"
+			,"repetitive":0
+			,"type":"string"}
 
 		url = {"default":""
 			,"id":"url"

--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar_items/__init__.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar_items/__init__.py
@@ -1,0 +1,126 @@
+class calendar_items:
+	"""
+	python-representation of calendar_items
+	"""
+
+	# Access
+	access = {"delete_custom":""
+		,"delete_deny":[""
+			,""
+			,""
+			,""
+			,""
+			,""]
+		,"insert_custom":"{$}"
+		,"insert_deny":[""
+			,""
+			,""
+			,""
+			,""
+			,""]}
+
+	# Enabled
+	enabled = 0
+
+	# Id
+	id = "calendar_items"
+
+	# Name
+	name = "Calendar Items"
+
+	# Package
+	package = "com.zms.calendar"
+
+	# Revision
+	revision = "0.0.2"
+
+	# Type
+	type = "ZMSRecordSet"
+
+	# Attrs
+	class Attrs:
+		records = {"default":""
+			,"id":"records"
+			,"keys":[]
+			,"mandatory":1
+			,"multilang":0
+			,"name":"Datensätze"
+			,"repetitive":0
+			,"type":"list"}
+
+		col_id = {"default":""
+			,"id":"col_id"
+			,"keys":[]
+			,"mandatory":1
+			,"multilang":0
+			,"name":"COL_ID"
+			,"repetitive":0
+			,"type":"identifier"}
+
+		start_time = {"custom":1
+			,"default":""
+			,"id":"start_time"
+			,"keys":[]
+			,"mandatory":0
+			,"multilang":0
+			,"name":"Start Date/Time"
+			,"repetitive":0
+			,"type":"datetime"}
+
+		end_time = {"custom":1
+			,"default":""
+			,"id":"end_time"
+			,"keys":[]
+			,"mandatory":0
+			,"multilang":0
+			,"name":"End Date/Time"
+			,"repetitive":0
+			,"type":"datetime"}
+
+		title = {"custom":1
+			,"default":""
+			,"id":"title"
+			,"keys":[]
+			,"mandatory":0
+			,"multilang":0
+			,"name":"Title"
+			,"repetitive":0
+			,"type":"string"}
+
+		description = {"custom":1
+			,"default":""
+			,"id":"description"
+			,"keys":[]
+			,"mandatory":0
+			,"multilang":0
+			,"name":"Description"
+			,"repetitive":0
+			,"type":"text"}
+
+		url = {"default":""
+			,"id":"url"
+			,"keys":[]
+			,"mandatory":0
+			,"multilang":0
+			,"name":"Link"
+			,"repetitive":0
+			,"type":"url"}
+
+		icon_clazz = {"custom":"far fa-list-alt text-info"
+			,"default":""
+			,"id":"icon_clazz"
+			,"keys":[]
+			,"mandatory":0
+			,"multilang":0
+			,"name":"Icon-Class (CSS)"
+			,"repetitive":0
+			,"type":"constant"}
+
+		standard_html = {"default":""
+			,"id":"standard_html"
+			,"keys":[]
+			,"mandatory":0
+			,"multilang":0
+			,"name":"Template: Calendar Data"
+			,"repetitive":0
+			,"type":"zpt"}

--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar_items/standard_html.zpt
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar_items/standard_html.zpt
@@ -1,0 +1,9 @@
+<!-- ZMSCalendar_records.standard_html -->
+
+<tal:block tal:define="
+		zmscontext options/zmscontext">
+	<h2 tal:content="python:zmscontext.getTitlealt(request)">The title.alt</h2>
+	<p class="description" tal:content="python:'%i %s'%(len(zmscontext.attr(zmscontext.getMetaobj(zmscontext.meta_id)['attrs'][0]['id'])),zmscontext.getLangStr('ATTR_RECORDS',request['lang']))">#N records</p>
+</tal:block>
+
+<!-- /ZMSCalendar_records.standard_html -->

--- a/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar_items/standard_html.zpt
+++ b/Products/zms/conf/metaobj_manager/com.zms.calendar/calendar_items/standard_html.zpt
@@ -1,9 +1,52 @@
 <!-- ZMSCalendar_records.standard_html -->
 
 <tal:block tal:define="
-		zmscontext options/zmscontext">
-	<h2 tal:content="python:zmscontext.getTitlealt(request)">The title.alt</h2>
-	<p class="description" tal:content="python:'%i %s'%(len(zmscontext.attr(zmscontext.getMetaobj(zmscontext.meta_id)['attrs'][0]['id'])),zmscontext.getLangStr('ATTR_RECORDS',request['lang']))">#N records</p>
+	zmscontext options/zmscontext;
+	is_manage python:'/manage' in request.get('URL','');
+	records python:zmscontext.attr('records')">
+
+	<tal:block tal:condition="is_manage">
+		<h2 tal:content="python:zmscontext.getTitlealt(request)">The title.alt</h2>
+		<p class="description" tal:content="python:'%i %s'%(len(records),zmscontext.getLangStr('ATTR_RECORDS',request['lang']))">#N records</p>
+	</tal:block>
+
+	<table class="table table-striped" tal:condition="not:is_manage">
+		<thead>
+			<tr>
+				<th class="start_date">Datum</th>
+				<th class="start_time">Wann</th>
+				<th class="title">Was</th>
+				<th class="location">Wo</th>
+				<th class="contact">Wer</th>
+				<th class="description">Sonstiges</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr tal:repeat="event records" tal:attributes="id python:event['col_id']">
+				<tal:block tal:define="
+					start_date python:zmscontext.getLangFmtDate(event['start_time'],fmt_str='%d.%m.%Y');
+					start_time python:zmscontext.getLangFmtDate(event['start_time'],fmt_str='%H:%M');
+					start_time python:(start_time=='00:00' or event['all_day']==True) and 'Ganztags' or start_time;"
+					tal:condition="python: '2021' not in str(start_date)">
+					<td class="start_date" tal:content="start_date">Datum</td>
+					<td class="start_time" tal:content="start_time">Wann</td>
+					<td class="title" tal:content="structure python:event['title']">Was</td>
+					<td class="location" tal:content="structure python:event['location']">Wo</td>
+					<td class="contact" tal:content="structure python:event['contact']">Wer</td>
+					<td class="description">
+						<a href="#" target="_blank" title="Mehr Info..." 
+							tal:condition="python:event['url']" 
+							tal:attributes="href python:event['url']"
+							><i class="icon-link fas fa-link"></i>&nbsp;
+						</a>
+						<span tal:content="structure python:event['description']">Sonstiges</span>
+
+					</td>
+				</tal:block>
+			</tr>
+		</tbody>
+	</table>
+
 </tal:block>
 
 <!-- /ZMSCalendar_records.standard_html -->

--- a/docs/notebooks/snippets_02.ipynb
+++ b/docs/notebooks/snippets_02.ipynb
@@ -4,29 +4,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Calendar Rendering with Python calendar module"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Inspired by https://www.huiwenteo.com/normal/2018/07/24/django-calendar.html\n",
-    "import IPython\n",
+    "# Calendar Rendering with Python calendar module\n",
+    "_Inspired by https://www.huiwenteo.com/normal/2018/07/24/django-calendar.html_\n",
     "\n",
-    "from datetime import datetime, timedelta\n",
-    "import dateutil.parser as dparser\n",
-    "from calendar import HTMLCalendar\n",
-    "import locale\n",
-    "## IMPORTANT NOTE: first install your OS locale pack, e.g.\n",
-    "## sudo apt-get install language-pack-de-base"
+    "NOTES: \n",
+    "1. first install your OS locale pack, e.g. <br/> `sudo apt-get install language-pack-de-base`\n",
+    "2. as an alternative to Zope's DateTime you can use dateutil for date parsing <br/> `import dateutil.parser as dparser`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [
     {
@@ -35,23 +23,37 @@
        "'de_DE.UTF-8'"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 87,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "locale.setlocale(locale.LC_ALL, 'de_DE.UTF-8')\n",
-    "\n",
-    "# # BASIC TESTS\n",
-    "# htmlcal = calendar.HTMLCalendar(calendar.MONDAY)\n",
-    "# print(htmlcal.formatmonth(2022, 5))\n",
-    "# IPython.display.HTML(htmlcal.formatmonth(2022, 5))"
+    "import IPython\n",
+    "from datetime import datetime, timedelta\n",
+    "from DateTime import DateTime \n",
+    "from calendar import HTMLCalendar\n",
+    "import locale\n",
+    "locale.setlocale(locale.LC_ALL, 'de_DE.UTF-8')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### SOME TESTS SNIPPETS\n",
+    "# print(DateTime('2022-05-21 10:00').asdatetime() - DateTime('2022-05-18 15:45').asdatetime() )\n",
+    "# print(DateTime('18.05.2022 15:00').asdatetime().date())\n",
+    "# htmlcal = HTMLCalendar()\n",
+    "# print(htmlcal.formatmonth(2022, 5))\n",
+    "# IPython.display.HTML(htmlcal.formatmonth(2022, 5))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,30 +61,39 @@
     "\t{\n",
     "\t\t'start_time':'2022-05-18 15:00',\n",
     "\t\t'end_time':'2022-05-18 18:00',\n",
-    "\t\t'title':'Exam of Economics 1st Semester Part 1',\n",
+    "\t\t'title':'A. Exam of Economics 1st Semester Part 1',\n",
     "\t\t'description':'Its gonna be hard, but not impossible',\n",
     "\t},\n",
     "\t{\n",
     "\t\t'start_time':'2022-05-20 15:00',\n",
     "\t\t'end_time':'2022-05-20 18:00',\n",
-    "\t\t'title':'Exam of Economics 1st Semester Part 2',\n",
-    "\t\t'description':'Its gonna be hard and impossible',\n",
-    "\t}\n",
+    "\t\t'title':'B. Exam of Economics 1st Semester Part 2',\n",
+    "\t\t'description':'Its gonna be hard and almost impossible',\n",
+    "\t},\n",
+    "\t{\n",
+    "\t\t'start_time':'2022-05-20 19:00',\n",
+    "\t\t'end_time':'2022-05-20 21:00',\n",
+    "\t\t'title':'C. Exam of Economics 1st Semester Part 3',\n",
+    "\t\t'description':'Its gonna be hard and definitly impossible',\n",
+    "\t},\n",
     "]\n",
     "\n",
     "\n",
     "# HELPERS\n",
     "def parse_dt(s='2022-05-20 18:00'):\n",
-    "\treturn dparser.parse(s).date()\n",
+    "\treturn DateTime(s).asdatetime().date()\n",
     "\n",
     "def filter_events_by_date(events, year, month, day):\n",
     "\tthis_dt = datetime(year, month, day).date()\n",
-    "\treturn [e for e in events if parse_dt(e.get('start_time',''))==this_dt]"
+    "\treturn [e for e in events if parse_dt(e.get('start_time',''))==this_dt]\n",
+    "\n",
+    "def add_tags(tag,text):\n",
+    "\treturn '<%s title=\"%s\">%s</%s>'%(tag,text,text,tag)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 95,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,8 +102,6 @@
     "\t\tself.year = year\n",
     "\t\tself.month = month\n",
     "\t\tself.events = events\n",
-    "\t\tself.td_style='vertical-align:top;width:6rem;'\n",
-    "\t\tself.e_style='width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;'\n",
     "\t\tsuper(Calendar, self).__init__()\n",
     "\n",
     "\t# formats a day as a td\n",
@@ -107,14 +116,13 @@
     "\t\telse:\n",
     "\t\t\tevents_dt = filter_events_by_date(events, self.year, self.month, day)\n",
     "\t\t\tevents_titles = [e.get('title','') for e in events_dt]\n",
-    "\t\t\ts = '<br/>'.join(events_titles)\n",
-    "\t\t\t# return '<td class=\"%s\">%d</td>' % (self.cssclasses[weekday], day)\n",
-    "\t\t\treturn '<td style=\"%s\" class=\"%s\" title=\"%s\">%d <p style=\"%s\">%s</p></td>' % (self.td_style, self.cssclasses[weekday], s, day, self.e_style, s)"
+    "\t\t\ts = '\\n'.join([add_tags('p',e) for e in events_titles])\n",
+    "\t\t\treturn '<td class=\"%s\">%d %s</td>' % (self.cssclasses[weekday], day, s)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [
     {
@@ -123,31 +131,100 @@
        "<table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" class=\"month\">\n",
        "<tr><th colspan=\"7\" class=\"month\">Mai 2022</th></tr>\n",
        "<tr><th class=\"mon\">Mo</th><th class=\"tue\">Di</th><th class=\"wed\">Mi</th><th class=\"thu\">Do</th><th class=\"fri\">Fr</th><th class=\"sat\">Sa</th><th class=\"sun\">So</th></tr>\n",
-       "<tr><td class=\"noday\">&nbsp;</td><td class=\"noday\">&nbsp;</td><td class=\"noday\">&nbsp;</td><td class=\"noday\">&nbsp;</td><td class=\"noday\">&nbsp;</td><td class=\"noday\">&nbsp;</td><td style=\"vertical-align:top;width:6rem;\" class=\"sun\" title=\"\">1 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td></tr>\n",
-       "<tr><td style=\"vertical-align:top;width:6rem;\" class=\"mon\" title=\"\">2 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"tue\" title=\"\">3 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"wed\" title=\"\">4 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"thu\" title=\"\">5 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"fri\" title=\"\">6 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"sat\" title=\"\">7 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"sun\" title=\"\">8 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td></tr>\n",
-       "<tr><td style=\"vertical-align:top;width:6rem;\" class=\"mon\" title=\"\">9 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"tue\" title=\"\">10 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"wed\" title=\"\">11 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"thu\" title=\"\">12 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"fri\" title=\"\">13 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"sat\" title=\"\">14 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"sun\" title=\"\">15 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td></tr>\n",
-       "<tr><td style=\"vertical-align:top;width:6rem;\" class=\"mon\" title=\"\">16 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"tue\" title=\"\">17 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"wed\" title=\"Exam of Economics 1st Semester Part 1\">18 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\">Exam of Economics 1st Semester Part 1</p></td><td style=\"vertical-align:top;width:6rem;\" class=\"thu\" title=\"\">19 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"fri\" title=\"Exam of Economics 1st Semester Part 2\">20 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\">Exam of Economics 1st Semester Part 2</p></td><td style=\"vertical-align:top;width:6rem;\" class=\"sat\" title=\"\">21 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"sun\" title=\"\">22 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td></tr>\n",
-       "<tr><td style=\"vertical-align:top;width:6rem;\" class=\"mon\" title=\"\">23 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"tue\" title=\"\">24 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"wed\" title=\"\">25 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"thu\" title=\"\">26 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"fri\" title=\"\">27 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"sat\" title=\"\">28 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"sun\" title=\"\">29 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td></tr>\n",
-       "<tr><td style=\"vertical-align:top;width:6rem;\" class=\"mon\" title=\"\">30 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td style=\"vertical-align:top;width:6rem;\" class=\"tue\" title=\"\">31 <p style=\"width:6rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\"></p></td><td class=\"noday\">&nbsp;</td><td class=\"noday\">&nbsp;</td><td class=\"noday\">&nbsp;</td><td class=\"noday\">&nbsp;</td><td class=\"noday\">&nbsp;</td></tr>\n",
-       "</table>\n"
+       "<tr><td class=\"noday\">&nbsp;</td><td class=\"noday\">&nbsp;</td><td class=\"noday\">&nbsp;</td><td class=\"noday\">&nbsp;</td><td class=\"noday\">&nbsp;</td><td class=\"noday\">&nbsp;</td><td class=\"sun\">1 </td></tr>\n",
+       "<tr><td class=\"mon\">2 </td><td class=\"tue\">3 </td><td class=\"wed\">4 </td><td class=\"thu\">5 </td><td class=\"fri\">6 </td><td class=\"sat\">7 </td><td class=\"sun\">8 </td></tr>\n",
+       "<tr><td class=\"mon\">9 </td><td class=\"tue\">10 </td><td class=\"wed\">11 </td><td class=\"thu\">12 </td><td class=\"fri\">13 </td><td class=\"sat\">14 </td><td class=\"sun\">15 </td></tr>\n",
+       "<tr><td class=\"mon\">16 </td><td class=\"tue\">17 </td><td class=\"wed\">18 <p title=\"A. Exam of Economics 1st Semester Part 1\">A. Exam of Economics 1st Semester Part 1</p></td><td class=\"thu\">19 </td><td class=\"fri\">20 <p title=\"B. Exam of Economics 1st Semester Part 2\">B. Exam of Economics 1st Semester Part 2</p>\n",
+       "<p title=\"C. Exam of Economics 1st Semester Part 3\">C. Exam of Economics 1st Semester Part 3</p></td><td class=\"sat\">21 </td><td class=\"sun\">22 </td></tr>\n",
+       "<tr><td class=\"mon\">23 </td><td class=\"tue\">24 </td><td class=\"wed\">25 </td><td class=\"thu\">26 </td><td class=\"fri\">27 </td><td class=\"sat\">28 </td><td class=\"sun\">29 </td></tr>\n",
+       "<tr><td class=\"mon\">30 </td><td class=\"tue\">31 </td><td class=\"noday\">&nbsp;</td><td class=\"noday\">&nbsp;</td><td class=\"noday\">&nbsp;</td><td class=\"noday\">&nbsp;</td><td class=\"noday\">&nbsp;</td></tr>\n",
+       "</table>\n",
+       "\n",
+       "\t<style>\n",
+       "\t\ttable.month th,\n",
+       "\t\ttable.month td {\n",
+       "\t\t\tborder:1px solid silver !important;\n",
+       "\t\t\tvertical-align:top;\n",
+       "\t\t\twidth:6rem;\n",
+       "\t\t}\n",
+       "\t\t.month td p {\n",
+       "\t\t\twidth:6rem;\n",
+       "\t\t\twhite-space:nowrap;\n",
+       "\t\t\toverflow:hidden;\n",
+       "\t\t\ttext-overflow:ellipsis;\n",
+       "\t\t\tcursor:pointer;\n",
+       "\t\t\tline-height:1.25:\n",
+       "\t\t\tmargin:0 !important;\n",
+       "\t\t\tpadding:0 !important;\n",
+       "\t\t\tborder-bottom:1px solid transparent;\n",
+       "\t\t}\n",
+       "\t\t.month td p:hover {\n",
+       "\t\t\tborder-color:violet;\n",
+       "\t\t}\n",
+       "\t\t.month td p:hover:before {\n",
+       "\t\t\tcontent:attr(title);\n",
+       "\t\t\tposition:absolute;\n",
+       "\t\t\tdisplay:block;\n",
+       "\t\t\tbackground:violet;\n",
+       "\t\t\tcolor:white;\n",
+       "\t\t\tpadding:.35em .75em;\n",
+       "\t\t\ttransform: translateY(-2.5em);\n",
+       "\t\t\tbox-shadow:.35em .35em 2em #0003;\n",
+       "\t\t}\n",
+       "\t</style>\n"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 96,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "css = '''\n",
+    "\t<style>\n",
+    "\t\ttable.month th,\n",
+    "\t\ttable.month td {\n",
+    "\t\t\tborder:1px solid silver !important;\n",
+    "\t\t\tvertical-align:top;\n",
+    "\t\t\twidth:6rem;\n",
+    "\t\t}\n",
+    "\t\t.month td p {\n",
+    "\t\t\twidth:6rem;\n",
+    "\t\t\twhite-space:nowrap;\n",
+    "\t\t\toverflow:hidden;\n",
+    "\t\t\ttext-overflow:ellipsis;\n",
+    "\t\t\tcursor:pointer;\n",
+    "\t\t\tline-height:1.25:\n",
+    "\t\t\tmargin:0 !important;\n",
+    "\t\t\tpadding:0 !important;\n",
+    "\t\t\tborder-bottom:1px solid transparent;\n",
+    "\t\t}\n",
+    "\t\t.month td p:hover {\n",
+    "\t\t\tborder-color:violet;\n",
+    "\t\t}\n",
+    "\t\t.month td p:hover:before {\n",
+    "\t\t\tcontent:attr(title);\n",
+    "\t\t\tposition:absolute;\n",
+    "\t\t\tdisplay:block;\n",
+    "\t\t\tbackground:violet;\n",
+    "\t\t\tcolor:white;\n",
+    "\t\t\tpadding:.35em .75em;\n",
+    "\t\t\ttransform: translateY(-2.5em);\n",
+    "\t\t\tbox-shadow:.35em .35em 2em #0003;\n",
+    "\t\t}\n",
+    "\t</style>\n",
+    "'''\n",
+    "\n",
     "htmlcal = Calendar(year=2022,month=5,events=events)\n",
-    "IPython.display.HTML(htmlcal.formatmonth(htmlcal.year, htmlcal.month))\n"
+    "IPython.display.HTML(htmlcal.formatmonth(htmlcal.year, htmlcal.month) +  css)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 97,
    "metadata": {},
    "outputs": [
     {
@@ -155,18 +232,22 @@
       "text/plain": [
        "[{'start_time': '2022-05-20 15:00',\n",
        "  'end_time': '2022-05-20 18:00',\n",
-       "  'title': 'Exam of Economics 1st Semester Part 2',\n",
-       "  'description': 'Its gonna be hard and impossible'}]"
+       "  'title': 'B. Exam of Economics 1st Semester Part 2',\n",
+       "  'description': 'Its gonna be hard and almost impossible'},\n",
+       " {'start_time': '2022-05-20 19:00',\n",
+       "  'end_time': '2022-05-20 21:00',\n",
+       "  'title': 'C. Exam of Economics 1st Semester Part 3',\n",
+       "  'description': 'Its gonna be hard and definitly impossible'}]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 97,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "## TEST EVENT FILTER\n",
-    "filter_events_by_date(events, 2022, 5, 20)\n"
+    "filter_events_by_date(events, 2022, 5, 20)"
    ]
   }
  ],


### PR DESCRIPTION
Using python standrd lib calendar for generating a table grid calender als ZMS content object primarily allowing to edit events in a simple ZMS datatable.
_References:_
1. https://docs.python.org/2.7/library/calendar.html#calendar.HTMLCalendar
2. https://docs.python.org/3.8/library/calendar.html#calendar.HTMLCalendar

Work in progress (V0.0.1)
![com_zms_calendar](https://user-images.githubusercontent.com/29705216/169152655-c8105bda-1026-485f-808f-a47685ffbc8a.gif)

IMPORTANT NOTE: first install your OS locale pack, e.g.
`sudo apt-get install language-pack-de-base`
