### PR TITLE
ZMSFormulator: avoid XML parse error on lang dict

### DIFF
--- a/Products/zms/conf/metaobj_manager/zms.formulator/ZMSFormulator/__init__.py
+++ b/Products/zms/conf/metaobj_manager/zms.formulator/ZMSFormulator/__init__.py
@@ -28,7 +28,7 @@ class ZMSFormulator:
 	package = "zms.formulator"
 
 	# Revision
-	revision = "5.0.0"
+	revision = "5.0.1"
 
 	# Type
 	type = "ZMSDocument"

--- a/Products/zms/conf/metaobj_manager/zms.formulator/ZMSFormulator/javscriptandstyle.zpt
+++ b/Products/zms/conf/metaobj_manager/zms.formulator/ZMSFormulator/javscriptandstyle.zpt
@@ -1,6 +1,7 @@
 <script type="text/javascript" charset="UTF-8" src="/++resource++zmi/ace.ajax.org/ace.js"></script>
 <tal:block tal:condition="python:request.get('ZMS_INSERT',None) is None">
 <script type="text/javascript">
+//<!--
 $ZMI.registerReady(function() {
   $('#BTN_Refresh').click(function() {
     $.ajax({
@@ -115,6 +116,7 @@ $ZMI.registerReady(function() {
     text3.val(edit3.getSession().getValue()).change();
   });
 });
+//-->
 </script>
 </tal:block>
 <style>

--- a/Products/zms/conf/metaobj_manager/zms.formulator/ZMSFormulatorItem/__init__.py
+++ b/Products/zms/conf/metaobj_manager/zms.formulator/ZMSFormulatorItem/__init__.py
@@ -28,7 +28,7 @@ class ZMSFormulatorItem:
 	package = "zms.formulator"
 
 	# Revision
-	revision = "5.0.0"
+	revision = "5.0.1"
 
 	# Type
 	type = "ZMSObject"

--- a/Products/zms/conf/metaobj_manager/zms.formulator/ZMSFormulatorItem/interface.dtml
+++ b/Products/zms/conf/metaobj_manager/zms.formulator/ZMSFormulatorItem/interface.dtml
@@ -1,5 +1,6 @@
 <script type="text/javascript" charset="UTF-8" src="/++resource++zmi/ace.ajax.org/ace.js"></script>
 <script type="text/javascript">
+//<!-- 
 $ZMI.registerReady(function() {
   $('#tabProperties .accordion-inner').attr('class','accordion-inner ' + $('#tr_type :selected').text());
   $('#tr_replyToField').hide();
@@ -94,6 +95,7 @@ $ZMI.registerReady(function() {
   text1.val(edit1.getSession().getValue()).change();
   });
 });
+//-->
 </script>
 <style>
 .ACE_Editor {

--- a/Products/zms/conf/metaobj_manager/zms.formulator/__init__.py
+++ b/Products/zms/conf/metaobj_manager/zms.formulator/__init__.py
@@ -22,7 +22,7 @@ class zms_formulator:
 	package = ""
 
 	# Revision
-	revision = "5.0.0"
+	revision = "5.0.1"
 
 	# Type
 	type = "ZMSPackage"

--- a/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/__init__.py
+++ b/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/__init__.py
@@ -166,15 +166,6 @@ class zms_formulator_lib:
 			,"repetitive":0
 			,"type":"resource"}
 
-		# langdictxml = {"default":""
-		# 	,"id":"langdict.xml"
-		# 	,"keys":[]
-		# 	,"mandatory":0
-		# 	,"multilang":0
-		# 	,"name":"langdict.xml"
-		# 	,"repetitive":0
-		# 	,"type":"resource"}
-		#
 		jsoneditor = {"default":""
 			,"id":"JSONEditor"
 			,"keys":[]

--- a/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/__init__.py
+++ b/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/__init__.py
@@ -22,7 +22,7 @@ class zms_formulator_lib:
 	package = "zms.formulator"
 
 	# Revision
-	revision = "5.0.0"
+	revision = "5.0.1"
 
 	# Type
 	type = "ZMSLibrary"
@@ -47,15 +47,15 @@ class zms_formulator_lib:
 			,"repetitive":0
 			,"type":"resource"}
 
-		langdictxml = {"default":""
-			,"id":"langdict.xml"
-			,"keys":[]
-			,"mandatory":0
-			,"multilang":0
-			,"name":"langdict.xml"
-			,"repetitive":0
-			,"type":"resource"}
-
+		# langdictxml = {"default":""
+		# 	,"id":"langdict.xml"
+		# 	,"keys":[]
+		# 	,"mandatory":0
+		# 	,"multilang":0
+		# 	,"name":"langdict.xml"
+		# 	,"repetitive":0
+		# 	,"type":"resource"}
+		#
 		jsoneditor = {"default":""
 			,"id":"JSONEditor"
 			,"keys":[]

--- a/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/__init__.py
+++ b/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/__init__.py
@@ -47,15 +47,15 @@ class zms_formulator_lib:
 			,"repetitive":0
 			,"type":"resource"}
 
-		# langdictxml = {"default":""
-		# 	,"id":"langdict.xml"
-		# 	,"keys":[]
-		# 	,"mandatory":0
-		# 	,"multilang":0
-		# 	,"name":"langdict.xml"
-		# 	,"repetitive":0
-		# 	,"type":"resource"}
-		#
+		langdictxml = {"default":""
+			,"id":"langdict.xml"
+			,"keys":[]
+			,"mandatory":0
+			,"multilang":0
+			,"name":"langdict.xml"
+			,"repetitive":0
+			,"type":"resource"}
+		
 		jsoneditor = {"default":""
 			,"id":"JSONEditor"
 			,"keys":[]

--- a/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/__init__.py
+++ b/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/__init__.py
@@ -18,6 +18,125 @@ class zms_formulator_lib:
 	# Name
 	name = "zms.formulator.lib"
 
+	# Lang_dict
+	lang_dict = {"zms.formulator.lib.BUTTON_RESTORE":{"eng":"Restore"
+			,"fra":"Restaurer"
+			,"ger":"Zurücksetzen"}
+		,"zms.formulator.lib.BUTTON_SUBMIT":{"eng":"Submit"
+			,"fra":"Soumettre"
+			,"ger":"Absenden"}
+		,"zms.formulator.lib.ERROR_ADDITIONALITEMS":{"eng":"No additional items allowed in this array"
+			,"fra":"No additional items allowed in this array"
+			,"ger":"Keine weiteren Elemente in diesem Array erlaubt!"}
+		,"zms.formulator.lib.ERROR_ADDITIONAL_PROPERTIES":{"eng":"No additional properties allowed, but property {{0}} is set"
+			,"fra":"No additional properties allowed, but property {{0}} is set"
+			,"ger":"Keine weiteren Eigenschaften sind erlaubt; die Eigenschaft {{0}} ist gesetzt"}
+		,"zms.formulator.lib.ERROR_ANYOF":{"eng":"Value must validate against at least one of the provided schemas"
+			,"fra":"Value must validate against at least one of the provided schemas"
+			,"ger":"Value must validate against at least one of the provided schemas"}
+		,"zms.formulator.lib.ERROR_DEPENDENCY":{"eng":"Must have property {{0}}"
+			,"fra":"Must have property {{0}}"
+			,"ger":"Muss die Eigenschaft {{0}} haben"}
+		,"zms.formulator.lib.ERROR_DISALLOW":{"eng":"Value must not be of type {{0}}"
+			,"fra":"Value must not be of type {{0}}"
+			,"ger":"Der Wert darf nicht dem Typen {{0}} entsprechen"}
+		,"zms.formulator.lib.ERROR_DISALLOW_UNION":{"eng":"Value must not be one of the provided disallowed types"
+			,"fra":"Value must not be one of the provided disallowed types"
+			,"ger":"Der Wert darf nicht einem der unerlaubten Typen entsprechen"}
+		,"zms.formulator.lib.ERROR_ENUM":{"eng":"Value must be one of the enumerated values"
+			,"fra":"Value must be one of the enumerated values"
+			,"ger":"Der Wert muss einem der aufgezählten Werte entsprechen"}
+		,"zms.formulator.lib.ERROR_MANDATORY":{"eng":"Value is mandatory"
+			,"fra":"Value is mandatory"
+			,"ger":"Der Wert ist eine Pflichtangabe"}
+		,"zms.formulator.lib.ERROR_MAXIMUM_EXCL":{"eng":"Value must be less than {{0}}"
+			,"fra":"Value must be less than {{0}}"
+			,"ger":"Der Wert muss kleiner sein als {{0}}"}
+		,"zms.formulator.lib.ERROR_MAXIMUM_INCL":{"eng":"Value must be at most {{0}}"
+			,"fra":"Value must be at most {{0}}"
+			,"ger":"Der Wert muss maximal {{0}} sein"}
+		,"zms.formulator.lib.ERROR_MAXITEMS":{"eng":"Value must have at most {{0}} items"
+			,"fra":"Value must have at most {{0}} items"
+			,"ger":"Der Wert darf maximal {{0}} Elemente enthalten"}
+		,"zms.formulator.lib.ERROR_MAXLENGTH":{"eng":"Value must be at most {{0}} characters long"
+			,"fra":"Value must be at most {{0}} characters long"
+			,"ger":"Der Wert darf maximal {{0}} Zeichen lang sein"}
+		,"zms.formulator.lib.ERROR_MAXPROPERTIES":{"eng":"Object must have at most {{0}} properties"
+			,"fra":"Object must have at most {{0}} properties"
+			,"ger":"Das Objekt darf maximal {{0}} Eigenschaften haben"}
+		,"zms.formulator.lib.ERROR_MINIMUM_EXCL":{"eng":"Value must be greater than {{0}}"
+			,"fra":"Value must be greater than {{0}}"
+			,"ger":"Der Wert muss grösser sein als {{0}}"}
+		,"zms.formulator.lib.ERROR_MINIMUM_INCL":{"eng":"Value must be at least {{0}}"
+			,"fra":"Value must be at least {{0}}"
+			,"ger":"Der Wert muss mindestens {{0}} sein"}
+		,"zms.formulator.lib.ERROR_MINITEMS":{"eng":"Value must have at least {{0}} items"
+			,"fra":"Value must have at least {{0}} items"
+			,"ger":"Der Wert muss mindestens {{0}} Elemente enthalten"}
+		,"zms.formulator.lib.ERROR_MINLENGTH":{"eng":"Value must be at least {{0}} characters long"
+			,"fra":"Value must be at least {{0}} characters long"
+			,"ger":"Der Wert muss mindestens {{0}} Zeichen lang sein"}
+		,"zms.formulator.lib.ERROR_MINPROPERTIES":{"eng":"Object must have at least {{0}} properties"
+			,"fra":"Object must have at least {{0}} properties"
+			,"ger":"Das Objekt muss mindestens {{0}} Eigenschaften haben"}
+		,"zms.formulator.lib.ERROR_MULTIPLEOF":{"eng":"Value must be a multiple of {{0}}"
+			,"fra":"Value must be a multiple of {{0}}"
+			,"ger":"Der Wert muss ein Vielfaches von {{0}} sein"}
+		,"zms.formulator.lib.ERROR_NOT":{"eng":"Value must not validate against the provided schema"
+			,"fra":"Value must not validate against the provided schema"
+			,"ger":"Value must not validate against the provided schema"}
+		,"zms.formulator.lib.ERROR_NOTEMPTY":{"eng":"Value required"
+			,"fra":"Value required"
+			,"ger":"Es wird ein Wert benötigt"}
+		,"zms.formulator.lib.ERROR_NOTSET":{"eng":"Property must be set"
+			,"fra":"Property must be set"
+			,"ger":"Eigenschaft muss angegeben werden"}
+		,"zms.formulator.lib.ERROR_ONEOF":{"eng":"Value must validate against exactly one of the provided schemas. It currently validates against {{0}} of the schemas."
+			,"fra":"Value must validate against exactly one of the provided schemas. It currently validates against {{0}} of the schemas."
+			,"ger":"Value must validate against exactly one of the provided schemas. It currently validates against {{0}} of the schemas."}
+		,"zms.formulator.lib.ERROR_PATTERN":{"eng":"Value must match the provided pattern"
+			,"fra":"Value must match the provided pattern"
+			,"ger":"Der Wert muss dem vorgegebenen Muster entsprechen"}
+		,"zms.formulator.lib.ERROR_REQUIRED":{"eng":"Object is missing the required property '{{0}}'"
+			,"fra":"Object is missing the required property '{{0}}'"
+			,"ger":"Dem Objekt fehlt die benötigte Eigenschaft '{{0}}'"}
+		,"zms.formulator.lib.ERROR_TYPE":{"eng":"Value must be of type {{0}}"
+			,"fra":"Value must be of type {{0}}"
+			,"ger":"Der Wert muss dem Typen {{0}} entsprechen"}
+		,"zms.formulator.lib.ERROR_TYPE_UNION":{"eng":"Value must be one of the provided types"
+			,"fra":"Value must be one of the provided types"
+			,"ger":"Der Wert muss dem vorgegebenen Typen entsprechen"}
+		,"zms.formulator.lib.ERROR_UNIQUEITEMS":{"eng":"Array must have unique items"
+			,"fra":"Array must have unique items"
+			,"ger":"Das Feld darf nur eindeutige Elemente enthalten!"}
+		,"zms.formulator.lib.FEEDBACK_MSG":{"eng":"Thank you, we have received the data."
+			,"fra":"Thank you, we have received the data."
+			,"ger":"Vielen Dank, die Daten sind bei uns eingegangen."}
+		,"zms.formulator.lib.HINT_CHECKINPUT":{"eng":"Please check your input!"
+			,"fra":"Please check your input!"
+			,"ger":"Bitte überprüfen Sie Ihre Eingabe!"}
+		,"zms.formulator.lib.HINT_DATANOTSENT":{"eng":"Data was not sent. Are you a robot?"
+			,"fra":"Data was not sent. Are you a robot?"
+			,"ger":"Daten wurden nicht übertragen! Bist du etwa ein Roboter?"}
+		,"zms.formulator.lib.HINT_DATASENT":{"eng":"Data was sent."
+			,"fra":"Data was sent."
+			,"ger":"Die Daten wurden übertragen."}
+		,"zms.formulator.lib.HINT_EMAILSYNTAX":{"eng":"E-Mails expect a format like \\\"user@domain.tld\\\""
+			,"fra":"E-Mails expect a format like \\\"user@domain.tld\\\""
+			,"ger":"E-Mails erwarten ein Format wie \\\"user@domain.tld\\\""}
+		,"zms.formulator.lib.HINT_ERROROCCURED":{"eng":"An Error occurred!"
+			,"fra":"An Error occurred!"
+			,"ger":"Es ist ein Fehler aufgetreten!"}
+		,"zms.formulator.lib.HINT_FILESIZE":{"eng":"File size:"
+			,"fra":"File size:"
+			,"ger":"Dateigröße:"}
+		,"zms.formulator.lib.HINT_FILETYPE":{"eng":"File type:"
+			,"fra":"File type:"
+			,"ger":"Dateityp:"}
+		,"zms.formulator.lib.HINT_MULTISELECT":{"eng":"Hint: Select multiple entries by holding cmd- or Ctrl-key."
+			,"fra":"Hint: Select multiple entries by holding cmd- or Ctrl-key."
+			,"ger":"Tipp: Sie können mehrere Einträge durch das Halten der cmd- bzw. Strg-Taste auswählen."}}
+
 	# Package
 	package = "zms.formulator"
 
@@ -47,15 +166,15 @@ class zms_formulator_lib:
 			,"repetitive":0
 			,"type":"resource"}
 
-		langdictxml = {"default":""
-			,"id":"langdict.xml"
-			,"keys":[]
-			,"mandatory":0
-			,"multilang":0
-			,"name":"langdict.xml"
-			,"repetitive":0
-			,"type":"resource"}
-		
+		# langdictxml = {"default":""
+		# 	,"id":"langdict.xml"
+		# 	,"keys":[]
+		# 	,"mandatory":0
+		# 	,"multilang":0
+		# 	,"name":"langdict.xml"
+		# 	,"repetitive":0
+		# 	,"type":"resource"}
+		#
 		jsoneditor = {"default":""
 			,"id":"JSONEditor"
 			,"keys":[]

--- a/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/langdict.xml
+++ b/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/langdict.xml
@@ -1,23 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<?zms version='ZMS5-5.1.0
-'?>
+<?zms version='ZMS5-5.1.0'?>
 <list>
   <item type="dictionary">
     <dictionary>
-      <item key="eng">Restore</item>
-      <item key="fra">Restaurer</item>
-      <item key="ger">Zurücksetzen</item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.BUTTON_RESTORE</item>
+      <item key="eng"><![CDATA[Restore]]></item>
+      <item key="fra"><![CDATA[Restaurer]]></item>
+      <item key="ger"><![CDATA[Zurücksetzen]]></item>
+      <item key="key"><![CDATA[zms.formulator.lib.BUTTON_RESTORE]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng">Submit</item>
-      <item key="fra">Soumettre</item>
-      <item key="ger">Absenden</item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.BUTTON_SUBMIT</item>
+      <item key="eng"><![CDATA[Submit]]></item>
+      <item key="fra"><![CDATA[Soumettre]]></item>
+      <item key="ger"><![CDATA[Absenden]]></item>
+      <item key="key"><![CDATA[zms.formulator.lib.BUTTON_SUBMIT]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -25,8 +22,7 @@
       <item key="eng"><![CDATA[No additional items allowed in this array]]></item>
       <item key="fra"><![CDATA[No additional items allowed in this array]]></item>
       <item key="ger"><![CDATA[Keine weiteren Elemente in diesem Array erlaubt!]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_ADDITIONALITEMS</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_ADDITIONALITEMS]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -34,8 +30,7 @@
       <item key="eng"><![CDATA[No additional properties allowed, but property {{0}} is set]]></item>
       <item key="fra"><![CDATA[No additional properties allowed, but property {{0}} is set]]></item>
       <item key="ger"><![CDATA[Keine weiteren Eigenschaften sind erlaubt; die Eigenschaft {{0}} ist gesetzt]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_ADDITIONAL_PROPERTIES</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_ADDITIONAL_PROPERTIES]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -43,8 +38,7 @@
       <item key="eng"><![CDATA[Value must validate against at least one of the provided schemas]]></item>
       <item key="fra"><![CDATA[Value must validate against at least one of the provided schemas]]></item>
       <item key="ger"><![CDATA[Value must validate against at least one of the provided schemas]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_ANYOF</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_ANYOF]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -52,8 +46,7 @@
       <item key="eng"><![CDATA[Must have property {{0}}]]></item>
       <item key="fra"><![CDATA[Must have property {{0}}]]></item>
       <item key="ger"><![CDATA[Muss die Eigenschaft {0}} haben]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_DEPENDENCY</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_DEPENDENCY]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -61,8 +54,7 @@
       <item key="eng"><![CDATA[Value must not be of type {{0}}]]></item>
       <item key="fra"><![CDATA[Value must not be of type {{0}}]]></item>
       <item key="ger"><![CDATA[Der Wert darf nicht dem Typen {{0}} entsprechen]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_DISALLOW</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_DISALLOW]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -70,8 +62,7 @@
       <item key="eng"><![CDATA[Value must not be one of the provided disallowed types]]></item>
       <item key="fra"><![CDATA[Value must not be one of the provided disallowed types]]></item>
       <item key="ger"><![CDATA[Der Wert darf nicht einem der unerlaubten Typen entsprechen]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_DISALLOW_UNION</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_DISALLOW_UNION]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -79,8 +70,7 @@
       <item key="eng"><![CDATA[Value must be one of the enumerated values]]></item>
       <item key="fra"><![CDATA[Value must be one of the enumerated values]]></item>
       <item key="ger"><![CDATA[Der Wert muss einem der aufgezählten Werte entsprechen]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_ENUM</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_ENUM]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -88,8 +78,7 @@
       <item key="eng"><![CDATA[Value is mandatory]]></item>
       <item key="fra"><![CDATA[Value is mandatory]]></item>
       <item key="ger"><![CDATA[Der Wert ist eine Pflichtangabe]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_MANDATORY</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MANDATORY]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -97,8 +86,7 @@
       <item key="eng"><![CDATA[Value must be less than {{0}}]]></item>
       <item key="fra"><![CDATA[Value must be less than {{0}}]]></item>
       <item key="ger"><![CDATA[Der Wert muss kleiner sein als {{0}}]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_MAXIMUM_EXCL</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MAXIMUM_EXCL]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -106,8 +94,7 @@
       <item key="eng"><![CDATA[Value must be at most {{0}}]]></item>
       <item key="fra"><![CDATA[Value must be at most {{0}}]]></item>
       <item key="ger"><![CDATA[Der Wert muss maximal {{0}} sein]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_MAXIMUM_INCL</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MAXIMUM_INCL]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -115,8 +102,7 @@
       <item key="eng"><![CDATA[Value must have at most {{0}} items]]></item>
       <item key="fra"><![CDATA[Value must have at most {{0}} items]]></item>
       <item key="ger"><![CDATA[Der Wert darf maximal {{0}} Elemente enthalten]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_MAXITEMS</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MAXITEMS]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -124,8 +110,7 @@
       <item key="eng"><![CDATA[Value must be at most {{0}} characters long]]></item>
       <item key="fra"><![CDATA[Value must be at most {{0}} characters long]]></item>
       <item key="ger"><![CDATA[Der Wert darf maximal {{0}} Zeichen lang sein]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_MAXLENGTH</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MAXLENGTH]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -133,8 +118,7 @@
       <item key="eng"><![CDATA[Object must have at most {{0}} properties]]></item>
       <item key="fra"><![CDATA[Object must have at most {{0}} properties]]></item>
       <item key="ger"><![CDATA[Das Objekt darf maximal {{0}} Eigenschaften haben]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_MAXPROPERTIES</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MAXPROPERTIES]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -142,8 +126,7 @@
       <item key="eng"><![CDATA[Value must be greater than {{0}}]]></item>
       <item key="fra"><![CDATA[Value must be greater than {{0}}]]></item>
       <item key="ger"><![CDATA[Der Wert muss grösser sein als {{0}}]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_MINIMUM_EXCL</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MINIMUM_EXCL]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -151,8 +134,7 @@
       <item key="eng"><![CDATA[Value must be at least {{0}}]]></item>
       <item key="fra"><![CDATA[Value must be at least {{0}}]]></item>
       <item key="ger"><![CDATA[Der Wert muss mindestens {{0}} sein]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_MINIMUM_INCL</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MINIMUM_INCL]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -160,8 +142,7 @@
       <item key="eng"><![CDATA[Value must have at least {{0}} items]]></item>
       <item key="fra"><![CDATA[Value must have at least {{0}} items]]></item>
       <item key="ger"><![CDATA[Der Wert muss mindestens {{0}} Elemente enthalten]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_MINITEMS</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MINITEMS]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -169,8 +150,7 @@
       <item key="eng"><![CDATA[Value must be at least {{0}} characters long]]></item>
       <item key="fra"><![CDATA[Value must be at least {{0}} characters long]]></item>
       <item key="ger"><![CDATA[Der Wert muss mindestens {{0}} Zeichen lang sein]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_MINLENGTH</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MINLENGTH]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -178,8 +158,7 @@
       <item key="eng"><![CDATA[Object must have at least {{0}} properties]]></item>
       <item key="fra"><![CDATA[Object must have at least {{0}} properties]]></item>
       <item key="ger"><![CDATA[Das Objekt muss mindestens {{0}} Eigenschaften haben]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_MINPROPERTIES</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MINPROPERTIES]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -187,8 +166,7 @@
       <item key="eng"><![CDATA[Value must be a multiple of {{0}}]]></item>
       <item key="fra"><![CDATA[Value must be a multiple of {{0}}]]></item>
       <item key="ger"><![CDATA[Der Wert muss ein Vielfaches von {{0}} sein]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_MULTIPLEOF</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MULTIPLEOF]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -196,8 +174,7 @@
       <item key="eng"><![CDATA[Value must not validate against the provided schema]]></item>
       <item key="fra"><![CDATA[Value must not validate against the provided schema]]></item>
       <item key="ger"><![CDATA[Value must not validate against the provided schema]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_NOT</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_NOT]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -205,8 +182,7 @@
       <item key="eng"><![CDATA[Value required]]></item>
       <item key="fra"><![CDATA[Value required]]></item>
       <item key="ger"><![CDATA[Es wird ein Wert benötigt]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_NOTEMPTY</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_NOTEMPTY]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -214,8 +190,7 @@
       <item key="eng"><![CDATA[Property must be set]]></item>
       <item key="fra"><![CDATA[Property must be set]]></item>
       <item key="ger"><![CDATA[Eigenschaft muss angegeben werden]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_NOTSET</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_NOTSET]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -223,8 +198,7 @@
       <item key="eng"><![CDATA[Value must validate against exactly one of the provided schemas. It currently validates against {{0}} of the schemas.]]></item>
       <item key="fra"><![CDATA[Value must validate against exactly one of the provided schemas. It currently validates against {{0}} of the schemas.]]></item>
       <item key="ger"><![CDATA[Value must validate against exactly one of the provided schemas. It currently validates against {{0}} of the schemas.]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_ONEOF</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_ONEOF]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -232,8 +206,7 @@
       <item key="eng"><![CDATA[Value must match the provided pattern]]></item>
       <item key="fra"><![CDATA[Value must match the provided pattern]]></item>
       <item key="ger"><![CDATA[Der Wert muss dem vorgegebenen Muster entsprechen]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_PATTERN</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_PATTERN]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -241,8 +214,7 @@
       <item key="eng"><![CDATA[Object is missing the required property '{{0}}']]></item>
       <item key="fra"><![CDATA[Object is missing the required property '{{0}}']]></item>
       <item key="ger"><![CDATA[Dem Objekt fehlt die benötigte Eigenschaft ’{{0}}]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_REQUIRED</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_REQUIRED]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -250,8 +222,7 @@
       <item key="eng"><![CDATA[Value must be of type {{0}}]]></item>
       <item key="fra"><![CDATA[Value must be of type {{0}}]]></item>
       <item key="ger"><![CDATA[Der Wert muss dem Typen {{0}} entsprechen]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_TYPE</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_TYPE]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -259,8 +230,7 @@
       <item key="eng"><![CDATA[Value must be one of the provided types]]></item>
       <item key="fra"><![CDATA[Value must be one of the provided types]]></item>
       <item key="ger"><![CDATA[Der Wert muss dem vorgegebenen Typen entsprechen]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_TYPE_UNION</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_TYPE_UNION]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -268,8 +238,7 @@
       <item key="eng"><![CDATA[Array must have unique items]]></item>
       <item key="fra"><![CDATA[Array must have unique items]]></item>
       <item key="ger"><![CDATA[Das Feld darf nur eindeutige Elemente enthalten!]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.ERROR_UNIQUEITEMS</item>
+      <item key="key"><![CDATA[zms.formulator.lib.ERROR_UNIQUEITEMS]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -277,8 +246,7 @@
       <item key="eng"><![CDATA[Thank you, we have received the data.]]></item>
       <item key="fra"><![CDATA[Thank you, we have received the data.]]></item>
       <item key="ger"><![CDATA[Vielen Dank, die Daten sind bei uns eingegangen.]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.FEEDBACK_MSG</item>
+      <item key="key"><![CDATA[zms.formulator.lib.FEEDBACK_MSG]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -286,8 +254,7 @@
       <item key="eng"><![CDATA[Please check your input!]]></item>
       <item key="fra"><![CDATA[Please check your input!]]></item>
       <item key="ger"><![CDATA[Bitte überprüfen Sie Ihre Eingabe!]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.HINT_CHECKINPUT</item>
+      <item key="key"><![CDATA[zms.formulator.lib.HINT_CHECKINPUT]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -295,8 +262,7 @@
       <item key="eng"><![CDATA[Data was not sent. Are you a robot?]]></item>
       <item key="fra"><![CDATA[Data was not sent. Are you a robot?]]></item>
       <item key="ger"><![CDATA[Daten wurden nicht übertragen! Bist du etwa ein Roboter?]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.HINT_DATANOTSENT</item>
+      <item key="key"><![CDATA[zms.formulator.lib.HINT_DATANOTSENT]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -304,8 +270,7 @@
       <item key="eng"><![CDATA[Data was sent.]]></item>
       <item key="fra"><![CDATA[Data was sent.]]></item>
       <item key="ger"><![CDATA[Die Daten wurden übertragen.]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.HINT_DATASENT</item>
+      <item key="key"><![CDATA[zms.formulator.lib.HINT_DATASENT]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -313,8 +278,7 @@
       <item key="eng"><![CDATA[E-Mails expect a format like \"user@domain.tld\"]]></item>
       <item key="fra"><![CDATA[E-Mails expect a format like \"user@domain.tld\"]]></item>
       <item key="ger"><![CDATA[E-Mails erwarten ein Format wie \"user@domain.tld\"]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.HINT_EMAILSYNTAX</item>
+      <item key="key"><![CDATA[zms.formulator.lib.HINT_EMAILSYNTAX]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -322,26 +286,23 @@
       <item key="eng"><![CDATA[An Error occurred!]]></item>
       <item key="fra"><![CDATA[An Error occurred!]]></item>
       <item key="ger"><![CDATA[Es ist ein Fehler aufgetreten!]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.HINT_ERROROCCURED</item>
+      <item key="key"><![CDATA[zms.formulator.lib.HINT_ERROROCCURED]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
       <item key="eng"><![CDATA[File size:]]></item>
       <item key="fra"><![CDATA[File size:]]></item>
-      <item key="ger">Dateigröße:</item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.HINT_FILESIZE</item>
+      <item key="ger"><![CDATA[Dateigröße:]]></item>
+      <item key="key"><![CDATA[zms.formulator.lib.HINT_FILESIZE]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
       <item key="eng"><![CDATA[File type:]]></item>
       <item key="fra"><![CDATA[File type:]]></item>
-      <item key="ger">Dateityp:</item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.HINT_FILETYPE</item>
+      <item key="ger"><![CDATA[Dateityp:]]></item>
+      <item key="key"><![CDATA[zms.formulator.lib.HINT_FILETYPE]]></item>
     </dictionary>
   </item>
   <item type="dictionary">
@@ -349,8 +310,7 @@
       <item key="eng"><![CDATA[Hint: Select multiple entries by holding cmd- or Ctrl-key.]]></item>
       <item key="fra"><![CDATA[Hint: Select multiple entries by holding cmd- or Ctrl-key.]]></item>
       <item key="ger"><![CDATA[Tipp: Sie können mehrere Einträge durch das Halten der cmd- bzw. Strg-Taste auswählen.]]></item>
-      <item key="ita"></item>
-      <item key="key">zms.formulator.lib.HINT_MULTISELECT</item>
+      <item key="key"><![CDATA[zms.formulator.lib.HINT_MULTISELECT]]></item>
     </dictionary>
   </item>
 </list>

--- a/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/langdict.xml
+++ b/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/langdict.xml
@@ -45,7 +45,7 @@
     <dictionary>
       <item key="eng">Must have property {{0}}</item>
       <item key="fra">Must have property {{0}}</item>
-      <item key="ger">Muss die Eigenschaft {0}} haben</item>
+      <item key="ger">Muss die Eigenschaft {{0}} haben</item>
       <item key="key">zms.formulator.lib.ERROR_DEPENDENCY</item>
     </dictionary>
   </item>
@@ -213,7 +213,7 @@
     <dictionary>
       <item key="eng">Object is missing the required property '{{0}}'</item>
       <item key="fra">Object is missing the required property '{{0}}'</item>
-      <item key="ger">Dem Objekt fehlt die benötigte Eigenschaft ’{{0}}</item>
+      <item key="ger">Dem Objekt fehlt die benötigte Eigenschaft '{{0}}'</item>
       <item key="key">zms.formulator.lib.ERROR_REQUIRED</item>
     </dictionary>
   </item>

--- a/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/langdict.xml
+++ b/Products/zms/conf/metaobj_manager/zms.formulator/zms.formulator.lib/langdict.xml
@@ -3,314 +3,314 @@
 <list>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Restore]]></item>
-      <item key="fra"><![CDATA[Restaurer]]></item>
-      <item key="ger"><![CDATA[Zurücksetzen]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.BUTTON_RESTORE]]></item>
+      <item key="eng">Restore</item>
+      <item key="fra">Restaurer</item>
+      <item key="ger">Zurücksetzen</item>
+      <item key="key">zms.formulator.lib.BUTTON_RESTORE</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Submit]]></item>
-      <item key="fra"><![CDATA[Soumettre]]></item>
-      <item key="ger"><![CDATA[Absenden]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.BUTTON_SUBMIT]]></item>
+      <item key="eng">Submit</item>
+      <item key="fra">Soumettre</item>
+      <item key="ger">Absenden</item>
+      <item key="key">zms.formulator.lib.BUTTON_SUBMIT</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[No additional items allowed in this array]]></item>
-      <item key="fra"><![CDATA[No additional items allowed in this array]]></item>
-      <item key="ger"><![CDATA[Keine weiteren Elemente in diesem Array erlaubt!]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_ADDITIONALITEMS]]></item>
+      <item key="eng">No additional items allowed in this array</item>
+      <item key="fra">No additional items allowed in this array</item>
+      <item key="ger">Keine weiteren Elemente in diesem Array erlaubt!</item>
+      <item key="key">zms.formulator.lib.ERROR_ADDITIONALITEMS</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[No additional properties allowed, but property {{0}} is set]]></item>
-      <item key="fra"><![CDATA[No additional properties allowed, but property {{0}} is set]]></item>
-      <item key="ger"><![CDATA[Keine weiteren Eigenschaften sind erlaubt; die Eigenschaft {{0}} ist gesetzt]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_ADDITIONAL_PROPERTIES]]></item>
+      <item key="eng">No additional properties allowed, but property {{0}} is set</item>
+      <item key="fra">No additional properties allowed, but property {{0}} is set</item>
+      <item key="ger">Keine weiteren Eigenschaften sind erlaubt; die Eigenschaft {{0}} ist gesetzt</item>
+      <item key="key">zms.formulator.lib.ERROR_ADDITIONAL_PROPERTIES</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value must validate against at least one of the provided schemas]]></item>
-      <item key="fra"><![CDATA[Value must validate against at least one of the provided schemas]]></item>
-      <item key="ger"><![CDATA[Value must validate against at least one of the provided schemas]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_ANYOF]]></item>
+      <item key="eng">Value must validate against at least one of the provided schemas</item>
+      <item key="fra">Value must validate against at least one of the provided schemas</item>
+      <item key="ger">Value must validate against at least one of the provided schemas</item>
+      <item key="key">zms.formulator.lib.ERROR_ANYOF</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Must have property {{0}}]]></item>
-      <item key="fra"><![CDATA[Must have property {{0}}]]></item>
-      <item key="ger"><![CDATA[Muss die Eigenschaft {0}} haben]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_DEPENDENCY]]></item>
+      <item key="eng">Must have property {{0}}</item>
+      <item key="fra">Must have property {{0}}</item>
+      <item key="ger">Muss die Eigenschaft {0}} haben</item>
+      <item key="key">zms.formulator.lib.ERROR_DEPENDENCY</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value must not be of type {{0}}]]></item>
-      <item key="fra"><![CDATA[Value must not be of type {{0}}]]></item>
-      <item key="ger"><![CDATA[Der Wert darf nicht dem Typen {{0}} entsprechen]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_DISALLOW]]></item>
+      <item key="eng">Value must not be of type {{0}}</item>
+      <item key="fra">Value must not be of type {{0}}</item>
+      <item key="ger">Der Wert darf nicht dem Typen {{0}} entsprechen</item>
+      <item key="key">zms.formulator.lib.ERROR_DISALLOW</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value must not be one of the provided disallowed types]]></item>
-      <item key="fra"><![CDATA[Value must not be one of the provided disallowed types]]></item>
-      <item key="ger"><![CDATA[Der Wert darf nicht einem der unerlaubten Typen entsprechen]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_DISALLOW_UNION]]></item>
+      <item key="eng">Value must not be one of the provided disallowed types</item>
+      <item key="fra">Value must not be one of the provided disallowed types</item>
+      <item key="ger">Der Wert darf nicht einem der unerlaubten Typen entsprechen</item>
+      <item key="key">zms.formulator.lib.ERROR_DISALLOW_UNION</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value must be one of the enumerated values]]></item>
-      <item key="fra"><![CDATA[Value must be one of the enumerated values]]></item>
-      <item key="ger"><![CDATA[Der Wert muss einem der aufgezählten Werte entsprechen]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_ENUM]]></item>
+      <item key="eng">Value must be one of the enumerated values</item>
+      <item key="fra">Value must be one of the enumerated values</item>
+      <item key="ger">Der Wert muss einem der aufgezählten Werte entsprechen</item>
+      <item key="key">zms.formulator.lib.ERROR_ENUM</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value is mandatory]]></item>
-      <item key="fra"><![CDATA[Value is mandatory]]></item>
-      <item key="ger"><![CDATA[Der Wert ist eine Pflichtangabe]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MANDATORY]]></item>
+      <item key="eng">Value is mandatory</item>
+      <item key="fra">Value is mandatory</item>
+      <item key="ger">Der Wert ist eine Pflichtangabe</item>
+      <item key="key">zms.formulator.lib.ERROR_MANDATORY</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value must be less than {{0}}]]></item>
-      <item key="fra"><![CDATA[Value must be less than {{0}}]]></item>
-      <item key="ger"><![CDATA[Der Wert muss kleiner sein als {{0}}]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MAXIMUM_EXCL]]></item>
+      <item key="eng">Value must be less than {{0}}</item>
+      <item key="fra">Value must be less than {{0}}</item>
+      <item key="ger">Der Wert muss kleiner sein als {{0}}</item>
+      <item key="key">zms.formulator.lib.ERROR_MAXIMUM_EXCL</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value must be at most {{0}}]]></item>
-      <item key="fra"><![CDATA[Value must be at most {{0}}]]></item>
-      <item key="ger"><![CDATA[Der Wert muss maximal {{0}} sein]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MAXIMUM_INCL]]></item>
+      <item key="eng">Value must be at most {{0}}</item>
+      <item key="fra">Value must be at most {{0}}</item>
+      <item key="ger">Der Wert muss maximal {{0}} sein</item>
+      <item key="key">zms.formulator.lib.ERROR_MAXIMUM_INCL</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value must have at most {{0}} items]]></item>
-      <item key="fra"><![CDATA[Value must have at most {{0}} items]]></item>
-      <item key="ger"><![CDATA[Der Wert darf maximal {{0}} Elemente enthalten]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MAXITEMS]]></item>
+      <item key="eng">Value must have at most {{0}} items</item>
+      <item key="fra">Value must have at most {{0}} items</item>
+      <item key="ger">Der Wert darf maximal {{0}} Elemente enthalten</item>
+      <item key="key">zms.formulator.lib.ERROR_MAXITEMS</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value must be at most {{0}} characters long]]></item>
-      <item key="fra"><![CDATA[Value must be at most {{0}} characters long]]></item>
-      <item key="ger"><![CDATA[Der Wert darf maximal {{0}} Zeichen lang sein]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MAXLENGTH]]></item>
+      <item key="eng">Value must be at most {{0}} characters long</item>
+      <item key="fra">Value must be at most {{0}} characters long</item>
+      <item key="ger">Der Wert darf maximal {{0}} Zeichen lang sein</item>
+      <item key="key">zms.formulator.lib.ERROR_MAXLENGTH</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Object must have at most {{0}} properties]]></item>
-      <item key="fra"><![CDATA[Object must have at most {{0}} properties]]></item>
-      <item key="ger"><![CDATA[Das Objekt darf maximal {{0}} Eigenschaften haben]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MAXPROPERTIES]]></item>
+      <item key="eng">Object must have at most {{0}} properties</item>
+      <item key="fra">Object must have at most {{0}} properties</item>
+      <item key="ger">Das Objekt darf maximal {{0}} Eigenschaften haben</item>
+      <item key="key">zms.formulator.lib.ERROR_MAXPROPERTIES</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value must be greater than {{0}}]]></item>
-      <item key="fra"><![CDATA[Value must be greater than {{0}}]]></item>
-      <item key="ger"><![CDATA[Der Wert muss grösser sein als {{0}}]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MINIMUM_EXCL]]></item>
+      <item key="eng">Value must be greater than {{0}}</item>
+      <item key="fra">Value must be greater than {{0}}</item>
+      <item key="ger">Der Wert muss grösser sein als {{0}}</item>
+      <item key="key">zms.formulator.lib.ERROR_MINIMUM_EXCL</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value must be at least {{0}}]]></item>
-      <item key="fra"><![CDATA[Value must be at least {{0}}]]></item>
-      <item key="ger"><![CDATA[Der Wert muss mindestens {{0}} sein]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MINIMUM_INCL]]></item>
+      <item key="eng">Value must be at least {{0}}</item>
+      <item key="fra">Value must be at least {{0}}</item>
+      <item key="ger">Der Wert muss mindestens {{0}} sein</item>
+      <item key="key">zms.formulator.lib.ERROR_MINIMUM_INCL</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value must have at least {{0}} items]]></item>
-      <item key="fra"><![CDATA[Value must have at least {{0}} items]]></item>
-      <item key="ger"><![CDATA[Der Wert muss mindestens {{0}} Elemente enthalten]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MINITEMS]]></item>
+      <item key="eng">Value must have at least {{0}} items</item>
+      <item key="fra">Value must have at least {{0}} items</item>
+      <item key="ger">Der Wert muss mindestens {{0}} Elemente enthalten</item>
+      <item key="key">zms.formulator.lib.ERROR_MINITEMS</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value must be at least {{0}} characters long]]></item>
-      <item key="fra"><![CDATA[Value must be at least {{0}} characters long]]></item>
-      <item key="ger"><![CDATA[Der Wert muss mindestens {{0}} Zeichen lang sein]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MINLENGTH]]></item>
+      <item key="eng">Value must be at least {{0}} characters long</item>
+      <item key="fra">Value must be at least {{0}} characters long</item>
+      <item key="ger">Der Wert muss mindestens {{0}} Zeichen lang sein</item>
+      <item key="key">zms.formulator.lib.ERROR_MINLENGTH</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Object must have at least {{0}} properties]]></item>
-      <item key="fra"><![CDATA[Object must have at least {{0}} properties]]></item>
-      <item key="ger"><![CDATA[Das Objekt muss mindestens {{0}} Eigenschaften haben]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MINPROPERTIES]]></item>
+      <item key="eng">Object must have at least {{0}} properties</item>
+      <item key="fra">Object must have at least {{0}} properties</item>
+      <item key="ger">Das Objekt muss mindestens {{0}} Eigenschaften haben</item>
+      <item key="key">zms.formulator.lib.ERROR_MINPROPERTIES</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value must be a multiple of {{0}}]]></item>
-      <item key="fra"><![CDATA[Value must be a multiple of {{0}}]]></item>
-      <item key="ger"><![CDATA[Der Wert muss ein Vielfaches von {{0}} sein]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_MULTIPLEOF]]></item>
+      <item key="eng">Value must be a multiple of {{0}}</item>
+      <item key="fra">Value must be a multiple of {{0}}</item>
+      <item key="ger">Der Wert muss ein Vielfaches von {{0}} sein</item>
+      <item key="key">zms.formulator.lib.ERROR_MULTIPLEOF</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value must not validate against the provided schema]]></item>
-      <item key="fra"><![CDATA[Value must not validate against the provided schema]]></item>
-      <item key="ger"><![CDATA[Value must not validate against the provided schema]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_NOT]]></item>
+      <item key="eng">Value must not validate against the provided schema</item>
+      <item key="fra">Value must not validate against the provided schema</item>
+      <item key="ger">Value must not validate against the provided schema</item>
+      <item key="key">zms.formulator.lib.ERROR_NOT</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value required]]></item>
-      <item key="fra"><![CDATA[Value required]]></item>
-      <item key="ger"><![CDATA[Es wird ein Wert benötigt]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_NOTEMPTY]]></item>
+      <item key="eng">Value required</item>
+      <item key="fra">Value required</item>
+      <item key="ger">Es wird ein Wert benötigt</item>
+      <item key="key">zms.formulator.lib.ERROR_NOTEMPTY</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Property must be set]]></item>
-      <item key="fra"><![CDATA[Property must be set]]></item>
-      <item key="ger"><![CDATA[Eigenschaft muss angegeben werden]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_NOTSET]]></item>
+      <item key="eng">Property must be set</item>
+      <item key="fra">Property must be set</item>
+      <item key="ger">Eigenschaft muss angegeben werden</item>
+      <item key="key">zms.formulator.lib.ERROR_NOTSET</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value must validate against exactly one of the provided schemas. It currently validates against {{0}} of the schemas.]]></item>
-      <item key="fra"><![CDATA[Value must validate against exactly one of the provided schemas. It currently validates against {{0}} of the schemas.]]></item>
-      <item key="ger"><![CDATA[Value must validate against exactly one of the provided schemas. It currently validates against {{0}} of the schemas.]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_ONEOF]]></item>
+      <item key="eng">Value must validate against exactly one of the provided schemas. It currently validates against {{0}} of the schemas.</item>
+      <item key="fra">Value must validate against exactly one of the provided schemas. It currently validates against {{0}} of the schemas.</item>
+      <item key="ger">Value must validate against exactly one of the provided schemas. It currently validates against {{0}} of the schemas.</item>
+      <item key="key">zms.formulator.lib.ERROR_ONEOF</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value must match the provided pattern]]></item>
-      <item key="fra"><![CDATA[Value must match the provided pattern]]></item>
-      <item key="ger"><![CDATA[Der Wert muss dem vorgegebenen Muster entsprechen]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_PATTERN]]></item>
+      <item key="eng">Value must match the provided pattern</item>
+      <item key="fra">Value must match the provided pattern</item>
+      <item key="ger">Der Wert muss dem vorgegebenen Muster entsprechen</item>
+      <item key="key">zms.formulator.lib.ERROR_PATTERN</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Object is missing the required property '{{0}}']]></item>
-      <item key="fra"><![CDATA[Object is missing the required property '{{0}}']]></item>
-      <item key="ger"><![CDATA[Dem Objekt fehlt die benötigte Eigenschaft ’{{0}}]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_REQUIRED]]></item>
+      <item key="eng">Object is missing the required property '{{0}}'</item>
+      <item key="fra">Object is missing the required property '{{0}}'</item>
+      <item key="ger">Dem Objekt fehlt die benötigte Eigenschaft ’{{0}}</item>
+      <item key="key">zms.formulator.lib.ERROR_REQUIRED</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value must be of type {{0}}]]></item>
-      <item key="fra"><![CDATA[Value must be of type {{0}}]]></item>
-      <item key="ger"><![CDATA[Der Wert muss dem Typen {{0}} entsprechen]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_TYPE]]></item>
+      <item key="eng">Value must be of type {{0}}</item>
+      <item key="fra">Value must be of type {{0}}</item>
+      <item key="ger">Der Wert muss dem Typen {{0}} entsprechen</item>
+      <item key="key">zms.formulator.lib.ERROR_TYPE</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Value must be one of the provided types]]></item>
-      <item key="fra"><![CDATA[Value must be one of the provided types]]></item>
-      <item key="ger"><![CDATA[Der Wert muss dem vorgegebenen Typen entsprechen]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_TYPE_UNION]]></item>
+      <item key="eng">Value must be one of the provided types</item>
+      <item key="fra">Value must be one of the provided types</item>
+      <item key="ger">Der Wert muss dem vorgegebenen Typen entsprechen</item>
+      <item key="key">zms.formulator.lib.ERROR_TYPE_UNION</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Array must have unique items]]></item>
-      <item key="fra"><![CDATA[Array must have unique items]]></item>
-      <item key="ger"><![CDATA[Das Feld darf nur eindeutige Elemente enthalten!]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.ERROR_UNIQUEITEMS]]></item>
+      <item key="eng">Array must have unique items</item>
+      <item key="fra">Array must have unique items</item>
+      <item key="ger">Das Feld darf nur eindeutige Elemente enthalten!</item>
+      <item key="key">zms.formulator.lib.ERROR_UNIQUEITEMS</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Thank you, we have received the data.]]></item>
-      <item key="fra"><![CDATA[Thank you, we have received the data.]]></item>
-      <item key="ger"><![CDATA[Vielen Dank, die Daten sind bei uns eingegangen.]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.FEEDBACK_MSG]]></item>
+      <item key="eng">Thank you, we have received the data.</item>
+      <item key="fra">Thank you, we have received the data.</item>
+      <item key="ger">Vielen Dank, die Daten sind bei uns eingegangen.</item>
+      <item key="key">zms.formulator.lib.FEEDBACK_MSG</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Please check your input!]]></item>
-      <item key="fra"><![CDATA[Please check your input!]]></item>
-      <item key="ger"><![CDATA[Bitte überprüfen Sie Ihre Eingabe!]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.HINT_CHECKINPUT]]></item>
+      <item key="eng">Please check your input!</item>
+      <item key="fra">Please check your input!</item>
+      <item key="ger">Bitte überprüfen Sie Ihre Eingabe!</item>
+      <item key="key">zms.formulator.lib.HINT_CHECKINPUT</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Data was not sent. Are you a robot?]]></item>
-      <item key="fra"><![CDATA[Data was not sent. Are you a robot?]]></item>
-      <item key="ger"><![CDATA[Daten wurden nicht übertragen! Bist du etwa ein Roboter?]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.HINT_DATANOTSENT]]></item>
+      <item key="eng">Data was not sent. Are you a robot?</item>
+      <item key="fra">Data was not sent. Are you a robot?</item>
+      <item key="ger">Daten wurden nicht übertragen! Bist du etwa ein Roboter?</item>
+      <item key="key">zms.formulator.lib.HINT_DATANOTSENT</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Data was sent.]]></item>
-      <item key="fra"><![CDATA[Data was sent.]]></item>
-      <item key="ger"><![CDATA[Die Daten wurden übertragen.]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.HINT_DATASENT]]></item>
+      <item key="eng">Data was sent.</item>
+      <item key="fra">Data was sent.</item>
+      <item key="ger">Die Daten wurden übertragen.</item>
+      <item key="key">zms.formulator.lib.HINT_DATASENT</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[E-Mails expect a format like \"user@domain.tld\"]]></item>
-      <item key="fra"><![CDATA[E-Mails expect a format like \"user@domain.tld\"]]></item>
-      <item key="ger"><![CDATA[E-Mails erwarten ein Format wie \"user@domain.tld\"]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.HINT_EMAILSYNTAX]]></item>
+      <item key="eng">E-Mails expect a format like \"user@domain.tld\"</item>
+      <item key="fra">E-Mails expect a format like \"user@domain.tld\"</item>
+      <item key="ger">E-Mails erwarten ein Format wie \"user@domain.tld\"</item>
+      <item key="key">zms.formulator.lib.HINT_EMAILSYNTAX</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[An Error occurred!]]></item>
-      <item key="fra"><![CDATA[An Error occurred!]]></item>
-      <item key="ger"><![CDATA[Es ist ein Fehler aufgetreten!]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.HINT_ERROROCCURED]]></item>
+      <item key="eng">An Error occurred!</item>
+      <item key="fra">An Error occurred!</item>
+      <item key="ger">Es ist ein Fehler aufgetreten!</item>
+      <item key="key">zms.formulator.lib.HINT_ERROROCCURED</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[File size:]]></item>
-      <item key="fra"><![CDATA[File size:]]></item>
-      <item key="ger"><![CDATA[Dateigröße:]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.HINT_FILESIZE]]></item>
+      <item key="eng">File size:</item>
+      <item key="fra">File size:</item>
+      <item key="ger">Dateigröße:</item>
+      <item key="key">zms.formulator.lib.HINT_FILESIZE</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[File type:]]></item>
-      <item key="fra"><![CDATA[File type:]]></item>
-      <item key="ger"><![CDATA[Dateityp:]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.HINT_FILETYPE]]></item>
+      <item key="eng">File type:</item>
+      <item key="fra">File type:</item>
+      <item key="ger">Dateityp:</item>
+      <item key="key">zms.formulator.lib.HINT_FILETYPE</item>
     </dictionary>
   </item>
   <item type="dictionary">
     <dictionary>
