### PR TITLE
sort_list(): fixed sorting of struct_time fields

### DIFF
--- a/Products/zms/_globals.py
+++ b/Products/zms/_globals.py
@@ -109,6 +109,8 @@ def sort_item( i):
     i = time.strftime('%Y%m%d%H%M%S',i)
   elif isinstance(i, float):
     pass
+  elif i is None:
+    i = 0
   elif not isinstance(i, int):
       i = standard.pystr(i)
       mapping = umlaut_map

--- a/Products/zms/_globals.py
+++ b/Products/zms/_globals.py
@@ -23,6 +23,7 @@
 from Products.PageTemplates.Expressions import SecureModuleImporter
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 import sys
+import time
 from Products.zms import standard
 
 # Umlauts
@@ -104,7 +105,9 @@ umlaut_map = {
         u'Я': 'JA',}
 
 def sort_item( i):
-  if not isinstance(i, int):
+  if isinstance(i, time.struct_time):
+    i = time.strftime('%Y%m%d%H%M%S',i)
+  elif not isinstance(i, int):
       i = standard.pystr(i)
       mapping = umlaut_map
       for key in mapping:

--- a/Products/zms/_globals.py
+++ b/Products/zms/_globals.py
@@ -109,7 +109,7 @@ def sort_item( i):
     i = time.strftime('%Y%m%d%H%M%S',i)
   elif isinstance(i, float):
     pass
-  elif i is None:
+  elif i is None or i == '':
     i = 0
   elif not isinstance(i, int):
       i = standard.pystr(i)

--- a/Products/zms/_globals.py
+++ b/Products/zms/_globals.py
@@ -107,6 +107,8 @@ umlaut_map = {
 def sort_item( i):
   if isinstance(i, time.struct_time):
     i = time.strftime('%Y%m%d%H%M%S',i)
+  elif isinstance(i, float):
+    pass
   elif not isinstance(i, int):
       i = standard.pystr(i)
       mapping = umlaut_map

--- a/Products/zms/standard.py
+++ b/Products/zms/standard.py
@@ -1724,7 +1724,11 @@ def sort_list(l, qorder=None, qorderdir='asc', ignorecase=1):
     tl = [(_globals.sort_item(x[qorder]), x) for x in l]
   if ignorecase and len(tl) > 0 and isinstance(tl[0][0], str):
     tl = [(str(x[0]).upper(), x[1]) for x in tl]
-  tl = sorted(tl,key=lambda x:x[0])
+  try:
+    tl = sorted(tl,key=lambda x:x[0])
+  except:
+    writeError(context, '[sort_list]: mixed datatypes normalized to strings')
+    tl = sorted(tl,key=lambda x:str(x[0]))
   tl = [x[1] for x in tl]
   if qorderdir == 'desc':
     tl.reverse()

--- a/docs/notebooks/snippets_01.ipynb
+++ b/docs/notebooks/snippets_01.ipynb
@@ -187,7 +187,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "l = ['X',2,0,'A',1.101,100,'',1.3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -197,56 +206,77 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m/tmp/ipykernel_1679/3375452855.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0ml\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m'X'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m1.101\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m''\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m1.3\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0ml\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msorted\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ml\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ml\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/tmp/ipykernel_1679/473051605.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Comparison of mixed datatyles will result in a type error\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mls\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msorted\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ml\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mls\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;31mTypeError\u001b[0m: '<' not supported between instances of 'int' and 'str'"
      ]
     }
    ],
    "source": [
     "# Comparison of mixed datatyles will result in a type error\n",
-    "l = ['X',2,0,1.101,'',1.3]\n",
-    "l = sorted(l)\n",
-    "print(l)"
+    "ls = sorted(l)\n",
+    "print(ls)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['', '0', '1.101', '1.3', '2', 'X']\n"
+      "['', '0', '1.101', '1.3', '100', '2', 'A', 'X']\n"
      ]
     }
    ],
    "source": [
     "# Normalize list items to string type\n",
-    "l = ['X',2,0,1.101,'',1.3]\n",
-    "l = sorted([str(x) for x in l])\n",
-    "print(l)"
+    "ls = sorted([str(x) for x in l])\n",
+    "print(ls)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[1.101, 1.3, 2, 0, 'X', '']\n"
+      "[1.101, 1.3, 2, 0, 100, 'X', 'A', '']\n"
      ]
     }
    ],
    "source": [
+    "# Sorting by datatype\n",
     "# Ref: https://stackoverflow.com/questions/55503240/sorting-mixed-variable-types-allowed-in-python-2-but-not-in-python-3\n",
-    "l = ['X',2,0,1.101,'',1.3]\n",
-    "l = sorted(l,key=lambda x:type(x).__name__)\n",
-    "print(l)"
+    "ls = sorted(l,key=lambda x:type(x).__name__)\n",
+    "print(ls)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "'<' not supported between instances of 'str' and 'NoneType'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m/tmp/ipykernel_1679/666002045.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0ml2\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m'0'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m'X'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m''\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mls\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msorted\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ml2\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mls\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: '<' not supported between instances of 'str' and 'NoneType'"
+     ]
+    }
+   ],
+   "source": [
+    "l2 = [None,'0',0,'X','']\n",
+    "ls = sorted(l2)\n",
+    "print(ls)"
    ]
   }
  ],

--- a/docs/notebooks/snippets_01.ipynb
+++ b/docs/notebooks/snippets_01.ipynb
@@ -176,6 +176,78 @@
    "source": [
     "encoder.dumps(user_dict)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Python 3: Sorting (PR#67)\n",
+    "With ZMS3/Py2 mixed type sorting was not a problem. Python 3 is nore sensitive to datatypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "'<' not supported between instances of 'int' and 'str'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m/tmp/ipykernel_1679/3375452855.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0ml\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m'X'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m1.101\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m''\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m1.3\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0ml\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msorted\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ml\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ml\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: '<' not supported between instances of 'int' and 'str'"
+     ]
+    }
+   ],
+   "source": [
+    "# Comparison of mixed datatyles will result in a type error\n",
+    "l = ['X',2,0,1.101,'',1.3]\n",
+    "l = sorted(l)\n",
+    "print(l)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['', '0', '1.101', '1.3', '2', 'X']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Normalize list items to string type\n",
+    "l = ['X',2,0,1.101,'',1.3]\n",
+    "l = sorted([str(x) for x in l])\n",
+    "print(l)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1.101, 1.3, 2, 0, 'X', '']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Ref: https://stackoverflow.com/questions/55503240/sorting-mixed-variable-types-allowed-in-python-2-but-not-in-python-3\n",
+    "l = ['X',2,0,1.101,'',1.3]\n",
+    "l = sorted(l,key=lambda x:type(x).__name__)\n",
+    "print(l)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
hi @zmsdev,
sorting a data-grid by struct_time fields may result in a incorrect order:

![struct_time_sorting](https://user-images.githubusercontent.com/29705216/173563660-a3b7022c-53bc-4d3a-ade8-38f7afbb045e.gif)


my code proposal addresses the struct_time type and transforms it into a sortable number:

Change: https://github.com/zms-publishing/ZMS/compare/main...fix_structime_sorting#

https://github.com/zms-publishing/ZMS/blob/324b7160e38fdc1a5653d04a71b64509bbb40d47/Products/zms/_globals.py#L107-L116

Background: the _sort_list_()-function uses the _sort_item_()-function to normalise the sortable values
