### PR TITLE
Fixed RTE img/file links

### DIFF
--- a/Products/zms/ZMSRepositoryManager.py
+++ b/Products/zms/ZMSRepositoryManager.py
@@ -299,7 +299,8 @@ class ZMSRepositoryManager(
                 if 'ob' in i:
                   del i['ob']
                 try:
-                  py.append('\t\t%s = %s'%(self.id_quote(i['id']), standard.str_json(i, encoding="utf-8", formatted=True, level=3, allow_booleans=False)))
+                  id_quoted = i['id'].startswith('_') and i['id'] or self.id_quote(i['id'])
+                  py.append('\t\t%s = %s'%(id_quoted, standard.str_json(i, encoding="utf-8", formatted=True, level=3, allow_booleans=False)))
                 except:
                   py.append('\t\t# ERROR: '+standard.writeError(self,'can\'t localFiles \'%s\''%i['id']))
                 py.append('')

--- a/Products/zms/ZMSRepositoryManager.py
+++ b/Products/zms/ZMSRepositoryManager.py
@@ -279,6 +279,9 @@ class ZMSRepositoryManager(
           if v and isinstance(v, list):
             py.append('\t# %s'%k.capitalize())
             py.append('\tclass %s:'%standard.id_quote(k).capitalize())
+            # Are there duplicated ids after id-quoting?
+            id_list = [ self.id_quote(i['id']) for i in v if i.get('ob') is None ] 
+            id_duplicates =  [ i for i in id_list if id_list.count(i) > 1 ]
             for i in v:
               if 'id' in i:
                 ob = i.get('ob')
@@ -299,7 +302,8 @@ class ZMSRepositoryManager(
                 if 'ob' in i:
                   del i['ob']
                 try:
-                  id_quoted = i['id'].startswith('_') and i['id'] or self.id_quote(i['id'])
+                  # Prevent id-quoting if duplicates may result
+                  id_quoted = ( i['id'].startswith('_') and ( self.id_quote(i['id']) in id_duplicates) ) and i['id'] or self.id_quote(i['id'])
                   py.append('\t\t%s = %s'%(id_quoted, standard.str_json(i, encoding="utf-8", formatted=True, level=3, allow_booleans=False)))
                 except:
                   py.append('\t\t# ERROR: '+standard.writeError(self,'can\'t localFiles \'%s\''%i['id']))

--- a/Products/zms/conf/metaobj_manager/com.zms.foundation/ZMSFigure/__init__.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.foundation/ZMSFigure/__init__.py
@@ -26,7 +26,7 @@ class ZMSFigure:
 	package = "com.zms.foundation"
 
 	# Revision
-	revision = "5.0.1"
+	revision = "5.0.2"
 
 	# Type
 	type = "ZMSObject"

--- a/Products/zms/conf/metaobj_manager/com.zms.foundation/ZMSFigure/__init__.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.foundation/ZMSFigure/__init__.py
@@ -51,7 +51,7 @@ class ZMSFigure:
 			,"repetitive":0
 			,"type":"image"}
 
-		previewimg = {"default":""
+		_img = {"default":""
 			,"id":"_img"
 			,"keys":[]
 			,"mandatory":0

--- a/Products/zms/conf/metaobj_manager/com.zms.foundation/ZMSFigure/standard_html.zpt
+++ b/Products/zms/conf/metaobj_manager/com.zms.foundation/ZMSFigure/standard_html.zpt
@@ -16,7 +16,7 @@
 		id id; 
 		style python:is_manage and 'max-width:100%;;display:inline-block;;' or default; 
 		title python:'Image Dimensions: %spx x %spx, Preview Max. Dimension: %s'%(imgwidth, imgheight, imgmaxsize);"
-	><a class="zmslightbox fancybox" 
+	><a class="zmslightbox fancybox"
 		data-turbolinks="false"
 		tal:omit-tag="python:imgwidth < imgmaxsize and imgheight < imgmaxsize"
 		tal:condition="img" 

--- a/Products/zms/import/ZMSFigure-5.0.2.metaobj.xml
+++ b/Products/zms/import/ZMSFigure-5.0.2.metaobj.xml
@@ -1,11 +1,56 @@
-<?xml version="1.0" encoding="utf-8"?>
-<?zms version='ZMS5-0.0.0dev (snapshot #5747:5810M)'?>
+<?xml version="1.0" encoding="utf-8" ?>
+<?zms version='ZMS5-5.1.0
+'?>
 <dictionary>
   <item key="key">ZMSFigure</item>
   <item key="value" type="dictionary">
     <dictionary>
       <item key="__obj_attrs__" type="list">
         <list>
+          <item type="dictionary">
+            <dictionary>
+              <item key="custom"><![CDATA[## Script (Python) "ZMSFigure.titlealt"
+##bind container=container
+##bind context=context
+##bind namespace=
+##bind script=script
+##bind subpath=traverse_subpath
+##parameters=zmscontext=None
+##title=py: DC.Title.Alt
+##
+# --// BO titlealt //--
+
+from Products.zms import standard
+try:
+    titlealt = standard.string_maxlen(zmscontext.attr('figcaption'),24)
+    img = zmscontext.attr('img')
+    if titlealt:
+        if len(titlealt) < 24:
+            return titlealt
+        else:
+            return '%s...'%(titlealt)
+    else:
+        return img.getFilename() 
+except:
+    return 'ZMSFigure'
+
+# --// EO titlealt //--
+]]>
+              </item>
+              <item key="default"></item>
+              <item key="id">titlealt</item>
+              <item key="keys" type="list">
+                <list>
+                </list>
+              </item>
+              <item key="mandatory" type="int">0</item>
+              <item key="meta_type"></item>
+              <item key="multilang" type="int">0</item>
+              <item key="name">DC.Title.Alt</item>
+              <item key="repetitive" type="int">0</item>
+              <item key="type">py</item>
+            </dictionary>
+          </item>
           <item type="dictionary">
             <dictionary>
               <item key="default"></item>
@@ -69,50 +114,6 @@
               <item key="name"><![CDATA[Icon-Class (CSS)]]></item>
               <item key="repetitive" type="int">0</item>
               <item key="type">constant</item>
-            </dictionary>
-          </item>
-          <item type="dictionary">
-            <dictionary>
-              <item key="custom"><![CDATA[## Script (Python) "ZMSFigure.titlealt"
-##bind container=container
-##bind context=context
-##bind namespace=
-##bind script=script
-##bind subpath=traverse_subpath
-##parameters=zmscontext=None
-##title=py: DC.Title.Alt
-##
-# --// BO titlealt //--
-
-from Products.zms import standard
-try:
-    titlealt = standard.string_maxlen(zmscontext.attr('figcaption'),24)
-    img = zmscontext.attr('img')
-    if titlealt:
-        if len(titlealt) < 24:
-            return titlealt
-        else:
-            return '%s...'%(titlealt)
-    else:
-        return img.getFilename() 
-except:
-    return 'ZMSFigure'
-
-# --// EO titlealt //--
-]]>
-              </item>
-              <item key="default"></item>
-              <item key="id">titlealt</item>
-              <item key="keys" type="list">
-                <list>
-                </list>
-              </item>
-              <item key="mandatory" type="int">0</item>
-              <item key="meta_type"></item>
-              <item key="multilang" type="int">0</item>
-              <item key="name">DC.Title.Alt</item>
-              <item key="repetitive" type="int">0</item>
-              <item key="type">py</item>
             </dictionary>
           </item>
           <item type="dictionary">
@@ -278,7 +279,7 @@ return None
       <item key="id">ZMSFigure</item>
       <item key="name">ZMSFigure</item>
       <item key="package">com.zms.foundation</item>
-      <item key="revision">5.0.1</item>
+      <item key="revision">5.0.2</item>
       <item key="type">ZMSObject</item>
     </dictionary>
   </item>

--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -1274,28 +1274,14 @@ ZMIObjectTree.prototype.addPages = function(pages) {
 		var page_titlealt = $page.attr("titlealt");
 		var page_icon = $page.attr("zmi_icon");
 		var anchor = "";
-		if ( page_is_pageelement) {
-			var file_filename = $("file>filename",$page);
-			if (file_filename.length) {
-				anchor = "/" + file_filename.text();
-			}
-		}
-		if (page_meta_type=='ZMSGraphic') {
-			var $img = $("img",$page);
-			if ($img.length==1) {
-				link_url = '<img data-id=&quot;'+page_uid+'&quot; src=&quot;'+$("href",$img).text()+'&quot;>';
-				try { page_titlealt = filename; } catch(err) { };
-			}
-		}
-		else if (page_meta_type=='ZMSFile') {
-			var $file = $("file",$page);
-			if ($file.length==1) {
-				var $fname = $("filename",$file).text();
-				var $ext = $fname.substring($fname.lastIndexOf('.')+1,$fname.length);
-				link_url = '<a data-id=&quot;'+page_uid+'&quot; href=&quot;'+$("href",$file).text()+'&quot; target=&quot;_blank&quot;>'+$page.attr("titlealt").replace(/"/g,'')+'&#32;('+$ext.toUpperCase()+',&#32;'+$("size",$file).text()+')</a>'; 
-				try { page_titlealt = filename; } catch(err) { };
-			}
-		}
+
+		if (page_meta_type=='ZMSGraphic' && link_url) {
+			link_url = '<img data-id=&quot;' + page_uid + '&quot;' + ' src=&quot;' + link_url + '&quot;>';
+		} else if (page_meta_type=='ZMSFile' && link_url) {
+			var $path_elements = link_url.split('/');
+			var $fname = $path_elements[$path_elements.length -1 ].split('?')[0];
+			link_url = '<a data-id=&quot;' + page_uid + '&quot;' + ' href=&quot;' + link_url + '&quot; target=&quot;_blank&quot;>' + $fname + '</a>'; 
+		};
 		var callback = that.p['toggleClick.callback'];
 		var css = [];
 		if (!page_is_active) {
@@ -1309,22 +1295,22 @@ ZMIObjectTree.prototype.addPages = function(pages) {
 				css.push('type-'+page_type)
 			}
 		};
-		html += '<ul data-id="'+page_id+'" data-home-id="'+page_home_id+'" class="zmi-page '+page_meta_type+'">';
-		html += '<li class="'+css.join(' ')+'">';
-		html += $ZMI.icon("fas fa-caret-right toggle",'title="+" onclick="$ZMI.objectTree.toggleClick(this'+(typeof callback=="undefined"?'':','+callback)+')"')+' ';
+		html += '<ul data-id="' + page_id + '" data-home-id="' + page_home_id + '" class="zmi-page ' + page_meta_type + '">';
+		html += '<li class="' + css.join(' ') + '">';
+		html += $ZMI.icon("fas fa-caret-right toggle",'title="+" onclick="$ZMI.objectTree.toggleClick(this' + (typeof callback=="undefined"?'':',' + callback) + ')"') + ' ';
 		if (page_is_pageelement) {
-			html += '<span style="cursor:help" onclick="$ZMI.objectTree.previewClick(this)" title="'+$ZMI.getLangStr('TAB_PREVIEW')+'"><i class="'+page_icon+'"></i></span> ';
+			html += '<span style="cursor:help" onclick="$ZMI.objectTree.previewClick(this)" title="' + getZMILangStr('TAB_PREVIEW') + '"><i class="' + page_icon + '"></i></span> ';
 		}
-		html += '<a href="'+page_absolute_url+'"'
-				+ ' data-link-url="'+link_url+'"'
-				+ ' data-uid="'+page_uid+'"'
-				+ ' data-page-physical-path="'+page_physical_path+'"'
-				+ ' data-anchor="'+anchor+'"'
-				+ ' data-page-is-page="'+page_is_page+'"'
-				+ ' data-page-titlealt="'+page_titlealt.replace(/"/g,'&quot;').replace(/'/g,'&apos;')+'"'
+		html += '<a href="' + page_absolute_url + '"'
+				+ ' data-link-url="' + link_url + '"'
+				+ ' data-uid="' + page_uid + '"'
+				+ ' data-page-physical-path="' + page_physical_path + '"'
+				+ ' data-anchor="' + anchor + '"'
+				+ ' data-page-is-page="' + page_is_page + '"'
+				+ ' data-page-titlealt="' + page_titlealt.replace(/"/g,'&quot;').replace(/'/g,'&apos;') + '"'
 				+ ' onclick="return zmiSelectObject(this);return false;">';
 		if (!page_is_pageelement) {
-			html += '<i class="'+page_icon+'"></i> ';
+			html += '<i class="' + page_icon + '"></i> ';
 		}
 		html += page_titlealt;
 		html += '</a>';

--- a/Products/zms/zpt/ZMSWorkflowProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSWorkflowProvider/manage_main.zpt
@@ -16,7 +16,7 @@
 <tal:block tal:content="structure python:here.zmi_breadcrumbs(here,request)">zmi_breadcrumbs</tal:block>
 
 <style>
-
+	/*<!-- */
 	table.table.zmi-sortable th,
 	table.table.zmi-sortable td {
 		padding: 0;
@@ -135,11 +135,11 @@
 		border: 0;
 		padding: 2rem 0.5rem .5rem !important;
 	}
-
+	/*-->*/
 </style>
 
 <script>
-
+	//<!--
 	/**
 	 * Transfer selected object to node list.
 	 */
@@ -190,7 +190,7 @@
 			}
 		);
 	});
-
+	//-->
 </script>
 
 <div class="d-none">
@@ -386,7 +386,7 @@
 
 
 <nav id="subTab">
-<ul class="nav nav-tabs" role="tablist" tal:attributes="title python:here.getRevision()">
+	<ul class="nav nav-tabs" role="tablist" tal:attributes="title python:here.getRevision()">
 		<li class="nav-item"><a class="nav-link" href="#edit" data-toggle="tab" 
 			tal:attributes="class python:request.get('key','edit')=='edit' and 'nav-link active show' or 'nav-link'"
 			tal:content="python:here.getZMILangStr('TAB_WORKFLOW_MODEL')">Workflow-Model</a></li>
@@ -396,7 +396,7 @@
 		<li class="nav-item"><a class="nav-link" href="#history" data-toggle="tab" 
 			tal:attributes="class python:request.get('key')=='history' and 'nav-link active show' or 'nav-link'"
 			tal:content="python:here.getZMILangStr('TAB_WORKFLOW_VERSION')">Version Control</a></li>
-</ul>
+	</ul>
 </nav>
 
 <div class="tab-content">

--- a/Products/zms/zpt/ZMSWorkflowProvider/manage_main_acquired.zpt
+++ b/Products/zms/zpt/ZMSWorkflowProvider/manage_main_acquired.zpt
@@ -8,17 +8,17 @@
 <tal:block tal:content="structure python:here.zmi_breadcrumbs(here,request)">zmi_breadcrumbs</tal:block>
 
 <script>
-
-/**
- * Transfer selected object to node list.
- */
-function selectObject(ignoredUrl, ignoredTitle, nodeName) {
-	var form = $('form.form-initialized[action="manage_changeWorkflow"]');
-	var textArea = form.find('textarea.url-input');
-	var newVal = textArea.val() + '\n' + nodeName;
-	textArea.val(newVal).trigger('change');
-}
-
+	//<!--
+	/**
+	 * Transfer selected object to node list.
+	 */
+	function selectObject(ignoredUrl, ignoredTitle, nodeName) {
+		var form = $('form.form-initialized[action="manage_changeWorkflow"]');
+		var textArea = form.find('textarea.url-input');
+		var newVal = textArea.val() + '\n' + nodeName;
+		textArea.val(newVal).trigger('change');
+	}
+	//-->
 </script>
 
 <form class="form-horizontal card" action="manage_changeWorkflow" method="post" enctype="multipart/form-data">

--- a/Products/zms/zpt/objattrs/zmi_select_richtext_standard.zpt
+++ b/Products/zms/zpt/objattrs/zmi_select_richtext_standard.zpt
@@ -8,15 +8,24 @@
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  */
 
-function selectObject(href, title, oid) {
+function selectObject(href, title, uid) {
+	var is_image = false;
+	var tag_el = 'a';
 	var attrs = [];
-	if (typeof oid != 'undefined') {
-		attrs.push('data-id="'+oid+'"');
+	if (typeof uid != 'undefined') {
+		attrs.push('data-id="'+uid+'"');
 	}
 	if (typeof href != 'undefined') {
-		attrs.push('href="'+href+'"');
+		is_image = (href.match('\.(jpg|gif|jpeg|png)') != null);
+		if (is_image) {
+			attrs.push('src="'+href+'"');
+			tag_el = 'img';
+		} else {
+			attrs.push('href="'+href+'"');
+		}
 	}
-	tagSelected('a '+attrs.join(' '),'<','>');
+	// console.log('selectObject: add link element ' + tag_el)
+	tagSelected(tag_el + ' ' + attrs.join(' '), '<', '>');
 }
 
 // Insert tab into richedit-textarea.


### PR DESCRIPTION
The XML-Stream on manage_ajaxGetChildNodes() was simplified with the transition of ZMS3 to ZMS5. Now the XML strucuture is based in one element and attributes, but no child elements anymore.

![manage_ajaxGetChildNodes](https://user-images.githubusercontent.com/29705216/190022036-77fecbc0-9ae7-42c1-8613-d7be0a87513d.gif)

The link selector GUI in ZMS did not process this reduced XML correctly and images were not shown anymore.  The fix make it work again:

![image_links](https://user-images.githubusercontent.com/29705216/190022041-90705c56-9304-4dd7-9c2f-4f0977f8cf1a.gif)
