### PR TITLE
added splitscreen preview

### DIFF
--- a/Products/zms/plugins/www/zmi.core.js
+++ b/Products/zms/plugins/www/zmi.core.js
@@ -117,7 +117,11 @@ $ZMI.registerReady(function(){
 				}
 				else {
 					href += '?lang='+lang +'&preview=contentEditable';
-					window.top.location.href = href;
+					if (window.top.frames[0].name=='editor') {
+						window.top.frames[0].location.href = href
+					} else {
+						window.top.location.href = href;
+					}
 				}
 			})
 		.attr( "title", "Click to edit!");

--- a/Products/zms/zmsobject.py
+++ b/Products/zms/zmsobject.py
@@ -118,6 +118,7 @@ class ZMSObject(ZMSItem.ZMSItem,
     # ----------
     f_recordset_grid = PageTemplateFile('zpt/object/f_recordset_grid', globals()) # ZMI RecordSet::Grid
     preview_html = PageTemplateFile('zpt/object/preview', globals())
+    preview_splitscreen = PageTemplateFile('zpt/object/preview_splitscreen', globals())
     preview_top_html = PageTemplateFile('zpt/object/preview_top', globals())
     f_api_html = PageTemplateFile('zpt/object/f_api', globals())
     f_api_top_html = PageTemplateFile('zpt/object/f_api_top', globals())

--- a/Products/zms/zpt/common/zmi_body_header.zpt
+++ b/Products/zms/zpt/common/zmi_body_header.zpt
@@ -120,9 +120,15 @@
 			</li><!-- .dropdown -->
 			<tal:block tal:condition="python: here.getTrashcan().getId()!=here.getId()">
 				<li class="view_preview">
-					<a target="_blank" tal:attributes="href python:'preview_html?lang=%s&preview=preview'%request['lang']">
+					<a target="_blank" 
+						tal:attributes="href python:'preview_html?lang=%s&preview=preview'%request['lang']">
 						<i class="far fa-eye"></i>
-						<span tal:content="python:here.getZMILangStr('TAB_PREVIEW')">preview</span></a>
+						<span tal:content="python:here.getZMILangStr('TAB_PREVIEW')">preview</span>
+					</a>
+					<a target="_top" title="Show Preview as Splitted Screen"
+						tal:attributes="href python:'preview_splitscreen?lang=%s&preview=preview'%request['lang']">
+						<i class="fas fa-columns" style="display:unset;margin: 0 0 0 1.5em;"></i>
+					</a>
 				</li>
 				<li class="view_live"
 					tal:define="protocol python:here.getConfProperty( 'ASP.protocol', request.get('SERVER_URL').split('://')[0] );

--- a/Products/zms/zpt/object/preview_splitscreen.zpt
+++ b/Products/zms/zpt/object/preview_splitscreen.zpt
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" "http://www.w3.org/TR/html4/frameset.dtd">
+<html lang="en" tal:define="standard modules/Products.zms/standard">
+<head tal:replace="structure python:here.zmi_html_head(here,request)">zmi_html_head</head>
+<frameset cols="42%,*" border="1" frameborder="0" framespacing="0">
+	<frame name="editor" marginheight="1" tal:attributes="src python:'manage_main?lang=%s'%request['lang']">
+	<frameset name="preview" rows="46,*" border="0" frameborder="0" framespacing="0">
+		<frame name="navigate" marginheight="1" scrolling="no" noresize="noresize" tal:attributes="src python:'preview_top_html?lang=%s'%request['lang']">
+		<frame name="partner" marginheight="1" tal:attributes="src python:here.getHref2IndexHtml(request)">
+	</frameset>
+</frameset>
+	<tal:block tal:content="structure python:here.zmi_html_foot(here,request)">zmi_html_foot</tal:block>
+</html>


### PR DESCRIPTION
This is a first rough UX prototype showing the page preview as a splitscreen  for evaluation.  Of course this presentation implies certain disadvantages (eg. window re/size, visual interference etc.) but there a some striking advantages, too:
1. no growing bunch of windows 
2. intuitive 3rd view navigation conncted to atomic zmi editor
3. better visual control for typographic details

Any ideas/code-proposals/comments?

![splitscreen](https://user-images.githubusercontent.com/29705216/170364143-13c4ba32-46ed-4090-8fa6-3d5c0f77523b.gif)

 