### PR TITLE
Show custom version from env/git in system info only

### DIFF
--- a/Products/zms/zms.py
+++ b/Products/zms/zms.py
@@ -368,14 +368,14 @@ class ZMS(
     #
     #  Get version.
     # --------------------------------------------------------------------------
-    def zms_version(self):
+    def zms_version(self, custom=False):
       file = open(_fileutil.getOSPath(package_home(globals())+'/version.txt'),'r')
       rtn = file.read()
       file.close()
       zms_custom_version = os.environ.get('ZMS_CUSTOM_VERSION', '')
-      if zms_custom_version != '':
+      if custom and zms_custom_version != '':
         rtn += ' ({})'.format(zms_custom_version)
-      if os.path.exists(_fileutil.getOSPath(package_home(globals())+'/../../.git/FETCH_HEAD')):
+      if custom and os.path.exists(_fileutil.getOSPath(package_home(globals())+'/../../.git/FETCH_HEAD')):
         file = open(_fileutil.getOSPath(package_home(globals())+'/../../.git/FETCH_HEAD'),'r')
         FETCH_HEAD = file.read()
         file.close()

--- a/Products/zms/zpt/ZMS/manage_customize.zpt
+++ b/Products/zms/zpt/ZMS/manage_customize.zpt
@@ -323,7 +323,7 @@
 				<div class="form-group row">
 					<label class="col-sm-2 control-label">ZMS Version</label>
 					<div class="col-sm-10">
-						<samp tal:content="structure python:here.zms_version()">zms_version</samp>
+						<samp tal:content="structure python:here.zms_version(custom=True)">zms_version</samp>
 					</div>
 				</div><!-- .form-group -->
 				<div class="form-group row">


### PR DESCRIPTION
This avoids unwanted custom zms_version infos in xml exports.