-      <item key="eng"><![CDATA[Hint: Select multiple entries by holding cmd- or Ctrl-key.]]></item>
-      <item key="fra"><![CDATA[Hint: Select multiple entries by holding cmd- or Ctrl-key.]]></item>
-      <item key="ger"><![CDATA[Tipp: Sie können mehrere Einträge durch das Halten der cmd- bzw. Strg-Taste auswählen.]]></item>
-      <item key="key"><![CDATA[zms.formulator.lib.HINT_MULTISELECT]]></item>
+      <item key="eng">Hint: Select multiple entries by holding cmd- or Ctrl-key.</item>
+      <item key="fra">Hint: Select multiple entries by holding cmd- or Ctrl-key.</item>
+      <item key="ger">Tipp: Sie können mehrere Einträge durch das Halten der cmd- bzw. Strg-Taste auswählen.</item>
+      <item key="key">zms.formulator.lib.HINT_MULTISELECT</item>
     </dictionary>
   </item>
 </list>


### PR DESCRIPTION
Importing the ZMSFormualator conf is blocked due an XML parse error of langdict.xml. This happens only if langdict.xml is part of the model. Removing it (by comments in init.py) results in a correct import. 
A systematic use CATAdid not solve the XML error on import:
```
<item key="(.*)">(?!<)(.*)</item> ==>
<item key="$1"><![CDATA[$2]]></item>
```
actually removing CDATA from language.xml avoids the error:
```
<item key="(.*)"><!\[CDATA\[(.*)\]\]></item>
<item key="$1">$2</item>

```
With the fix the file language.xml can imported separatly. 
But the lang-items, although part of the model (zms.formulator.lib/_init.py) are not visible in the ZMI, see following picture:

![UNIBE_langdict5](https://user-images.githubusercontent.com/29705216/180820644-5c030dd5-d0b8-4e3b-811a-2593dba87108.gif)

