### PR TITLE
System-Info: Revised package display

### DIFF
--- a/.vscode/ZMS5.code-workspace
+++ b/.vscode/ZMS5.code-workspace
@@ -39,6 +39,9 @@
 			"**/cache/**": true,
 			"**/Data.*": true,
 		},
+		"search.exclude": { 
+			"**/apidocs/**": true
+		},
 		"files.eol": "\n",
 		"files.autoSave": "afterDelay",
 		"workbench.colorTheme": "Visual Studio Light",

--- a/Products/zms/standard.py
+++ b/Products/zms/standard.py
@@ -255,10 +255,14 @@ def set_response_headers_cache(context, request=None, cache_max_age=24*3600, cac
 security.declarePublic('get_installed_packages')
 def get_installed_packages():
   import subprocess
-  pipfreeze = subprocess.Popen("../../../bin/pip freeze --all",
-                               stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                               shell=True, cwd=getPACKAGE_HOME(), universal_newlines=True)
-  packages = pipfreeze.communicate()[0].strip()
+  pip = ('/pip list', '/pip freeze --all')
+  packages = ''
+  pth = getPACKAGE_HOME().rsplit('/lib/')[0] + '/bin'
+  for cmd in pip:
+    output = subprocess.Popen(pth + cmd,
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                              shell=True, cwd=pth, universal_newlines=True)
+    packages += f'# {pth}{cmd}\n\n{output.communicate()[0].strip()}\n\n'
   return packages
 
 

--- a/Products/zms/standard.py
+++ b/Products/zms/standard.py
@@ -253,16 +253,19 @@ def set_response_headers_cache(context, request=None, cache_max_age=24*3600, cac
 
 
 security.declarePublic('get_installed_packages')
-def get_installed_packages():
+def get_installed_packages(pip_cmd='freeze'):
   import subprocess
-  pip = ('/pip list', '/pip freeze --all')
-  packages = ''
+  pip_cmds = {
+      'list':'/pip list', 
+      'freeze':'/pip freeze --all'
+    }
+  cmd = pip_cmds.get(pip_cmd,'freeze')
   pth = getPACKAGE_HOME().rsplit('/lib/')[0] + '/bin'
-  for cmd in pip:
-    output = subprocess.Popen(pth + cmd,
-                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                              shell=True, cwd=pth, universal_newlines=True)
-    packages += f'# {pth}{cmd}\n\n{output.communicate()[0].strip()}\n\n'
+  packages = ''
+  output = subprocess.Popen(pth + cmd,
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                            shell=True, cwd=pth, universal_newlines=True)
+  packages = f'# {pth}{cmd}\n\n{output.communicate()[0].strip()}'
   return packages
 
 

--- a/Products/zms/zpt/ZMS/manage_customize.zpt
+++ b/Products/zms/zpt/ZMS/manage_customize.zpt
@@ -356,8 +356,33 @@
 						</p>
 					</label>
 					<div class="col-sm-10">
-						<div class="ajax-lazy-load" data-ajax-url="manage_customizeInstalledProducts"></div>
+						<div class="custom-control custom-radio custom-control-inline">
+							<input type="radio" class="custom-control-input" 
+								onchange="show_pip_cmd($(this))"
+								id="pip_cmd1" name="pip_cmd" value="freeze" checked="checked" />
+							<label class="custom-control-label" for="pip_cmd1"><samp>pip freeze --all</samp></label>
+						  </div>
+						  <div class="custom-control custom-radio custom-control-inline">
+							<input type="radio" class="custom-control-input" 
+								onchange="show_pip_cmd($(this))"
+								id="pip_cmd2" name="pip_cmd" value="list" />
+							<label class="custom-control-label" for="pip_cmd2"><samp>pip list</samp></label>
+						  </div>
+						<div id="installed_products" class="ajax-lazy-load mt-2" data-ajax-url="manage_customizeInstalledProducts"></div>
 					</div>
+					<script>
+						// Ajax Lazy Load
+						function show_pip_cmd($elm) {
+							var pip_cmd = $elm.val();
+							var $installed_products = $('#installed_products');
+							var ajax_url = 'manage_customizeInstalledProducts';
+							var params = { 'pip_cmd':pip_cmd };
+							$installed_products.html('<i class="fas fa-spinner fa-spin"></i>&nbsp;'+getZMILangStr('MSG_LOADING'));
+							$.get( ajax_url, params, function( data) {
+								$installed_products.html(data);
+							});
+						}
+					</script>
 				</div><!-- .form-group -->
 			</form>
 		</div>

--- a/Products/zms/zpt/ZMS/manage_customizeinstalledproducts.zpt
+++ b/Products/zms/zpt/ZMS/manage_customizeinstalledproducts.zpt
@@ -1,6 +1,5 @@
-<tal:block tal:on-error="structure string:<!-- ERROR: manage_customizeinstalledproducts.zpt -->" tal:define="
-		standard modules/Products.zms/standard;
-		Std modules/Products/PythonScripts/standard">
+<tal:block tal:on-error="structure string:<samp style='color:red;'>ERROR: zms.standard.get_installed_packages()</samp>"
+		   tal:define="standard modules/Products.zms/standard; Std modules/Products/PythonScripts/standard">
 	<textarea disabled="disabled"
 		style="font-family:monospace;width:100%;height:50vh;padding:0 .5rem;background:#354f67;color:white;border:0;"
 		tal:content="structure python:standard.get_installed_packages()">

--- a/Products/zms/zpt/ZMS/manage_customizeinstalledproducts.zpt
+++ b/Products/zms/zpt/ZMS/manage_customizeinstalledproducts.zpt
@@ -1,7 +1,7 @@
 <tal:block tal:on-error="structure string:<samp style='color:red;'>ERROR: zms.standard.get_installed_packages()</samp>"
-		   tal:define="standard modules/Products.zms/standard; Std modules/Products/PythonScripts/standard">
+		tal:define="standard modules/Products.zms/standard; Std modules/Products/PythonScripts/standard">
 	<textarea disabled="disabled"
 		style="font-family:monospace;width:100%;height:50vh;padding:0 .5rem;background:#354f67;color:white;border:0;"
-		tal:content="structure python:standard.get_installed_packages()">
+		tal:content="structure python:standard.get_installed_packages(pip_cmd=request.get('pip_cmd','freeze'))">
 	</textarea>
 </tal:block>


### PR DESCRIPTION
Added `pip list` (shows Package version **_AND_** editable Project location if available) as supplementary info for `pip freeze --all` (shows Package version **_OR_** editable Git revision if available).

**CAUTION**: The displayed version of Zope or other packages may be misleading if it was previously installed as an editable package.

The version of an editable package persists for Zope (see also `Control Panel`), even if another Zope version has been post-installed via `pip` (see `site-packages`) – but in fact the editable version is still used by the app server (even if `pip uninstall` was executed before). The version in `site-packages` can only be reactivated if the editable package folder is removed – renaming and cleaning up `.pth` and `.egg-info` is not enough.

To reflect version changes of an editable package (in `pip list` and `Control Panel`) it has to bee reinstalled via e.g. `pip install -e ../Zope -c ../Zope/constraints.txt` – changes of Git revision (in `pip freeze`) are shown immediately.