### PR TITLE
ZMI: ensure lang var is not None

### DIFF
--- a/Products/zms/ZMSZCatalogConnector.py
+++ b/Products/zms/ZMSZCatalogConnector.py
@@ -364,8 +364,7 @@ class ZMSZCatalogConnector(
       
       # ZCatalog.
       request = self.REQUEST
-      # In case lang is set to None, use primary language
-      lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
+      lang = standard.nvl(self.REQUEST.get('lang'), self.getPrimaryLanguage())
       zcatalog = getZCatalog(self, lang)
       
       # Find search-results.
@@ -427,8 +426,7 @@ class ZMSZCatalogConnector(
       
       # ZCatalog.
       request = self.REQUEST
-      # In case lang is set to None, use primary language
-      lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
+      lang = standard.nvl(self.REQUEST.get('lang'), self.getPrimaryLanguage())
       zcatalog = getZCatalog(self, lang)
       
       # Lexicon.
@@ -463,8 +461,7 @@ class ZMSZCatalogConnector(
         setattr(node, attr_name, value)
       # Reindex object.
       request = self.REQUEST
-      # In case lang is set to None, use primary language
-      lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
+      lang = standard.nvl(self.REQUEST.get('lang'), self.getPrimaryLanguage())
       zcatalog = getZCatalog(self, lang)
       if zcatalog is not None:
         path = node.getPath()

--- a/Products/zms/ZMSZCatalogConnector.py
+++ b/Products/zms/ZMSZCatalogConnector.py
@@ -364,7 +364,8 @@ class ZMSZCatalogConnector(
       
       # ZCatalog.
       request = self.REQUEST
-      lang = request.get('lang', self.getPrimaryLanguage())
+      # In case lang is set to None, use primary language
+      lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
       zcatalog = getZCatalog(self, lang)
       
       # Find search-results.
@@ -426,7 +427,8 @@ class ZMSZCatalogConnector(
       
       # ZCatalog.
       request = self.REQUEST
-      lang = request.get('lang', self.getPrimaryLanguage())
+      # In case lang is set to None, use primary language
+      lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
       zcatalog = getZCatalog(self, lang)
       
       # Lexicon.
@@ -461,7 +463,8 @@ class ZMSZCatalogConnector(
         setattr(node, attr_name, value)
       # Reindex object.
       request = self.REQUEST
-      lang = request.get('lang', self.getPrimaryLanguage())
+      # In case lang is set to None, use primary language
+      lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
       zcatalog = getZCatalog(self, lang)
       if zcatalog is not None:
         path = node.getPath()

--- a/Products/zms/ZMSZCatalogConnector.py
+++ b/Products/zms/ZMSZCatalogConnector.py
@@ -364,7 +364,7 @@ class ZMSZCatalogConnector(
       
       # ZCatalog.
       request = self.REQUEST
-      lang = standard.nvl(self.REQUEST.get('lang'), self.getPrimaryLanguage())
+      lang = standard.nvl(request.get('lang'), self.getPrimaryLanguage())
       zcatalog = getZCatalog(self, lang)
       
       # Find search-results.
@@ -426,7 +426,7 @@ class ZMSZCatalogConnector(
       
       # ZCatalog.
       request = self.REQUEST
-      lang = standard.nvl(self.REQUEST.get('lang'), self.getPrimaryLanguage())
+      lang = standard.nvl(request.get('lang'), self.getPrimaryLanguage())
       zcatalog = getZCatalog(self, lang)
       
       # Lexicon.
@@ -461,7 +461,7 @@ class ZMSZCatalogConnector(
         setattr(node, attr_name, value)
       # Reindex object.
       request = self.REQUEST
-      lang = standard.nvl(self.REQUEST.get('lang'), self.getPrimaryLanguage())
+      lang = standard.nvl(request.get('lang'), self.getPrimaryLanguage())
       zcatalog = getZCatalog(self, lang)
       if zcatalog is not None:
         path = node.getPath()

--- a/Products/zms/_multilangmanager.py
+++ b/Products/zms/_multilangmanager.py
@@ -273,8 +273,7 @@ class MultiLanguageManager(object):
       Returns language-string for current content-language.
       """
       if lang is None:
-        # In case lang is set to None, use primary language
-        lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
+        lang = standard.nvl(self.REQUEST.get('lang'), self.getPrimaryLanguage())
 
       # Return custom value.
       d = self.get_lang_dict()

--- a/Products/zms/_multilangmanager.py
+++ b/Products/zms/_multilangmanager.py
@@ -273,8 +273,9 @@ class MultiLanguageManager(object):
       Returns language-string for current content-language.
       """
       if lang is None:
-        lang = self.REQUEST.get('lang', self.getPrimaryLanguage())
-      
+        # In case lang is set to None, use primary language
+        lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
+
       # Return custom value.
       d = self.get_lang_dict()
       if key in d and lang in d[key]:

--- a/Products/zms/_objattrs.py
+++ b/Products/zms/_objattrs.py
@@ -263,7 +263,8 @@ class ObjAttrs(object):
     #  ObjAttrs.isDisabledAttr:
     # --------------------------------------------------------------------------
     def isDisabledAttr(self, obj_attr, REQUEST):
-      lang = REQUEST.get('lang', self.getPrimaryLanguage())
+      # In case lang is set to None, use primary language
+      lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
       return REQUEST.get(obj_attr['id']+'-disabled', False) or not (obj_attr['multilang'] or REQUEST.get('ZMS_INSERT', None) is not None or self.getDCCoverage(REQUEST).find('.'+lang)>0)
 
 

--- a/Products/zms/_objattrs.py
+++ b/Products/zms/_objattrs.py
@@ -263,7 +263,7 @@ class ObjAttrs(object):
     #  ObjAttrs.isDisabledAttr:
     # --------------------------------------------------------------------------
     def isDisabledAttr(self, obj_attr, REQUEST):
-      lang = standard.nvl(self.REQUEST.get('lang'), self.getPrimaryLanguage())
+      lang = standard.nvl(REQUEST.get('lang'), self.getPrimaryLanguage())
       return REQUEST.get(obj_attr['id']+'-disabled', False) or not (obj_attr['multilang'] or REQUEST.get('ZMS_INSERT', None) is not None or self.getDCCoverage(REQUEST).find('.'+lang)>0)
 
 

--- a/Products/zms/_objattrs.py
+++ b/Products/zms/_objattrs.py
@@ -263,8 +263,7 @@ class ObjAttrs(object):
     #  ObjAttrs.isDisabledAttr:
     # --------------------------------------------------------------------------
     def isDisabledAttr(self, obj_attr, REQUEST):
-      # In case lang is set to None, use primary language
-      lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
+      lang = standard.nvl(self.REQUEST.get('lang'), self.getPrimaryLanguage())
       return REQUEST.get(obj_attr['id']+'-disabled', False) or not (obj_attr['multilang'] or REQUEST.get('ZMS_INSERT', None) is not None or self.getDCCoverage(REQUEST).find('.'+lang)>0)
 
 

--- a/Products/zms/_objinputs.py
+++ b/Products/zms/_objinputs.py
@@ -100,8 +100,7 @@ class ObjInputs(object):
   #	@return String
   # ----------------------------------------------------------------------------
   def getTextInput(self, fmName, elName, size=None, value='', type='text', enabled=True, css='form-control', placeholder=''):
-    # In case lang is set to None, use primary language
-    lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
+    lang = standard.nvl(self.REQUEST.get('lang'), self.getPrimaryLanguage())
     elId = elName
     if elId.endswith('_%s'%lang):
       elId = elId[:-len('_%s'%lang)]
@@ -167,8 +166,7 @@ class ObjInputs(object):
   # call getCheckbox(..., elId='', ...) with an empty string for elId
   # ----------------------------------------------------------------------------
   def getCheckbox(self, fmName, elName, elId=None, value=None, enabled=True, hidden=True, css='', btn=False, options=[0, 1]):
-    # In case lang is set to None, use primary language
-    lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
+    lang = standard.nvl(self.REQUEST.get('lang'), self.getPrimaryLanguage())
     if elId==None:
       elId = elName
     if elId.endswith('_%s'%lang):
@@ -214,8 +212,7 @@ class ObjInputs(object):
   #	@return String
   # ----------------------------------------------------------------------------
   def getTextArea(self, fmName, elName, cols, rows, value, enabled=True, css='form-control', wrap='virtual'):
-    # In case lang is set to None, use primary language
-    lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
+    lang = standard.nvl(self.REQUEST.get('lang'), self.getPrimaryLanguage())
     elId = elName
     if elId.endswith('_%s'%lang):
       elId = elId[:-len('_%s'%lang)]

--- a/Products/zms/_objinputs.py
+++ b/Products/zms/_objinputs.py
@@ -100,7 +100,8 @@ class ObjInputs(object):
   #	@return String
   # ----------------------------------------------------------------------------
   def getTextInput(self, fmName, elName, size=None, value='', type='text', enabled=True, css='form-control', placeholder=''):
-    lang = self.REQUEST.get('lang', self.getPrimaryLanguage())
+    # In case lang is set to None, use primary language
+    lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
     elId = elName
     if elId.endswith('_%s'%lang):
       elId = elId[:-len('_%s'%lang)]
@@ -166,7 +167,8 @@ class ObjInputs(object):
   # call getCheckbox(..., elId='', ...) with an empty string for elId
   # ----------------------------------------------------------------------------
   def getCheckbox(self, fmName, elName, elId=None, value=None, enabled=True, hidden=True, css='', btn=False, options=[0, 1]):
-    lang = self.REQUEST.get('lang', self.getPrimaryLanguage())
+    # In case lang is set to None, use primary language
+    lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
     if elId==None:
       elId = elName
     if elId.endswith('_%s'%lang):
@@ -212,7 +214,8 @@ class ObjInputs(object):
   #	@return String
   # ----------------------------------------------------------------------------
   def getTextArea(self, fmName, elName, cols, rows, value, enabled=True, css='form-control', wrap='virtual'):
-    lang = self.REQUEST.get('lang', self.getPrimaryLanguage())
+    # In case lang is set to None, use primary language
+    lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
     elId = elName
     if elId.endswith('_%s'%lang):
       elId = elId[:-len('_%s'%lang)]

--- a/Products/zms/_versionmanager.py
+++ b/Products/zms/_versionmanager.py
@@ -412,7 +412,8 @@ class VersionItem(object):
       obj_states = []
       states = self.getObjStates()
       if len(states) > 0:
-        lang = REQUEST.get('lang', self.getPrimaryLanguage())
+        # In case lang is set to None, use primary language
+        lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
         for obj_state in [ 'STATE_NEW', 'STATE_MODIFIED', 'STATE_DELETED']:
           obj_state_name = getObjStateName(obj_state, lang)
           if obj_state_name in states:

--- a/Products/zms/_versionmanager.py
+++ b/Products/zms/_versionmanager.py
@@ -412,7 +412,7 @@ class VersionItem(object):
       obj_states = []
       states = self.getObjStates()
       if len(states) > 0:
-        lang = standard.nvl(self.REQUEST.get('lang'), self.getPrimaryLanguage())
+        lang = standard.nvl(REQUEST.get('lang'), self.getPrimaryLanguage())
         for obj_state in [ 'STATE_NEW', 'STATE_MODIFIED', 'STATE_DELETED']:
           obj_state_name = getObjStateName(obj_state, lang)
           if obj_state_name in states:

--- a/Products/zms/_versionmanager.py
+++ b/Products/zms/_versionmanager.py
@@ -412,8 +412,7 @@ class VersionItem(object):
       obj_states = []
       states = self.getObjStates()
       if len(states) > 0:
-        # In case lang is set to None, use primary language
-        lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
+        lang = standard.nvl(self.REQUEST.get('lang'), self.getPrimaryLanguage())
         for obj_state in [ 'STATE_NEW', 'STATE_MODIFIED', 'STATE_DELETED']:
           obj_state_name = getObjStateName(obj_state, lang)
           if obj_state_name in states:

--- a/Products/zms/zmsobject.py
+++ b/Products/zms/zmsobject.py
@@ -492,7 +492,7 @@ class ZMSObject(ZMSItem.ZMSItem,
     # --------------------------------------------------------------------------
     def isVisible(self, REQUEST):
       REQUEST = standard.nvl(REQUEST, self.REQUEST)
-      lang = standard.nvl(self.REQUEST.get('lang'), self.getPrimaryLanguage())
+      lang = standard.nvl(REQUEST.get('lang'), self.getPrimaryLanguage())
       visible = True
       visible = visible and self.isTranslated(lang, REQUEST) # Object is translated.
       visible = visible and self.isCommitted(REQUEST) # Object has been committed.

--- a/Products/zms/zmsobject.py
+++ b/Products/zms/zmsobject.py
@@ -492,7 +492,8 @@ class ZMSObject(ZMSItem.ZMSItem,
     # --------------------------------------------------------------------------
     def isVisible(self, REQUEST):
       REQUEST = standard.nvl(REQUEST, self.REQUEST)
-      lang = REQUEST.get('lang', self.getPrimaryLanguage())
+      # In case lang is set to None, use primary language
+      lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
       visible = True
       visible = visible and self.isTranslated(lang, REQUEST) # Object is translated.
       visible = visible and self.isCommitted(REQUEST) # Object has been committed.

--- a/Products/zms/zmsobject.py
+++ b/Products/zms/zmsobject.py
@@ -492,8 +492,7 @@ class ZMSObject(ZMSItem.ZMSItem,
     # --------------------------------------------------------------------------
     def isVisible(self, REQUEST):
       REQUEST = standard.nvl(REQUEST, self.REQUEST)
-      # In case lang is set to None, use primary language
-      lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
+      lang = standard.nvl(self.REQUEST.get('lang'), self.getPrimaryLanguage())
       visible = True
       visible = visible and self.isTranslated(lang, REQUEST) # Object is translated.
       visible = visible and self.isCommitted(REQUEST) # Object has been committed.

--- a/Products/zms/zmssqldb.py
+++ b/Products/zms/zmssqldb.py
@@ -500,7 +500,8 @@ class ZMSSqlDb(zmscustom.ZMSCustom):
       column = {}
       try:
         request = self.REQUEST
-        lang = request.get('lang', self.getPrimaryLanguage())
+        # In case lang is set to None, use primary language
+        lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
         encoding = getattr(self, 'charset', 'utf-8')
         qcharset = self.REQUEST.get('qcharset', 'utf-8')
         entity = self.getEntity(tableName)

--- a/Products/zms/zmssqldb.py
+++ b/Products/zms/zmssqldb.py
@@ -500,7 +500,7 @@ class ZMSSqlDb(zmscustom.ZMSCustom):
       column = {}
       try:
         request = self.REQUEST
-        lang = standard.nvl(self.REQUEST.get('lang'), self.getPrimaryLanguage())
+        lang = standard.nvl(request.get('lang'), self.getPrimaryLanguage())
         encoding = getattr(self, 'charset', 'utf-8')
         qcharset = self.REQUEST.get('qcharset', 'utf-8')
         entity = self.getEntity(tableName)

--- a/Products/zms/zmssqldb.py
+++ b/Products/zms/zmssqldb.py
@@ -500,8 +500,7 @@ class ZMSSqlDb(zmscustom.ZMSCustom):
       column = {}
       try:
         request = self.REQUEST
-        # In case lang is set to None, use primary language
-        lang = self.REQUEST.get('lang') is not None and self.REQUEST.get('lang') or self.getPrimaryLanguage()
+        lang = standard.nvl(self.REQUEST.get('lang'), self.getPrimaryLanguage())
         encoding = getattr(self, 'charset', 'utf-8')
         qcharset = self.REQUEST.get('qcharset', 'utf-8')
         entity = self.getEntity(tableName)

--- a/Products/zms/zpt/objattrs/f_select_file.zpt
+++ b/Products/zms/zpt/objattrs/f_select_file.zpt
@@ -8,7 +8,7 @@
 
 	<div class="zmi-file d-flex align-items-center row" 
 		tal:define="has_file python:value is not None and here.operator_gettype(value) is not str;
-			allowed_ext python:request.set('ZMS_ALLOWED_EXTENSIONS',['jpg', 'jpeg', 'png', 'gif']);
+			allowed_ext python:request.set('ZMS_ALLOWED_EXTENSIONS',['jpg', 'jpeg', 'png', 'gif','svg']);
 			filename python:has_file and value.getFilename() or 'None';
 			href python:has_file and value.getHref(request) or 'None';
 			size python:has_file and here.getDataSizeStr(value.get_size()) or 'None';

--- a/Products/zms/zpt/objattrs/f_select_file.zpt
+++ b/Products/zms/zpt/objattrs/f_select_file.zpt
@@ -13,7 +13,7 @@
 			href python:has_file and value.getHref(request) or 'None';
 			size python:has_file and here.getDataSizeStr(value.get_size()) or 'None';
 			title python:has_file and '%s %s'%(filename,size) or 'No File Uploaded';
-			lang python:request.get('lang') is not None and request.get('lang') or context.getPrimaryLanguage()"
+			lang python:standard.nvl(request.get('lang'), context.getPrimaryLanguage());"
 		tal:attributes="id python:'zmi-file-%s'%elName">
 		<input type="hidden" tal:attributes="name python:'exists_%s'%elName; value python:request.get('ZMS_INSERT',None) is None and value not in [None,'']" />
 		<input type="hidden" tal:attributes="name python:'del_%s'%elName" value="0" />

--- a/Products/zms/zpt/objattrs/f_select_file.zpt
+++ b/Products/zms/zpt/objattrs/f_select_file.zpt
@@ -1,9 +1,8 @@
-<tal:block tal:define="global
-		standard modules/Products.zms/standard;
-		fmName options/fmName;
-		elName options/elName;
-		key options/key;
-		value python:options['value'].delegate();">
+<tal:block tal:define="standard modules/Products.zms/standard;
+	fmName options/fmName;
+	elName options/elName;
+	key options/key;
+	value python:options['value'].delegate();">
 
 	<script tal:condition="python:standard.once('zmiBlobJs',request)" type="text/javascript" charset="UTF-8" src="/++resource++zms_/objattrs/zmi.blob.js"></script> 
 
@@ -13,7 +12,8 @@
 			filename python:has_file and value.getFilename() or 'None';
 			href python:has_file and value.getHref(request) or 'None';
 			size python:has_file and here.getDataSizeStr(value.get_size()) or 'None';
-			title python:has_file and '%s %s'%(filename,size) or 'No File Uploaded'"
+			title python:has_file and '%s %s'%(filename,size) or 'No File Uploaded';
+			lang python:request.get('lang') is not None and request.get('lang') or context.getPrimaryLanguage()"
 		tal:attributes="id python:'zmi-file-%s'%elName">
 		<input type="hidden" tal:attributes="name python:'exists_%s'%elName; value python:request.get('ZMS_INSERT',None) is None and value not in [None,'']" />
 		<input type="hidden" tal:attributes="name python:'del_%s'%elName" value="0" />
@@ -22,7 +22,7 @@
 			<div class="zmi-input-file btn-group">
 
 				<div class="custom-file"
-					tal:condition="python:request['lang'] in here.getLanguages(request)"
+					tal:condition="python:lang in here.getLanguages(request)"
 					tal:attributes="class python:'custom-file%s'%(has_file and '' or ' new');
 						title title;
 						id python:'filename_%s'%elName;

--- a/Products/zms/zpt/objattrs/f_select_image.zpt
+++ b/Products/zms/zpt/objattrs/f_select_image.zpt
@@ -1,15 +1,14 @@
-<tal:block tal:define="global
-		standard modules/Products.zms/standard;
-		pilutil modules/Products.zms/pilutil;
-		fmName options/fmName;
-		elName options/elName;
-		key options/key;
-		value python:options['value'].delegate();
-		can_generate_preview python:pilutil.enabled() and (key.endswith('hires') or key.endswith('superres'));
-		max_generate_preview python:{
-				'imghires':'InstalledProducts.pil.thumbnail.max',
-				'imgsuperres':'InstalledProducts.pil.hires.thumbnail.max'
-			}.get(key,None)">
+<tal:block tal:define="standard modules/Products.zms/standard;
+	pilutil modules/Products.zms/pilutil;
+	fmName options/fmName;
+	elName options/elName;
+	key options/key;
+	value python:options['value'].delegate();
+	can_generate_preview python:pilutil.enabled() and (key.endswith('hires') or key.endswith('superres'));
+	max_generate_preview python:{
+			'imghires':'InstalledProducts.pil.thumbnail.max',
+			'imgsuperres':'InstalledProducts.pil.hires.thumbnail.max'
+		}.get(key,None)">
 
 	<tal:block tal:condition="python:standard.once('zmiGraphicExtEdit',request)">
 		<div id="ZMSGraphic_extEdit_template" class="d-none">
@@ -80,7 +79,8 @@
 			href python:has_file and value.getHref(request) or 'None';
 			dimensions python:has_file and '%sx%spx'%(str(value.getWidth()),str(value.getHeight())) or 'None';
 			size python:has_file and here.getDataSizeStr(value.get_size()) or 'None';
-			title python:has_file and '%s (%s) %s'%(filename,dimensions,size) or 'No File Uploaded'"
+			title python:has_file and '%s (%s) %s'%(filename,dimensions,size) or 'No File Uploaded';
+			lang python:request.get('lang') is not None and request.get('lang') or context.getPrimaryLanguage()"
 		tal:attributes="id python:'zmi-image-%s'%elName">
 		<input type="hidden" tal:attributes="name python:'exists_%s'%elName; value python:request.get('ZMS_INSERT',None) is None and value not in [None,'']" />
 		<input type="hidden" tal:attributes="name python:'del_%s'%elName" value="0" />
@@ -89,7 +89,7 @@
 
 			<div class="zmi-input-file btn-group">
 				<div class="custom-file"
-					tal:condition="python:request['lang'] in here.getLanguages(request)"
+					tal:condition="python:lang in here.getLanguages(request)"
 					tal:attributes="class python:'custom-file%s'%(has_file and '' or ' new');
 						title title;
 						id python:'filename_%s'%elName;

--- a/Products/zms/zpt/objattrs/f_select_image.zpt
+++ b/Products/zms/zpt/objattrs/f_select_image.zpt
@@ -80,7 +80,7 @@
 			dimensions python:has_file and '%sx%spx'%(str(value.getWidth()),str(value.getHeight())) or 'None';
 			size python:has_file and here.getDataSizeStr(value.get_size()) or 'None';
 			title python:has_file and '%s (%s) %s'%(filename,dimensions,size) or 'No File Uploaded';
-			lang python:request.get('lang') is not None and request.get('lang') or context.getPrimaryLanguage()"
+			lang python:standard.nvl(request.get('lang'), context.getPrimaryLanguage());"
 		tal:attributes="id python:'zmi-image-%s'%elName">
 		<input type="hidden" tal:attributes="name python:'exists_%s'%elName; value python:request.get('ZMS_INSERT',None) is None and value not in [None,'']" />
 		<input type="hidden" tal:attributes="name python:'del_%s'%elName" value="0" />

--- a/Products/zms/zpt/objattrs/f_select_image.zpt
+++ b/Products/zms/zpt/objattrs/f_select_image.zpt
@@ -6,9 +6,9 @@
 	value python:options['value'].delegate();
 	can_generate_preview python:pilutil.enabled() and (key.endswith('hires') or key.endswith('superres'));
 	max_generate_preview python:{
-			'imghires':'InstalledProducts.pil.thumbnail.max',
-			'imgsuperres':'InstalledProducts.pil.hires.thumbnail.max'
-		}.get(key,None)">
+		'imghires':'InstalledProducts.pil.thumbnail.max',
+		'imgsuperres':'InstalledProducts.pil.hires.thumbnail.max'
+	}.get(key,None)">
 
 	<tal:block tal:condition="python:standard.once('zmiGraphicExtEdit',request)">
 		<div id="ZMSGraphic_extEdit_template" class="d-none">
@@ -74,7 +74,7 @@
 
 	<div class="zmi-image d-flex align-items-center row"
 		tal:define="has_file python:value is not None and here.operator_gettype(value) is not str;
-			allowed_ext python:request.set('ZMS_ALLOWED_EXTENSIONS',['jpg', 'jpeg', 'png', 'gif']);
+			allowed_ext python:request.set('ZMS_ALLOWED_EXTENSIONS',['jpg', 'jpeg', 'png', 'gif','svg']);
 			filename python:has_file and value.getFilename() or 'None';
 			href python:has_file and value.getHref(request) or 'None';
 			dimensions python:has_file and '%sx%spx'%(str(value.getWidth()),str(value.getHeight())) or 'None';


### PR DESCRIPTION
In case lang is (unintentionally) set to None by the custom code the ZMI input elements cannot be rendered and provide a rather unspecific error hint:

![input_elements](https://user-images.githubusercontent.com/29705216/193780710-1550437f-7e44-4d8a-b660-7e9587a4f048.gif)

To avoid this the None case should be covered more explicitly.
Any comments/ideas to the fix?

Cheers
fh