### PR TITLE
Using meta-id for action list based insertations

### DIFF
--- a/Products/zms/_zmi_actions_util.py
+++ b/Products/zms/_zmi_actions_util.py
@@ -207,7 +207,7 @@ def zmi_insert_actions(container, context, objAttr, objChildren, objPath=''):
           value = 'manage_addZMSCustomDefault'
         else:
           value = 'manage_addProduct/zms/manage_addzmscustomform'
-        action = (container.display_type(REQUEST, meta_id), value, container.display_icon(REQUEST, meta_id))
+        action = (container.display_type(REQUEST, meta_id), value, container.display_icon(REQUEST, meta_id), meta_id)
         if action not in actions:
           actions.append( action)
   

--- a/Products/zms/manage_addzmscustomform.zpt
+++ b/Products/zms/manage_addzmscustomform.zpt
@@ -1,5 +1,5 @@
 <tal:block tal:define="global
-		meta_id python:here.getMetaobjId(request['custom']);
+		meta_id python:request.get('meta_id') or here.getMetaobjId(request['custom']);
 		metaObj python:here.getMetaobj(meta_id);
 		metaObjIds python:here.getMetaobjIds();
 		dummy0 python:request.set('ZMS_INSERT',meta_id);

--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -1559,7 +1559,12 @@ ZMIActionList.prototype.over = function(el, e, cb) {
 					opticon = $ZMI.icon(opticon);
 				}
 				var html = '';
-				html += '<a class="dropdown-item" title="'+opttitle+'" href="javascript:$ZMI.actionList.exec($(\'li.zmi-item' + (id==''?':first':'#zmi_item_'+id) + '\'),\'' + optlabel + '\',\'' + optvalue + '\')">';
+				var optid = '';
+				if (optvalue.toLowerCase().indexOf('manage_addproduct/')==0) {
+					// opttitle is meta_id in case of insertable content objects
+					optid = opttitle;
+				}
+				html += '<a class="dropdown-item" title="'+opttitle+'" href="javascript:$ZMI.actionList.exec($(\'li.zmi-item' + (id==''?':first':'#zmi_item_'+id) + '\'),\'' + optlabel + '\',\'' + optvalue + '\',\'' + optid + '\')">';
 				html += opticon+' <span>'+optlabel+'</span>';
 				html += '</a>';
 				$ul.append(html);
@@ -1602,7 +1607,7 @@ ZMIActionList.prototype.out = function(el) {
 /**
  *  Execute action.
  */
-ZMIActionList.prototype.exec = function(sender, label, target) {
+ZMIActionList.prototype.exec = function(sender, label, target, meta_id='') {
 	var id_prefix = this.getContextId(sender);
 	if (typeof id_prefix != 'undefined' && id_prefix != '') {
 		id_prefix = id_prefix.replace(/(\d*?)$/gi,'');
@@ -1628,7 +1633,12 @@ ZMIActionList.prototype.exec = function(sender, label, target) {
 			}
 		}
 		data['id_prefix'] = id_prefix;
-		var title = '<i class="fas fa-plus-sign"></i> '+getZMILangStr('BTN_INSERT')+': '+label;
+		var title = '<i class="fas fa-plus-sign"></i> ' + getZMILangStr('BTN_INSERT') + ':&nbsp;' + label;
+		// debugger;
+		if (meta_id!='') { 
+			data['meta_id'] = meta_id;
+			console.log('ZMIActionList.exec meta_id = ' + meta_id )
+		}
 		$('<li id="manage_addProduct" class="zmi-item zmi-highlighted"><div class="center">'+title+'</div></li>').insertAfter($el.parents(".zmi-item"));
 		// Show add-dialog.
 		$ZMI.iframe(target,data,{

--- a/Products/zms/zpt/ZMSObject/input_fields.zpt
+++ b/Products/zms/zpt/ZMSObject/input_fields.zpt
@@ -50,7 +50,7 @@
 									<tal:block tal:content="structure python:action[0][5:-5].strip()">the title</tal:block>
 								</div>
 								<tal:block tal:condition="not:python:action[0].startswith('-----') and action[0].endswith('-----')">
-									<a class="dropdown-item" tal:attributes="href python:'javascript:$ZMI.actionList.exec($(\'.attr_last_modified\'),\'%s\',\'%s\')'%(action[0],action[1])">
+									<a class="dropdown-item" tal:attributes="href python:'javascript:$ZMI.actionList.exec($(\'.attr_last_modified\'),\'%s\',\'%s\',\'\')'%(action[0],action[1])">
 										<i tal:condition="python:len(action)>=3 and action[2] is not None" tal:attributes="class python:action[2]"></i>
 										<span tal:content="structure python:action[0]">the title</span>
 									</a>


### PR DESCRIPTION
Hello @zmsdev and others,
we observed when using identical conten class labels or language strings (TYPE_*) for overwrite the class label an unexpected content class may be inserted. 
The reason is that the meta_id is computed by the label-text and this may be ambiguous:

![actionlist_json1](https://user-images.githubusercontent.com/29705216/180303058-207beffd-37c9-47da-833f-6a25f08d422a.gif)

My code proposal is adding the meta_id as a 4th element to the json stream used for rendering the action-lists / menus. This has some consequences for the processing in general because now the additional parameter needs to be considered, but only in case of content insertations. So there are some intereferences with "ZMS actions" or workflow steps , because here the 4th json element is used just as a title tooltip. 

![actionlist_json2](https://user-images.githubusercontent.com/29705216/180304505-c553eb9b-6158-4cf2-959c-50d42f3089df.gif)

![actionlist_json3](https://user-images.githubusercontent.com/29705216/180304561-9a207840-f9cc-4572-a89b-dc49d8468aea.gif)

We should discuss the objections. Maybe there other ideas to solve the ambiguity problem of labelling?