### PR TITLE
repomanager: ignore leading/trailing whitespace for diff

### DIFF
--- a/Products/zms/ZMSRepositoryManager.py
+++ b/Products/zms/ZMSRepositoryManager.py
@@ -232,10 +232,12 @@ class ZMSRepositoryManager(
           except:
             pass
         # If text then normalize Windows CR+LF line break to Unix LF
+        # and ignore leading/trailing whitespace since Zope removes 
+        # and github adds them
         if isinstance(l.get('data'), str):
-          l['data'] = l['data'].replace('\r','')
+          l['data'] = l['data'].replace('\r','').strip()
         if isinstance(r.get('data'), str):
-          r['data'] = r['data'].replace('\r','')
+          r['data'] = r['data'].replace('\r','').strip()
         # Only if text is not equal add to diff list
         if l.get('data') != r.get('data'):
           data = l_data or r_data


### PR DESCRIPTION
Hello @zmsdev ,
syncing with repomanager may end up in cycles of im/export because Zope removes trailing whitespace while some editors may add a final line-break. To avoid these false positive diffs I suggest to strip() the code before diffing.
The effect canbe seen on the following pics: the final line-break will not taken into account anymore.

1. ![EOL_0](https://user-images.githubusercontent.com/29705216/179298559-ffb4dac4-ce47-4a42-9e4c-90cb2c8a8e75.gif)
2. ![EOL_1](https://user-images.githubusercontent.com/29705216/179298568-da96fadc-d357-429b-a99d-d71679d07367.gif)
3. ![EOL_2](https://user-images.githubusercontent.com/29705216/179298577-5dc76969-18a6-4578-923e-553b7d8f0971.gif)

