### PR TITLE
zmi: added titleimage as data attr

### DIFF
--- a/Products/zms/plugins/www/zmi.core.css
+++ b/Products/zms/plugins/www/zmi.core.css
@@ -621,6 +621,7 @@ body.zmi ul.zmi-container > .zmi-item .right i.titleimage-preview::after {
 	background-color:#f5f5f5;
 	box-shadow: none;
 }
+body.zmi ul.zmi-container > .zmi-item .right video,
 body.zmi ul.zmi-container > .zmi-item .right i.titleimage-preview:hover::after {
 	content:"";
 	width:20vw;
@@ -641,7 +642,6 @@ body.zmi ul.zmi-container > .zmi-item .right i.titleimage-preview:hover::after {
 	box-shadow: 5px 5px 20px #c0c0c094;
 	transition: opacity .75s, height .5s, box-shadow 1s, background-color 1s  ease; 
 }
-
 @media (max-width: 767px) {
 	body.zmi header.navbar {
 		max-width: 100%;

--- a/Products/zms/zpt/ZMSContainerObject/zmi_manage_main_change.zpt
+++ b/Products/zms/zpt/ZMSContainerObject/zmi_manage_main_change.zpt
@@ -4,7 +4,9 @@
 <a class="object_has_titleimage" title="Title Image Preview: Click to Edit" 
 	tal:condition="python:here.attr('titleimage')" 
 	tal:attributes="href python:'%s/manage_properties?lang=%s'%(here.absolute_url(),request['manage_lang'])"
-	><i class="zmi-state far fa-image text-primary titleimage-preview" tal:attributes="style python:'--titleimage_url:url(%s)'%(here.attr('titleimage').getHref(request))"></i>
+	><i class="zmi-state far fa-image text-primary titleimage-preview" 
+		tal:define="titleimage_url python:here.attr('titleimage').getHref(request)"
+		tal:attributes="style python:'--titleimage_url:url(%s)'%(titleimage_url); data-titleimage_url titleimage_url;"></i>
 </a>
 
 <tal:block tal:define="standard modules/Products.zms/standard;


### PR DESCRIPTION
Showing the _titleimage_ by backgroud-image/url does not work with movies as a pure CSS solution. Even with static pictures shown as `background-image` there are some problems due to browser limitations (Ref: https://stackoverflow.com/questions/26967890/css-set-background-image-by-data-image-attr): image-URLs needs to be transformend into a full string variable including the "url()" function nesting. If using movie pure css will not work and JS is needed; to simplify the access to the media url now it is added as a `data-attribute`. 
The zmi core CSS will render the video-tag in the right column similar to the image preview.
But an addiitional custom JS function is needed to show video preview on `mouseover`. It may look like this:
 
```javascript
	$('.titleimage-preview').each( function() {
	    var media_url = $(this).data('titleimage_url');
		if ( media_url.search('.mp4') > -1 ) {
			var this_container = $(this).closest('.zmi-manage-main-change');
			var media_html = '<video autoplay="" autostart="" loop="" playsinline="" muted="" preload="auto"><source src="' +  media_url + '"></video>';
			$(this)
				.on('mouseout',function() {
					$('video',this_container).remove();
				})
				.on('mouseover',function() {
					if ($('video',this_container).length==0 ) {
						this_container.append(media_html)
					}
				})
			$(this).removeClass('titleimage-preview')
		}
	}) 

```
![video_hero_2022_img](https://user-images.githubusercontent.com/29705216/176886029-38b09419-6aff-4c24-a250-abf734f36494.gif)

