### PR TITLE
SOLR Connector: added debug option

### DIFF
--- a/Products/zms/ZMSZCatalogConnector.py
+++ b/Products/zms/ZMSZCatalogConnector.py
@@ -223,14 +223,17 @@ class ZMSZCatalogConnector(
     # --------------------------------------------------------------------------
     #  ZMSZCatalogConnector.search_xml:
     # --------------------------------------------------------------------------
-    def search_xml(self, q, page_index=0, page_size=10, REQUEST=None, RESPONSE=None):
+    def search_xml(self, q, page_index=0, page_size=10, debug=0, REQUEST=None, RESPONSE=None):
       """ ZMSZCatalogConnector.search_xml """
       # Check constraints.
       page_index = int(page_index)
       page_size = int(page_size)
       REQUEST.set('lang', REQUEST.get('lang', self.getPrimaryLanguage()))
       RESPONSE = REQUEST.RESPONSE
-      content_type = 'text/xml;charset=utf-8'
+      content_type = 'text/xml; charset=utf-8'
+      debug = int(debug)
+      if debug:
+        content_type = 'text/plain; charset=utf-8'
       RESPONSE.setHeader('Content-Type', content_type)
       RESPONSE.setHeader('Cache-Control', 'no-cache')
       RESPONSE.setHeader('Pragma', 'no-cache')
@@ -305,12 +308,15 @@ class ZMSZCatalogConnector(
     # --------------------------------------------------------------------------
     #  ZMSZCatalogConnector.suggest_xml:
     # --------------------------------------------------------------------------
-    def suggest_xml(self, q, fq='', limit=5, REQUEST=None, RESPONSE=None):
+    def suggest_xml(self, q, fq='', limit=5, debug=0, REQUEST=None, RESPONSE=None):
       """ ZMSZCatalogConnector.suggest_xml """
       # Check constraints.
       REQUEST.set('lang', REQUEST.get('lang', self.getPrimaryLanguage()))
       RESPONSE = REQUEST.RESPONSE
       content_type = 'text/xml;charset=utf-8'
+      debug = int(debug)
+      if debug:
+        content_type = 'text/plain; charset=utf-8'
       RESPONSE.setHeader('Content-Type', content_type)
       RESPONSE.setHeader('Cache-Control', 'no-cache')
       RESPONSE.setHeader('Pragma', 'no-cache')

--- a/Products/zms/ZMSZCatalogSolrConnector.py
+++ b/Products/zms/ZMSZCatalogSolrConnector.py
@@ -68,7 +68,7 @@ class ZMSZCatalogSolrConnector(
     # --------------------------------------------------------------------------
     #  ZMSZCatalogSolrConnector.search_xml:
     # --------------------------------------------------------------------------
-    def search_xml(self, q, page_index=0, page_size=10, REQUEST=None, RESPONSE=None):
+    def search_xml(self, q, page_index=0, page_size=10, debug=0, REQUEST=None, RESPONSE=None):
       """ ZMSZCatalogSolrConnector.search_xml """
       # Check constraints.
       zcm = self.getCatalogAdapter()
@@ -78,6 +78,9 @@ class ZMSZCatalogSolrConnector(
       REQUEST.set('lang', REQUEST.get('lang', self.getPrimaryLanguage()))
       RESPONSE = REQUEST.RESPONSE
       content_type = 'text/xml; charset=utf-8'
+      debug = int(debug)
+      if debug:
+        content_type = 'text/plain; charset=utf-8'
       RESPONSE.setHeader('Content-Type', content_type)
       RESPONSE.setHeader('Cache-Control', 'no-cache')
       RESPONSE.setHeader('Pragma', 'no-cache')
@@ -99,19 +102,22 @@ class ZMSZCatalogSolrConnector(
       solr_core = self.getConfProperty('solr.core', self.getAbsoluteHome().id)
       url = '%s/%s/select'%(solr_url, solr_core)
       url = self.url_append_params(url, p, sep='&')
-      result = self.http_import(url, method='GET')
-      result = standard.re_sub('name="(.*?)_[ist]"', 'name="\\1"', result)
+      result = standard.http_import(self, url, method='GET', debug=debug)
+      # result = standard.re_sub('name="(.*?)_[ist]"', 'name="\\1"', result)
       return result
 
 
     # --------------------------------------------------------------------------
     #  ZMSZCatalogSolrConnector.suggest_xml:
     # --------------------------------------------------------------------------
-    def suggest_xml(self, q, REQUEST=None, RESPONSE=None):
+    def suggest_xml(self, q, debug=0, REQUEST=None, RESPONSE=None):
       """ ZMSZCatalogSolrConnector.suggest_xml """
       # Check constraints.
       RESPONSE = REQUEST.RESPONSE
       content_type = 'text/xml; charset=utf-8'
+      debug = int(debug)
+      if debug:
+        content_type = 'text/plain; charset=utf-8'
       RESPONSE.setHeader('Content-Type', content_type)
       RESPONSE.setHeader('Cache-Control', 'no-cache')
       RESPONSE.setHeader('Pragma', 'no-cache')
@@ -119,11 +125,10 @@ class ZMSZCatalogSolrConnector(
       p = {}
       solr_url = self.getConfProperty('solr.url', 'http://localhost:8983/solr')
       solr_core = self.getConfProperty('solr.core', self.getAbsoluteHome().id)
-      SOLR_SUGGEST_SELECT = 'select?q=*:*&rows=0&facet=true&facet.field=text&facet.prefix=%s&facet.limit=5'
-      SOLR_SUGGEST_SUGGEST = 'suggest?q=%s'
-      solr_suggest = self.getConfProperty('solr.suggest', SOLR_SUGGEST_SELECT)%q
+      SOLR_SUGGEST = 'select?q=*:*&rows=0&facet=true&facet.field=text&facet.prefix=%s&facet.limit=5' # or 'suggest?q=%s'
+      solr_suggest = self.getConfProperty('solr.suggest', SOLR_SUGGEST)%(q)
       url = '%s/%s/%s'%(solr_url, solr_core, solr_suggest)
-      result = self.http_import(url, method='GET')
+      result = standard.http_import(self, url, method='GET',debug=debug)
       return result
 
 

--- a/Products/zms/ZMSZCatalogSolrConnector.py
+++ b/Products/zms/ZMSZCatalogSolrConnector.py
@@ -103,7 +103,7 @@ class ZMSZCatalogSolrConnector(
       url = '%s/%s/select'%(solr_url, solr_core)
       url = self.url_append_params(url, p, sep='&')
       result = standard.http_import(self, url, method='GET', debug=debug)
-      # result = standard.re_sub('name="(.*?)_[ist]"', 'name="\\1"', result)
+      result = standard.re_sub('name="(.*?)_[ist]"', 'name="\\1"', standard.pystr(result))
       return result
 
 

--- a/Products/zms/_deprecatedapi.py
+++ b/Products/zms/_deprecatedapi.py
@@ -472,9 +472,9 @@ class DeprecatedAPI(object):
     warn(self, 'getMimeTypeIconSrc', 'Products.zms.standard.getMimeTypeIconSrc')
     return standard.getMimeTypeIconSrc(mt)
     
-  def http_import(self, url, method='GET', auth=None, parse_qs=0, timeout=10, headers={'Accept':'*/*'}):
+  def http_import(self, url, method='GET', auth=None, parse_qs=0, timeout=10, headers={'Accept':'*/*'}, debug=0 ):
     warn(self, 'http_import', 'Products.zms.standard.http_import')
-    return standard.http_import( self, url, method=method, auth=auth, parse_qs=parse_qs, timeout=timeout, headers=headers)
+    return standard.http_import( self, url, method=method, auth=auth, parse_qs=parse_qs, timeout=timeout, headers=headers, debug=int(debug) )
 
   def getLangFmtDate(self, t, lang=None, fmt_str='SHORTDATETIME_FMT'):
     warn(self, 'getLangFmtDate', 'Products.zms.standard.getLangFmtDate')

--- a/Products/zms/plugins/www/zmi.core.css
+++ b/Products/zms/plugins/www/zmi.core.css
@@ -1900,6 +1900,11 @@ body.browse_iframe .toggle {
 .zmi .modal .modal-dialog > .modal-content > .modal-body {
 	overflow-x: auto;
 }
+.zmi.zcatalog.config .modal#solr_query .modal-dialog > .modal-content > .modal-body,
+.zmi.zcatalog.config .modal#solr_suggest .modal-dialog > .modal-content > .modal-body {
+	overflow-x: visible;
+	height: 80vh;
+}
 .zmi.users.config .modal .modal-dialog > .modal-content > .modal-body form {
 	min-height:42vh;
 }

--- a/Products/zms/plugins/www/zmi.core.css
+++ b/Products/zms/plugins/www/zmi.core.css
@@ -1900,8 +1900,7 @@ body.browse_iframe .toggle {
 .zmi .modal .modal-dialog > .modal-content > .modal-body {
 	overflow-x: auto;
 }
-.zmi.zcatalog.config .modal#solr_query .modal-dialog > .modal-content > .modal-body,
-.zmi.zcatalog.config .modal#solr_suggest .modal-dialog > .modal-content > .modal-body {
+.zmi.zcatalog.config .modal#connector_results .modal-dialog > .modal-content > .modal-body {
 	overflow-x: visible;
 	height: 80vh;
 }

--- a/Products/zms/standard.py
+++ b/Products/zms/standard.py
@@ -891,7 +891,7 @@ def http_request(url, method='GET', **kwargs):
 
 
 security.declarePublic('http_import')
-def http_import(context, url, method='GET', auth=None, parse_qs=0, timeout=10, headers={'Accept':'*/*'}):
+def http_import(context, url, method='GET', auth=None, parse_qs=0, timeout=10, headers={'Accept':'*/*'}, debug=0 ):
   """
   Send Http-Request and return Response-Body.
   @param url: Remote-URL
@@ -906,6 +906,8 @@ def http_import(context, url, method='GET', auth=None, parse_qs=0, timeout=10, h
   @type timeout: C{int}, values in seconds
   @param headers: Request-Headers
   @type headers: C{dict}
+  @param debug: Debug Mode will ignores Status Code of Return
+  @type debug: C{int}, values are 0 or 1
   @return: Response-Body
   @rtype: C{str}
   """
@@ -967,11 +969,12 @@ def http_import(context, url, method='GET', auth=None, parse_qs=0, timeout=10, h
   message = response.reason
 
   #### get parameter from content
-  if reply_code >= 400 or reply_code >= 500:
+  debug = int(debug)
+  if (reply_code >= 400 or reply_code >= 500 ) and not debug:
     error = "[%i]: %s at %s [%s]"%(reply_code, message, url, method)
     writeError( context, "[http_import.error]: %s"%error)
     raise zExceptions.InternalError(error)
-  elif reply_code==200:
+  elif reply_code==200 or debug:
     # get content
     data = response.read()
     rtn = None
@@ -2461,7 +2464,7 @@ class initutil(object):
   def getConfProperty(self, key, default=None):
     return self.__attr_conf_dict__.get(key, default)
 
-  def http_import(self, url, method='GET', auth=None, parse_qs=0, timeout=10, headers={'Accept':'*/*'}):
-    return http_import( self, url, method=method, auth=auth, parse_qs=parse_qs, timeout=timeout, headers=headers)
+  def http_import(self, url, method='GET', auth=None, parse_qs=0, timeout=10, headers={'Accept':'*/*'}, debug=0 ):
+    return http_import( self, url, method=method, auth=auth, parse_qs=parse_qs, timeout=timeout, headers=headers, debug=int(debug))
 
 security.apply(globals())

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_bigpicture.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_bigpicture.zpt
@@ -90,10 +90,10 @@
 	$ZMI.registerReady(function(){
 		$('#toggle_menu').click( function() {
 			if ( $('#toggle_menu').hasClass('fa-times') ) {
-				$('ol#toc').hide();
+				$('ol#toc').hide('fast');
 				$('#toggle_menu').removeClass('fa-times').addClass('fa-bars');
 			} else {
-				$('ol#toc').show();
+				$('ol#toc').show('fast');
 				$('#toggle_menu').removeClass('fa-bars').addClass('fa-times');
 			}
 		});

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_bigpicture.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_bigpicture.zpt
@@ -13,7 +13,8 @@
 		metaObjs python:[here.getMetaobj(x) for x in metaObjIds]">
 	<legend class="navbar navbar-nav navbar-expand navbar-dark" 
 		tal:content="python:'BigPicture::LogicalView::%s'%packageId">the legend</legend>
-	<ol class="objlist form-control">
+	<i id="toggle_menu" title="Toggle Menu" class="fas fa-times"></i>
+	<ol id="toc" class="objlist">
 		<li tal:repeat="metaObj python:[x for x in metaObjs if x['package']==packageId]">
 			<tal:block tal:define="
 					oid python:metaObj.get('id','');
@@ -87,8 +88,24 @@
 
 <script>
 	$ZMI.registerReady(function(){
-		$('ol.objlist a').click( function() { 
-			$('ol.objlist a').removeClass('active');
+		$('#toggle_menu').click( function() {
+			if ( $('#toggle_menu').hasClass('fa-times') ) {
+				$('ol#toc').hide();
+				$('#toggle_menu').removeClass('fa-times').addClass('fa-bars');
+			} else {
+				$('ol#toc').show();
+				$('#toggle_menu').removeClass('fa-bars').addClass('fa-times');
+			}
+		});
+		$(window).scroll(function() { 
+			if($(window).scrollTop() > 42) {
+				$('#toc').addClass('scrolled');
+			} else {
+				$('#toc').removeClass('scrolled');
+			}
+		});
+		$('ol#toc a').click( function() { 
+			$('#toc a').removeClass('active');
 			$('.box').removeClass('focused');
 			$(this).addClass('active'); 
 			$($(this).attr('href')).addClass('focused');
@@ -98,12 +115,28 @@
 </script>
 
 <style>
-.zmi.bigpicture form.card legend {
+.zmi.bigpicture form.card legend,
+#toggle_menu  {
 	color:white;
 	background: #354f67;
-	padding-left:1rem;
+	padding:1rem;
 	height:42px;
-	margin-bottom: 1rem;
+}
+#toggle_menu {
+	position: fixed;
+	width: 42px;
+	top: 0;
+	right: 0;
+	cursor:pointer;
+	z-index:2;
+}
+@media (max-width: 767px) {
+	#toggle_menu {
+		display:none;
+	}
+	#toc {
+		display:block !important;
+	}
 }
 .box {
 	background-color:#CFC;
@@ -131,24 +164,25 @@ p.box_number {
 	padding: 0 .5rem;
 	text-align: right;
 }
-ol.objlist {
-	position: fixed;
-	overflow-y: scroll;
-	overflow-x: hidden;
-	top: 59px;
-	bottom: 59px;
-	right: 20px;
-	padding: .5em 3em;
-	background: #fcfcfc;
-	box-shadow: inset 0 2px 2px rgba(0,0,0,.075);
+#toc {
+	top: 42px;
+	padding: 1rem 2rem 1.25rem 3rem;
+	background: #e9ecef;
 	width: auto;
-	height: calc(100vh - 120px);
-	border: 1px solid #ccc;
-	border-radius: 4px;
+	height: fit-content;
+	z-index:1;
 }
-ol.objlist li {
-	font-size: smaller;
+#toc.scrolled {
+	top: 0;
+}
+#toc li {
 	line-height: 1.75;
+}
+@media (min-width: 768px) {
+	#toc {
+		position: fixed;
+		right: 0;
+	}
 }
 .box div {
 	padding:.15em .5em
@@ -183,7 +217,7 @@ ol.objlist li {
 	float:right;
 }
 .box .attr.subobject {
-	background-color:#DFD;
+	background-color:#354f6726;
 }
 .box .ref {
 	padding:2px;

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_bigpicture.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_bigpicture.zpt
@@ -19,7 +19,7 @@
 					oid python:metaObj.get('id','');
 					oname python:metaObj.get('name','');
 					odisplay python:oid!=oname and '({})'.format(oname) or ''">
-				<a tal:attributes="href python:'#%s'%(metaObj.get('id','')); title metaObj/name"
+				<a data-turbolinks="false" tal:attributes="href python:'#%s'%(metaObj.get('id','')); title metaObj/name"
 					tal:content="python:oid">the name</a>
 				<span tal:replace="odisplay"></span>
 			</tal:block>
@@ -31,16 +31,17 @@
 			<p class="box_number" tal:content="repeat/metaObj/number">1</p>
 			<div class="objtype" tal:content="metaObj/type" title="Object Type">the type</div>
 			<div class="objid">
+				<a title="Edit Model..." target="_blank" tal:attributes="href python:'manage_main?id=%s'%(metaObj['id'])">
 				<i tal:attributes="class python:zmscontext.zmi_icon(metaObj['id'])"></i>
-				<a title="Edit Model..." target="_blank" tal:attributes="href python:'manage_main?id=%s'%(metaObj['id'])" tal:content="metaObj/id">the id</a>
-				<span class="objname" title="Display Name">
-					= <tal:block 
-						tal:define="l python:request.get('manage_lang','ger');
-									n python:metaObj.get('name','');
-									nstr python:here.getZMILangStr(n,l);
-									tstr python:here.getZMILangStr('TYPE_%s'%(n.upper()),l);"
-						tal:content="python:[tstr,nstr][tstr=='TYPE_%s'%(n.upper())]">the name</tal:block>
+				<span class="objid" tal:content="metaObj/id">the id</span>
+				<span class="objname" title="Display Name"
+					tal:define="l python:request.get('manage_lang','ger');
+						n python:metaObj.get('name','');
+						nstr python:here.getZMILangStr(n,l);
+						tstr python:here.getZMILangStr('TYPE_%s'%(n.upper()),l);"
+					tal:content="python:' = %s'%([tstr,nstr][tstr=='TYPE_%s'%(n.upper())])">the name
 				</span>
+				</a>
 			</div>
 			<tal:block tal:repeat="metaObjAttrId python:here.getMetaobjAttrIds(metaObj['id'])">
 				<tal:block tal:define="global metaObjAttr python:here.getMetaobjAttr(metaObj['id'],metaObjAttrId)">
@@ -152,14 +153,16 @@ ol.objlist li {
 .box div {
 	padding:.15em .5em
 }
-.box .objid {
+.box > .objid {
 	border-bottom:1px solid #354f67;
 	text-align:center;
 }
-.box .objid a {
-	font-weight:bold;
+.box > .objid a {
 	color:black;
 	text-decoration:none;
+}
+.box > .objid a .objid {
+	font-weight:bold;
 }
 .box .objtype {
 	text-align:center;

--- a/Products/zms/zpt/ZMSZCatalogAdapter/manage_main.zpt
+++ b/Products/zms/zpt/ZMSZCatalogAdapter/manage_main.zpt
@@ -91,10 +91,10 @@
 					<div class="col-sm-10">
 
 						<tal:block tal:define="global
-								metaObjIds python:here.getMetaobjIds();
-								metaObjs python:[x for x in [here.getMetaobj(y) for y in metaObjIds] if x['id'] not in ['ZMS'] and x['type'] in ['ZMSPackage','ZMSDocument','ZMSObject','ZMSRecordSet']];
-								metaObjPackages python:here.sort_list(['']+[x['id'] for x in metaObjs if x['type']=='ZMSPackage']);
-								metaObjPackages2 python:[x.get('package') for x in metaObjs if x.get('package') not in metaObjPackages]">
+							metaObjIds python:here.getMetaobjIds();
+							metaObjs python:[x for x in [here.getMetaobj(y) for y in metaObjIds] if x['id'] not in ['ZMS'] and x['type'] in ['ZMSPackage','ZMSDocument','ZMSObject','ZMSRecordSet']];
+							metaObjPackages python:here.sort_list(['']+[x['id'] for x in metaObjs if x['type']=='ZMSPackage']);
+							metaObjPackages2 python:[x.get('package') for x in metaObjs if x.get('package') not in metaObjPackages]">
 
 							<table class="table table-sm">
 								<colgroup>
@@ -198,27 +198,27 @@
 function toggleMetaobj() {
 	var selected = {};
 	$("table#indexes input:checked").each(function() {
-			var k = $(this).val();
-			selected[k] = {
-				type:$('input[name="type_'+k+'"]').val(),
-				boost:$('input[name="boost_'+k+'"]').val()};
-		});
+		var k = $(this).val();
+		selected[k] = {
+			type:$('input[name="type_'+k+'"]').val(),
+			boost:$('input[name="boost_'+k+'"]').val()};
+	});
 	var metaObjAttrs = {};
 	$("form input[name='ids:list']:checked").each(function() {
-			if(!$(this).prop("disabled")) {
-				var dataAttrs = $(this).attr("data-attrs").split(",");
-				for (var i = 0; i < dataAttrs.length; i++) {
-					var dataAttr = dataAttrs[i];
-					var metaObjAttr = {
-								id:dataAttr.substr(0,dataAttr.indexOf("(")),
-								type:dataAttr.substr(dataAttr.indexOf("(")+1,dataAttr.indexOf(")")-(dataAttr.indexOf("(")+1))
-							};
-					if (typeof metaObjAttrs[metaObjAttr.id] == 'undefined') {
-						metaObjAttrs[metaObjAttr.id] = metaObjAttr;
-					}
+		if(!$(this).prop("disabled")) {
+			var dataAttrs = $(this).attr("data-attrs").split(",");
+			for (var i = 0; i < dataAttrs.length; i++) {
+				var dataAttr = dataAttrs[i];
+				var metaObjAttr = {
+					id:dataAttr.substr(0,dataAttr.indexOf("(")),
+					type:dataAttr.substr(dataAttr.indexOf("(")+1,dataAttr.indexOf(")")-(dataAttr.indexOf("(")+1))
+				};
+				if (typeof metaObjAttrs[metaObjAttr.id] == 'undefined') {
+					metaObjAttrs[metaObjAttr.id] = metaObjAttr;
 				}
 			}
-		});
+		}
+	});
 	$("table#indexes tr").remove();
 	var metaObjAttrIds = [];
 	for (var metaObjAttrId in metaObjAttrs) {
@@ -235,90 +235,88 @@ function toggleMetaobj() {
 			boost = parseFloat(selected[metaObjAttrId].boost);
 		}
 		$("table#indexes").append(''
-				+ '<'+'tr>'
-					+ '<'+'td style="text-align:center;">'
-						+ '<'+'input type="checkbox" name="attr_ids:list" '+(preselected?' checked="checked"':'')+'value="'+metaObjAttrId+'" onclick="toggleMetaobj()"/>'
-					+ '<'+'/td>'
-					+ '<'+'td>'
-						+ '<'+'span>'+metaObjAttrId+' ('+type+')<'+'/span> '
-						+ '<'+'input type="hidden" name="type_'+metaObjAttrId+'" value="'+type+'"/> '
-					+ '<'+'/td>'
-					+ '<'+'td>'
-						+ '<'+'input class="form-control form-control-sm" type="number" step="0.1" title="Boost" name="boost_'+metaObjAttrId+'" value="'+boost.toFixed(1)+'"/> '
-					+ '<'+'/td>'
-				+ '<'+'/tr>');
+			+ '<'+'tr>'
+				+ '<'+'td style="text-align:center;">'
+					+ '<'+'input type="checkbox" name="attr_ids:list" '+(preselected?' checked="checked"':'')+'value="'+metaObjAttrId+'" onclick="toggleMetaobj()"/>'
+				+ '<'+'/td>'
+				+ '<'+'td>'
+					+ '<'+'span>'+metaObjAttrId+' ('+type+')<'+'/span> '
+					+ '<'+'input type="hidden" name="type_'+metaObjAttrId+'" value="'+type+'"/> '
+				+ '<'+'/td>'
+				+ '<'+'td>'
+					+ '<'+'input class="form-control form-control-sm" type="number" step="0.1" title="Boost" name="boost_'+metaObjAttrId+'" value="'+boost.toFixed(1)+'"/> '
+				+ '<'+'/td>'
+			+ '<'+'/tr>');
 	}
 	$("table#meta_types *.bg-info").removeClass("bg-info");
 	$("table#meta_types *.alert-success,table#indexes *.alert-success").removeClass("alert-success");
 	$("table#meta_types input:checked,table#indexes input:checked").each(function() {
-			var clazz = "alert-success";
-			if ($(this).prop("disabled")) {
-				clazz = "bg-info";
-			}
-			$("td,span",$(this).parents("tr")[0]).addClass(clazz);
-		});
+		var clazz = "alert-success";
+		if ($(this).prop("disabled")) {
+			clazz = "bg-info";
+		}
+		$("td,span",$(this).parents("tr")[0]).addClass(clazz);
+	});
 }
 
-function zmiExecuteCatalog(url)
-{
+function zmiExecuteCatalog(url) {
 	$(".zmi-sitemap .response").remove();
-	var $inputs = $(".zmi-sitemap input:checked");
+	var $inputs = $(".card.active .zmi-sitemap input:checked");
 	var i = 0;
 	var fn = function() {
-			if (i < $inputs.length) {
-				var $input = $($inputs[i]);
-				var uid = $input.val();
-				var data = {uid:uid};
-				var $a = $input.next("a");
-				$a.after(`<span class="response alert zmi-code"><i class="fas fa-spinner fa-spin"></i></span>`);
-				$.ajax({
-					url:url,
-					data:data,
-					error: function (xhr, ajaxOptions, thrownError) {
-							$a.next('.response').addClass('alert-danger').html('( '+thrownError+' )');
-							i++;
-							fn();
-						},
-					success:function(response) {
-							$a.next('.response').addClass('alert-success').html('( '+response+' )');
-							i++;
-							fn();
-						}
-					});
-			}
+		if (i < $inputs.length) {
+			var $input = $($inputs[i]);
+			var uid = $input.val();
+			var data = {uid:uid};
+			var $a = $input.next("a");
+			$a.after(`<span class="response alert zmi-code"><i class="fas fa-spinner fa-spin"></i></span>`);
+			$.ajax({
+				url:url,
+				data:data,
+				error: function (xhr, ajaxOptions, thrownError) {
+					$a.next('.response').addClass('alert-danger').html('( '+thrownError+' )');
+					i++;
+					fn();
+				},
+				success:function(response) {
+					$a.next('.response').addClass('alert-success').html('( '+response+' )');
+					i++;
+					fn();
+				}
+			});
 		}
+	}
 	fn();
 	return false;
 }
 
-function zmiReindexCatalog() 
-{
+function zmiReindexCatalog() {
 	$(".zmi-sitemap .response").remove();
-	var $inputs = $(".zmi-sitemap input:checked");
+	var $inputs = $(".card.active .zmi-sitemap input:checked");
 	var i = 0;
 	var fn = function() {
-			if (i < $inputs.length) {
-				var $input = $($inputs[i]);
-				var uid = $input.val();
-				var data = {uid:uid};
-				var $a = $input.next("a");
-				$a.after(`<span class="response alert zmi-code"><i class="fas fa-spinner fa-spin"></i></span>`);
-				$.ajax({
-					url:"manage_reindex",
-					data:data,
-					error: function (xhr, ajaxOptions, thrownError) {
-							$a.next('.response').addClass('alert-danger').html('( '+thrownError+' )');
-							i++;
-							fn();
-						},
-					success:function(response) {
-							$a.next('.response').addClass('alert-success').html('( '+response+' )');
-							i++;
-							fn();
-						}
-					});
-			}
+		if (i < $inputs.length) {
+			var $input = $($inputs[i]);
+			var uid = $input.val();
+			var data = {uid:uid};
+			var $a = $input.next("a");
+			$a.after(`<span class="response alert zmi-code"><i class="fas fa-spinner fa-spin"></i></span>`);
+			$.ajax({
+				url:"manage_reindex",
+				data:data,
+				error: function (xhr, ajaxOptions, thrownError) {
+					$a.next('.response').addClass('alert-danger').html('( '+thrownError+' )');
+					i++;
+					fn();
+				},
+				success:function(response) {
+					$a.next('.response').addClass('alert-success').html('( '+response+' )');
+					i++;
+					fn();
+				}
+			});
 		}
+	}
 	fn();
 	return false;
 }
@@ -329,47 +327,47 @@ function zmiSelectObject() {
 
 $(function() {
 
-		// select tab
-		$('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-				$("input[name=tab]:hidden").val($(e.target).text().trim());
-			});
+	// select tab
+	$('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
+			$("input[name=tab]:hidden").val($(e.target).text().trim());
+		});
 
-		var ids = $('#getIds').val().split(",");
-		for (var i = 0; i < ids.length; i++) {
-			$('input[name="ids:list"][value="'+ids[i]+'"]').prop("checked",true);
+	var ids = $('#getIds').val().split(",");
+	for (var i = 0; i < ids.length; i++) {
+		$('input[name="ids:list"][value="'+ids[i]+'"]').prop("checked",true);
+	}
+	toggleMetaobj();
+	var attrs = eval("("+$("#getAttrs").html()+")");
+	for (var k in attrs) {
+		$('input[name="attr_ids:list"][value="'+k+'"]').prop("checked",true);
+		$('input[name="type_'+k+'"]').val(attrs[k].type);
+		$('input[name="boost_'+k+'"]').val(attrs[k].boost);
+	}
+	toggleMetaobj();
+
+	// Sitemap
+	var href = $ZMI.getPhysicalPath();
+	$ZMI.objectTree.init(".zmi-sitemap",href,{
+		'params':{meta_types:'ZMS'},
+		'init.href':'ajaxGetNode',
+		'init.callback':function() {
+			var fn = function() {
+				var $toggle = $(".zmi-sitemap .toggle[title='+']");
+				if ($toggle.length > 0) {
+					$ZMI.objectTree.toggleClick($($toggle[0]),fn);
+				} else {
+					$(".zmi-sitemap ."+$ZMI.icon_clazz("icon-home").replace(/\s/gi,'.')).each(function() {
+						var $a = $(this).parent("a");
+						var uid = $a.attr('data-uid');
+						$a.before('<input name="home_ids:list" type="checkbox" title="'+uid+'" value="'+uid+'" checked="checked"> ');
+					});
+				}
+			}
+			fn();
 		}
-		toggleMetaobj();
-		var attrs = eval("("+$("#getAttrs").html()+")");
-		for (var k in attrs) {
-			$('input[name="attr_ids:list"][value="'+k+'"]').prop("checked",true);
-			$('input[name="type_'+k+'"]').val(attrs[k].type);
-			$('input[name="boost_'+k+'"]').val(attrs[k].boost);
-		}
-		toggleMetaobj();
-
-		// Sitemap
-		var href = $ZMI.getPhysicalPath();
-		$ZMI.objectTree.init(".zmi-sitemap",href,{
-				'params':{meta_types:'ZMS'},
-				'init.href':'ajaxGetNode',
-				'init.callback':function() {
-					var fn = function() {
-						var $toggle = $(".zmi-sitemap .toggle[title='+']");
-						if ($toggle.length > 0) {
-							$ZMI.objectTree.toggleClick($($toggle[0]),fn);
-						}
-						else {
-							$(".zmi-sitemap ."+$ZMI.icon_clazz("icon-home").replace(/\s/gi,'.')).each(function() {
-									var $a = $(this).parent("a");
-									var uid = $a.attr('data-uid');
-									$a.before('<input name="home_ids:list" type="checkbox" title="'+uid+'" value="'+uid+'" checked="checked"> ');
-								});
-						}
-					}
-					fn();
-				}});
-
 	});
+
+});
 </script>
 
 <footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>

--- a/Products/zms/zpt/ZMSZCatalogAdapter/manage_main.zpt
+++ b/Products/zms/zpt/ZMSZCatalogAdapter/manage_main.zpt
@@ -86,12 +86,10 @@
 						<input type="checkbox" value="1" id="catalog_awareness_active" name="catalog_awareness_active:int" tal:attributes="checked python:['','checked'][int(here.getConfProperty('ZMS.CatalogAwareness.active',1)==1)]"/>
 					</div><!-- .col-sm-10 -->
 				</div><!-- .form-group -->
-				<div class="form-group row">
+				<div class="form-group row align-items-baseline">
 					<label class="col-sm-2 control-label" for="catalog_model"><span>Model</span></label>
-					<div class="col-sm-10">
-
-						<tal:block tal:define="global
-							metaObjIds python:here.getMetaobjIds();
+					<div class="col-sm-10"
+						tal:define="metaObjIds python:here.getMetaobjIds();
 							metaObjs python:[x for x in [here.getMetaobj(y) for y in metaObjIds] if x['id'] not in ['ZMS'] and x['type'] in ['ZMSPackage','ZMSDocument','ZMSObject','ZMSRecordSet']];
 							metaObjPackages python:here.sort_list(['']+[x['id'] for x in metaObjs if x['type']=='ZMSPackage']);
 							metaObjPackages2 python:[x.get('package') for x in metaObjs if x.get('package') not in metaObjPackages]">
@@ -111,18 +109,20 @@
 									<tr>
 										<td class="p-0">
 
-											<table class="table table-sm" id="meta_types">
+											<table class="table table-sm table-borderless" id="meta_types">
 												<tbody>
 													<tal:block tal:repeat="metaObjPackage python:here.sort_list(metaObjPackages+metaObjPackages2)">
 														<tal:block tal:condition="python:metaObjPackage in metaObjPackages">
 															<tr tal:condition="python:len([x for x in metaObjs if x.get('package')==metaObjPackage])>0" tal:define="global metaObj python:here.getMetaobj(metaObjPackage)">
 																<td colspan="2">
 																	<tal:block tal:condition="python:metaObjPackage">
-																		<i class="fas fa-briefcase"></i>
+																		<a href="#" class="mr-1" target="_blank"
+																			tal:attributes="href python:'../metaobj_manager/manage_bigpicture?lang=%s&id=%s'%(request.get('lang','ger'),metaObjPackage)"
+																		><i class="fas fa-briefcase"></i></a>
 																		<strong tal:content="metaObjPackage">the id</strong>
 																	</tal:block>
 																	<tal:block tal:condition="python:not metaObjPackage">
-																		<i class="fas fa-briefcase"></i>
+																		<i class="fas fa-briefcase mr-1"></i>
 																		<strong>[default package]</strong>
 																	</tal:block>
 																</td>
@@ -158,15 +158,14 @@
 											</table>
 
 										</td>
-										<td class="p-0 border-left">
-											<table class="table table-sm" id="indexes">
+										<td class="p-0">
+											<table class="table table-sm table-borderless" id="indexes">
+												<!-- filled by script -->
 											</table>
 										</td>
 									</tr>
 								</tbody>
 							</table>
-
-						</tal:block>
 
 					</div><!-- .col-sm-10 -->
 				</div><!-- .form-group -->
@@ -195,6 +194,7 @@
 </div><!-- #zmi-tab -->
 
 <script>
+//<!--
 function toggleMetaobj() {
 	var selected = {};
 	$("table#indexes input:checked").each(function() {
@@ -368,6 +368,7 @@ $(function() {
 	});
 
 });
+//-->
 </script>
 
 <footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>

--- a/Products/zms/zpt/ZMSZCatalogAdapter/manage_main.zpt
+++ b/Products/zms/zpt/ZMSZCatalogAdapter/manage_main.zpt
@@ -116,7 +116,7 @@
 															<tr tal:condition="python:len([x for x in metaObjs if x.get('package')==metaObjPackage])>0" tal:define="global metaObj python:here.getMetaobj(metaObjPackage)">
 																<td colspan="2">
 																	<tal:block tal:condition="python:metaObjPackage">
-																		<a href="#" class="mr-1" target="_blank"
+																		<a href="#" class="mr-1" target="_blank" title="Show Content Package Details (Big Picture)"
 																			tal:attributes="href python:'../metaobj_manager/manage_bigpicture?lang=%s&id=%s'%(request.get('lang','ger'),metaObjPackage)"
 																		><i class="fas fa-briefcase"></i></a>
 																		<strong tal:content="metaObjPackage">the id</strong>

--- a/Products/zms/zpt/ZMSZCatalogAdapter/manage_solr_connector.zpt
+++ b/Products/zms/zpt/ZMSZCatalogAdapter/manage_solr_connector.zpt
@@ -1,15 +1,19 @@
 <tal:block tal:define="zmscontext python:here.getSelf(); standard modules/Products.zms/standard;">
 
-<div class="help" data-for="qsuggest">
+<div class="help" data-for="solr_qsuggest">
 	<div class="well">
-		<p>The ZMS configuration property <code>solr.suggest</code> is set for assembling the requesting URL.</p>
 		<p>
-			<b>A. Suggest with Facets (default):</b>
+			ZMS configuration property <code>solr.suggest</code> is required for assembling the backend-requesting SOLR-URL: 
+			the expression must contain exactly one string template <code>%s</code> for the given search string. 
+			<br/>
+			<br/>
+			<i>A. Suggest with Facets (default):</i>
 			<br/>
 			<code>select?q=*:*&amp;rows=0&amp;facet=true&amp;facet.field=text&amp;facet.prefix=%s&amp;facet.limit=5</code>
 			<br/>
 			<br/>
-			<b>B. Suggester - A Flexible "autocomplete" Component:</b><br/>
+			<i>B. Suggester - A Flexible "autocomplete" Component:</i>
+			<br/>
 			<code>suggest?q=%s</code>
 			<br/>
 			<br/>
@@ -18,13 +22,13 @@
 	</div>
 </div>
 
-<div id="ZCatalogSolrConnector"  tal:define="
+<div id="ZCatalogSolrConnector" 
+	tal:define="
 		solr_url python:here.getConfProperty('solr.url','http://localhost:8983/solr');
 		solr_core python:here.getConfProperty('solr.core',here.getAbsoluteHome().id);
 		admin_url python:'%s/#/%s/core-overview'%(solr_url,solr_core);
 		select_url python:'%s/%s/select'%(solr_url,solr_core);
-		suggest_url python:'%s/%s/suggest'%(solr_url,solr_core);
-		">
+		suggest_url python:'%s/%s/suggest'%(solr_url,solr_core);">
 	<div class="form-group row">
 		<label class="col-sm-2 control-label" for="solr_url"><span>URL</span></label>
 		<div class="col-sm-10"><input type="text" class="form-control" name="solr_url" tal:attributes="value solr_url"></div>
@@ -34,7 +38,7 @@
 		<div class="col-sm-10"><input type="text" class="form-control" name="solr_core" tal:attributes="value solr_core"></div>
 	</div>
 	<div class="form-group row">
-		<label class="col-sm-2 control-label" for="admin_url"><span>Admin</span></label>
+		<label class="col-sm-2 control-label" for="admin_url"><span>Admin-GUI</span></label>
 		<div class="col-sm-10"><a tal:attributes="href admin_url" target="_blank" tal:content="admin_url">the solr-admin</a></div>
 	</div>
 	<div class="form-group row">
@@ -46,28 +50,28 @@
 		</div><!-- .col-sm-10 -->
 	</div><!-- .form-group -->
 	<div class="form-group row">
-		<label class="col-sm-2 control-label" for="qsearch"><span>Query</span></label>
+		<label class="col-sm-2 control-label" for="solr_qsearch"><span>Query</span></label>
 		<div class="col-sm-10">
 			<div class="input-group">
-				<input type="text" class="form-control" id="qsearch" title="Enter Search Term..." 
+				<input type="text" class="form-control" id="solr_qsearch" title="Enter Search Term..." 
 					placeholder="*" name="q" tal:attributes="value python:request.get('q','*')">
 				<div class="input-group-append">
 					<button class="btn btn-primary" 
-						tal:attributes="onclick python:'javascript:$ZMI.iframe(\'%s/search_xml\',{q:$(\'#ZCatalogSolrConnector #qsearch\').val(),debug:1},{iframe:true,title:\'Solr: Select\',id:\'solr_query\'});;return false'%(here.absolute_url())"
+						tal:attributes="onclick python:'javascript:$ZMI.iframe(\'%s/search_xml\',{q:$(\'#ZCatalogSolrConnector #solr_qsearch\').val(),debug:1},{iframe:true,title:\'Solr: Select <kbd style=\042cursor:pointer\042 class=\042badge-primary\042 title=\042Reopen as XML\042 onclick=\042open_as_xml()\042><i class=\042fas fa-external-link-square-alt\042></i> xml</kbd>\',id:\'connector_results\'});;return false'%(here.absolute_url())"
 						><i class="fas fa-external-link-alt"></i></button>
 				</div>
 			</div>
 		</div>
 	</div>
 	<div class="form-group row">
-		<label class="col-sm-2 control-label" for="qsuggest"><span>Suggest</span></label>
+		<label class="col-sm-2 control-label" for="solr_qsuggest"><span>Suggest</span></label>
 		<div class="col-sm-10">
 			<div class="input-group">
-				<input type="text" class="form-control" id="qsuggest" title="Enter Prefix of Facet Name" 
+				<input type="text" class="form-control" id="solr_qsuggest" title="Enter Prefix of Facet Name" 
 					placeholder="*" name="q" tal:attributes="value python:request.get('q','*')" />
 				<div class="input-group-append">
 					<button class="btn btn-primary" 
-						tal:attributes="onclick python:'javascript:$ZMI.iframe(\'%s/suggest_xml\',{q:$(\'#ZCatalogSolrConnector #qsuggest\').val(),debug:1},{iframe:true,title:\'Solr: Suggest\',id:\'solr_suggest\'});;return false'%(here.absolute_url())"
+						tal:attributes="onclick python:'javascript:$ZMI.iframe(\'%s/suggest_xml\',{q:$(\'#ZCatalogSolrConnector #solr_qsuggest\').val(),debug:1},{iframe:true,title:\'Solr: Suggest <kbd style=\042cursor:pointer\042 class=\042badge-primary\042 title=\042Reopen as XML\042 onclick=\042open_as_xml()\042><i class=\042fas fa-external-link-square-alt\042></i> xml</kbd>\',id:\'connector_results\'});;return false'%(here.absolute_url())"
 						><i class="fas fa-external-link-alt"></i></button>
 				</div>
 			</div>
@@ -105,5 +109,11 @@
 		</div><!-- .col-sm-10 -->
 	</div><!-- .form-group -->
 </div>
-
+<script>
+//<!--
+	function open_as_xml() {
+		window.open($('iframe').attr('src').replace('&debug=1',''), name='_blank');
+	}
+//-->
+</script>
 </tal:block>

--- a/Products/zms/zpt/ZMSZCatalogAdapter/manage_solr_connector.zpt
+++ b/Products/zms/zpt/ZMSZCatalogAdapter/manage_solr_connector.zpt
@@ -2,14 +2,18 @@
 
 <div class="help" data-for="qsuggest">
 	<div class="well">
-		<h4>Suggest with facets</h4>
+		<p>The ZMS configuration property <code>solr.suggest</code> is set for assembling the requesting URL.</p>
 		<p>
-			<code>solr.suggest='select?q=*:*&amp;rows=0&amp;facet=true&amp;facet.field=text&amp;facet.prefix=%s&amp;facet.limit=5'</code>
-		</p>
-		<h4>Suggester - a flexible "autocomplete" component.</h4>
-		<p>
-			<code>solr.suggest='suggest?q=%s'</code><br/>
-			@see <a href="http://wiki.apache.org/solr/Suggester/" target="_blank">http://wiki.apache.org/solr/Suggester/</a>
+			<b>A. Suggest with Facets (default):</b>
+			<br/>
+			<code>select?q=*:*&amp;rows=0&amp;facet=true&amp;facet.field=text&amp;facet.prefix=%s&amp;facet.limit=5</code>
+			<br/>
+			<br/>
+			<b>B. Suggester - A Flexible "autocomplete" Component:</b><br/>
+			<code>suggest?q=%s</code>
+			<br/>
+			<br/>
+			<em>@see</em> <a href="http://wiki.apache.org/solr/Suggester/" target="_blank">http://wiki.apache.org/solr/Suggester/</a>
 		</p>
 	</div>
 </div>
@@ -45,10 +49,11 @@
 		<label class="col-sm-2 control-label" for="qsearch"><span>Query</span></label>
 		<div class="col-sm-10">
 			<div class="input-group">
-				<input type="text" class="form-control" id="qsearch" name="q" tal:attributes="value python:request.get('q','*')">
+				<input type="text" class="form-control" id="qsearch" title="Enter Search Term..." 
+					placeholder="*" name="q" tal:attributes="value python:request.get('q','*')">
 				<div class="input-group-append">
 					<button class="btn btn-primary" 
-						tal:attributes="onclick python:'javascript:$ZMI.iframe(\'%s/search_xml\',{q:$(\'#ZCatalogSolrConnector #qsearch\').val()},{iframe:true,title:\'Solr: Select\'});;return false'%(here.absolute_url())"
+						tal:attributes="onclick python:'javascript:$ZMI.iframe(\'%s/search_xml\',{q:$(\'#ZCatalogSolrConnector #qsearch\').val(),debug:1},{iframe:true,title:\'Solr: Select\',id:\'solr_query\'});;return false'%(here.absolute_url())"
 						><i class="fas fa-external-link-alt"></i></button>
 				</div>
 			</div>
@@ -58,10 +63,11 @@
 		<label class="col-sm-2 control-label" for="qsuggest"><span>Suggest</span></label>
 		<div class="col-sm-10">
 			<div class="input-group">
-				<input type="text" class="form-control" id="qsuggest" name="q" tal:attributes="value python:request.get('q','*')">
+				<input type="text" class="form-control" id="qsuggest" title="Enter Prefix of Facet Name" 
+					placeholder="*" name="q" tal:attributes="value python:request.get('q','*')" />
 				<div class="input-group-append">
 					<button class="btn btn-primary" 
-						tal:attributes="onclick python:'javascript:$ZMI.iframe(\'%s/suggest_xml\',{q:$(\'#ZCatalogSolrConnector #qsuggest\').val()},{iframe:true,title:\'Solr: Suggest\'});;return false'%(here.absolute_url())"
+						tal:attributes="onclick python:'javascript:$ZMI.iframe(\'%s/suggest_xml\',{q:$(\'#ZCatalogSolrConnector #qsuggest\').val(),debug:1},{iframe:true,title:\'Solr: Suggest\',id:\'solr_suggest\'});;return false'%(here.absolute_url())"
 						><i class="fas fa-external-link-alt"></i></button>
 				</div>
 			</div>

--- a/Products/zms/zpt/ZMSZCatalogAdapter/manage_solr_connector.zpt
+++ b/Products/zms/zpt/ZMSZCatalogAdapter/manage_solr_connector.zpt
@@ -84,7 +84,7 @@
 				<div class="zmi-sitemap-expand" onclick="$('.zmi-sitemap').toggleClass('full');$('.zmi-sitemap-expand i').toggleClass('fa-expand-arrows-alt fa-compress-arrows-alt')">
 					<i class="fas fa-expand-arrows-alt" title="Seitenanfang"></i>
 				</div>
-				<div class="zmi-sitemap">
+				<div class="zmi-sitemap mb-0">
 				</div><!-- .zmi-sitemap -->
 			</div>
 		</div><!-- .col-sm-10 -->

--- a/Products/zms/zpt/ZMSZCatalogAdapter/manage_solr_connector.zpt
+++ b/Products/zms/zpt/ZMSZCatalogAdapter/manage_solr_connector.zpt
@@ -57,7 +57,7 @@
 					placeholder="*" name="q" tal:attributes="value python:request.get('q','*')">
 				<div class="input-group-append">
 					<button class="btn btn-primary" 
-						tal:attributes="onclick python:'javascript:$ZMI.iframe(\'%s/search_xml\',{q:$(\'#ZCatalogSolrConnector #solr_qsearch\').val(),debug:1},{iframe:true,title:\'Solr: Select <kbd style=\042cursor:pointer\042 class=\042badge-primary\042 title=\042Reopen as XML\042 onclick=\042open_as_xml()\042><i class=\042fas fa-external-link-square-alt\042></i> xml</kbd>\',id:\'connector_results\'});;return false'%(here.absolute_url())"
+						tal:attributes="onclick python:'javascript:$ZMI.iframe(\'%s/search_xml\',{q:$(\'#ZCatalogSolrConnector #solr_qsearch\').val(),debug:1},{iframe:true,title:\'Solr: Query <kbd style=\042cursor:pointer\042 class=\042badge-primary\042 title=\042Reopen as XML\042 onclick=\042open_as_xml()\042><i class=\042fas fa-external-link-square-alt\042></i> xml</kbd>\',id:\'connector_results\'});;return false'%(here.absolute_url())"
 						><i class="fas fa-external-link-alt"></i></button>
 				</div>
 			</div>

--- a/Products/zms/zpt/ZMSZCatalogAdapter/manage_zcatalog_connector.zpt
+++ b/Products/zms/zpt/ZMSZCatalogAdapter/manage_zcatalog_connector.zpt
@@ -1,6 +1,6 @@
 <tal:block tal:define="zmscontext python:here.getSelf();">
 	<div id="ZCatalogConnector" tal:define="zcatalogs python:here.getDocumentElement().objectValues(['ZCatalog'])" tal:condition="python:len(zcatalogs)>0">
-		<div class="form-group row ">
+		<div class="form-group row align-items-baseline">
 			<label class="col-sm-2 control-label" for="zcatalog_objectIds"><span>ZCatalogs</span></label>
 			<div class="col-sm-10">
 				<div tal:repeat="si zcatalogs">
@@ -53,7 +53,7 @@
 				<div class="zmi-sitemap-expand" onclick="$('.zmi-sitemap').toggleClass('full');$('.zmi-sitemap-expand i').toggleClass('fa-expand-arrows-alt fa-compress-arrows-alt')">
 					<i class="fas fa-expand-arrows-alt" title="Seitenanfang"></i>
 				</div>
-				<div class="zmi-sitemap">
+				<div class="zmi-sitemap mb-0">
 				</div><!-- .zmi-sitemap -->
 			</div>
 		</div><!-- .col-sm-10 -->

--- a/Products/zms/zpt/ZMSZCatalogAdapter/manage_zcatalog_connector.zpt
+++ b/Products/zms/zpt/ZMSZCatalogAdapter/manage_zcatalog_connector.zpt
@@ -26,7 +26,7 @@
 					<input type="text" class="form-control" id="zcatalog_qsearch" name="q" tal:attributes="value python:request.get('q','*')">
 					<div class="input-group-append">
 						<button class="btn btn-primary" 
-							tal:attributes="onclick python:'javascript:$ZMI.iframe(\'%s/search_xml\',{q:$(\'#ZCatalogConnector #zcatalog_qsearch\').val(),debug:1},{iframe:true,title:\'ZCatalog: Select <kbd style=\042cursor:pointer\042 class=\042badge-primary\042 title=\042Reopen as XML\042 onclick=\042open_as_xml()\042><i class=\042fas fa-external-link-square-alt\042></i> xml</kbd>\',id:\'connector_results\'});;return false'%(here.absolute_url())"
+							tal:attributes="onclick python:'javascript:$ZMI.iframe(\'%s/search_xml\',{q:$(\'#ZCatalogConnector #zcatalog_qsearch\').val(),debug:1},{iframe:true,title:\'ZCatalog: Query <kbd style=\042cursor:pointer\042 class=\042badge-primary\042 title=\042Reopen as XML\042 onclick=\042open_as_xml()\042><i class=\042fas fa-external-link-square-alt\042></i> xml</kbd>\',id:\'connector_results\'});;return false'%(here.absolute_url())"
 							><i class="fas fa-external-link-alt"></i></button>
 					</div>
 				</div>

--- a/Products/zms/zpt/ZMSZCatalogAdapter/manage_zcatalog_connector.zpt
+++ b/Products/zms/zpt/ZMSZCatalogAdapter/manage_zcatalog_connector.zpt
@@ -1,6 +1,6 @@
 <tal:block tal:define="zmscontext python:here.getSelf();">
 	<div id="ZCatalogConnector" tal:define="zcatalogs python:here.getDocumentElement().objectValues(['ZCatalog'])" tal:condition="python:len(zcatalogs)>0">
-		<div class="form-group row">
+		<div class="form-group row ">
 			<label class="col-sm-2 control-label" for="zcatalog_objectIds"><span>ZCatalogs</span></label>
 			<div class="col-sm-10">
 				<div tal:repeat="si zcatalogs">
@@ -20,26 +20,26 @@
 			</div>
 		</div><!-- .form-group -->
 		<div class="form-group row">
-			<label class="col-sm-2 control-label" for="qsearch"><span>Query</span></label>
+			<label class="col-sm-2 control-label" for="zcatalog_qsearch"><span>Query</span></label>
 			<div class="col-sm-10">
 				<div class="input-group">
-					<input type="text" class="form-control" id="qsearch" name="q" tal:attributes="value python:request.get('q','*')">
+					<input type="text" class="form-control" id="zcatalog_qsearch" name="q" tal:attributes="value python:request.get('q','*')">
 					<div class="input-group-append">
 						<button class="btn btn-primary" 
-							tal:attributes="onclick python:'javascript:$ZMI.iframe(\'%s/search_xml\',{q:$(\'#ZCatalogConnector #qsearch\').val()},{iframe:true,title:\'ZCatalog: Select\'});;return false'%(here.absolute_url())"
+							tal:attributes="onclick python:'javascript:$ZMI.iframe(\'%s/search_xml\',{q:$(\'#ZCatalogConnector #zcatalog_qsearch\').val(),debug:1},{iframe:true,title:\'ZCatalog: Select <kbd style=\042cursor:pointer\042 class=\042badge-primary\042 title=\042Reopen as XML\042 onclick=\042open_as_xml()\042><i class=\042fas fa-external-link-square-alt\042></i> xml</kbd>\',id:\'connector_results\'});;return false'%(here.absolute_url())"
 							><i class="fas fa-external-link-alt"></i></button>
 					</div>
 				</div>
 			</div>
 		</div><!-- .form-group -->
 		<div class="form-group row">
-			<label class="col-sm-2 control-label" for="qsuggest"><span>Suggest</span></label>
+			<label class="col-sm-2 control-label" for="zcatalog_qsuggest"><span>Suggest</span></label>
 			<div class="col-sm-10">
 				<div class="input-group">
-					<input type="text" class="form-control" id="qsuggest" name="q" tal:attributes="value python:request.get('q','*')">
+					<input type="text" class="form-control" id="zcatalog_qsuggest" name="q" tal:attributes="value python:request.get('q','*')">
 					<div class="input-group-append">
 						<button class="btn btn-primary"
-							tal:attributes="onclick python:'javascript:$ZMI.iframe(\'%s/suggest_xml\',{q:$(\'#ZCatalogConnector #qsuggest\').val()},{iframe:true,title:\'ZCatalog: Suggest\'});;return false'%(here.absolute_url())"
+							tal:attributes="onclick python:'javascript:$ZMI.iframe(\'%s/suggest_xml\',{q:$(\'#ZCatalogConnector #zcatalog_qsuggest\').val(),debug:1},{iframe:true,title:\'ZCatalog: Suggest <kbd style=\042cursor:pointer\042 class=\042badge-primary\042 title=\042Reopen as XML\042 onclick=\042open_as_xml()\042><i class=\042fas fa-external-link-square-alt\042></i> xml</kbd>\',id:\'connector_results\'});;return false'%(here.absolute_url())"
 							><i class="fas fa-external-link-alt"></i></button>
 					</div>
 				</div>
@@ -70,3 +70,10 @@
 		</div><!-- .col-sm-10 -->
 	</div><!-- .form-group -->
 </tal:block>
+<script>
+//<!--
+	function open_as_xml() {
+		window.open($('iframe').attr('src').replace('&debug=1',''), name='_blank');
+	}
+//-->
+</script>


### PR DESCRIPTION
hi @zmsdev,
when adding the SOLR Connector GUI, all the reindexing/recreating actions are executed in parallel; so there was always a long latency until the SOLR indexing started. I fixed it by restricting it to the active card:

https://github.com/zms-publishing/ZMS/blob/4cff0490f7ec2491bd92daedb7c65929dc9c8a40/Products/zms/zpt/ZMSZCatalogAdapter/manage_main.zpt#L262-L264

Moreover the _query testing_ may deliver an unspecific error/404 and it was unclear where it comes from. That's why I introduced for ZMI a new debug-parameter to the function standard._http_import()_:

https://github.com/zms-publishing/ZMS/blob/4cff0490f7ec2491bd92daedb7c65929dc9c8a40/Products/zms/standard.py#L893-L895

If `debug==1` the http-response is not returned as xml but just as plain-text (because it may be other mime type like json) and in both functions 

1. ZMSZCatalogSolrConnector.search_xml
2. ZMSZCatalogSolrConnector.suggest_xml()

the http status code cases are ignored. Here is how it looks now:

![solr_connector](https://user-images.githubusercontent.com/29705216/184241122-8d70fc25-28b1-4c2c-981d-688bc23d9e50.gif)

Finally some whitespace war cleaned.