### PR TITLE
zmslog: catch FileNotFoundError

### DIFF
--- a/Products/zms/zmslog.py
+++ b/Products/zms/zmslog.py
@@ -22,6 +22,7 @@ import copy
 import logging
 import os
 import time
+import glob
 # Product Imports.
 from Products.zms import standard
 from Products.zms import ZMSItem
@@ -128,7 +129,20 @@ class ZMSLog(ZMSItem.ZMSItem):
     # --------------------------------------------------------------------------
     def tail_event_log(self, linesback=100, returnlist=True):
       filename = os.path.join(standard.getINSTANCE_HOME(),'var','log','event.log')
-      return _fileutil.tail_lines(filename,linesback,returnlist)
+      try:
+        return _fileutil.tail_lines(filename,linesback,returnlist)
+      except:
+        filename_prefix = os.path.join(standard.getINSTANCE_HOME(),'var','log','event')
+        filename_list = [f for f in glob.glob( r'' + filename_prefix + r'*.log')]
+        error_info = ['ERROR:']
+        error_info.append('Default event log file %s not found.'%(filename))
+        error_info.append('Please check zope.ini [handler_eventlog]')
+        if filename_list:
+          error_info.append('')
+          error_info.append('Following event log files are found:')
+          error_info.extend(filename_list)
+          error_info.append('HINT: If one of them is sym-linked as event.log, it will be showm.')
+        return error_info
 
 
 


### PR DESCRIPTION
Hi.
due to ZEO and a specific zope.ini configuration the default event.log file may not be found. I suggest, instead of returning an obscure FileNotFoundError of Zope,  to catch this (common) situation an give some detailed hints how to deal with it. 

![event_log](https://user-images.githubusercontent.com/29705216/185108331-fbbee758-1c78-4759-b595-3b9328144bcc.gif)

DISCUSSION:
If the remote develper is connected to a certain port in a ZEO environment and the event.logs are writte specifically for any port. it may be easy to symlink the corresponding event.log. if the file names are port-specific, in a production system its not clear which port ZEO is using and thus the log file name can not anticipated, In this scenario the zmslog can not be used in genereal.
