### PR TITLE
92: fix blocked xml-import by full reindex

### DIFF
--- a/Products/zms/_builder.py
+++ b/Products/zms/_builder.py
@@ -150,10 +150,6 @@ class Builder(object):
             raise ParseError('%s at line %s' % (pyexpat.ErrorString(p.ErrorCode), p.ErrorLineNumber))
         ####
 
-        # reindex
-        standard.triggerEvent( self, '*.ObjectImported')
-        ####
-
         return root
 
 
@@ -274,7 +270,10 @@ class Builder(object):
             
             # notify current node
             self.oCurrNode.xmlOnEndElement()
-            
+
+            # notify index
+            standard.triggerEvent(self.oCurrNode, "*.ObjectAdded")
+
             parent = self.oCurrNode.xmlGetParent()
             
             # set parent node as current node

--- a/Products/zms/_confmanager.py
+++ b/Products/zms/_confmanager.py
@@ -491,7 +491,8 @@ class ConfManager(
         {'key':'ZMS.input.image.maxlength','title':'Image.upload maxlength','desc':'ZMS can limit the maximum upload-image size to the given value (in Bytes).','datatype':'string'},
         {'key':'ZMSGraphic.superres','title':'Image superres-attribute','desc':'Super-resolution attribute for ZMS standard image-objects.','datatype':'boolean','default':0},
         {'key':'ZCatalog.TextIndexType','title':'Search with TextIndex-type','desc':'Use specified TextIndex-type (default: ZCTextIndex)','datatype':'string','default':'ZCTextIndex'},
-        {'key':'ZMSIndexZCatalog.ObjectImported','title':'Resync ZMSIndex on content import','desc':'Please be aware that activating implicit ZMSIndex-resync on content import can block bigger sites for a while','datatype':'boolean','default':0},
+        {'key':'ZMSIndexZCatalog.ObjectImported.reindex','title':'Reindex ZMSIndex on content import','desc':'Please be aware that activating implicit ZMSIndex-resync on content import can block bigger sites for a while','datatype':'boolean','default':1},
+        {'key':'ZMSIndexZCatalog.ObjectImported.resync','title':'Resync ZMSIndex on content import','desc':'Please be aware that activating implicit ZMSIndex-resync on content import can block bigger sites for a while','datatype':'boolean','default':0},
         {'key':'ZReferableItem.validateLinkObj','title':'Auto-correct inline-links on save','desc':'Ensure valid inline-links by text-parsing and using ZMSIndex for refreshing target urls on save event','datatype':'boolean','default':1},
       ]
     

--- a/Products/zms/zmsindex.py
+++ b/Products/zms/zmsindex.py
@@ -83,8 +83,9 @@ class ZMSIndex(ZMSItem.ZMSItem):
       base = list(self.getRootElement().getPhysicalPath())[:-1]
       url = list(self.getDocumentElement().getPhysicalPath())[len(base):-1]
       request.set('url','{$'+['','/'.join(url)+'@'][len(url)>0]+'}')
-      self.manage_reindex(regenerate_duplicates=True)
-      if self.getConfProperty('ZMSIndexZCatalog.ObjectImported',False) == True:
+      if self.getConfProperty('ZMSIndexZCatalog.ObjectImported.reindex',True) == False:
+        self.manage_reindex(regenerate_duplicates=True)
+      if self.getConfProperty('ZMSIndexZCatalog.ObjectImported.resync',False) == True:
         self.manage_resync()
 
     ##############################################################################


### PR DESCRIPTION
- trigger ObjectAdded for each imported node and remove ObjectImported with full reindex after xml-import
- ObjectImported is still needed for import of zexp
- new config-keys to enable/disable index on import