### PR TITLE
ZMSIndex: Added filterpath to avoid empty searches by default

### DIFF
--- a/Products/zms/zpt/ZMSIndex/manage_main.zpt
+++ b/Products/zms/zpt/ZMSIndex/manage_main.zpt
@@ -47,7 +47,7 @@ function openWindow(url) {
 				</a>
 			</div>
 			<a class="btn btn-default btn-secondary" target="_blank" style="margin-right:1em"
-				tal:attributes="href python:'%s/manage_catalogView'%zmscontext.zcatalog_index.absolute_url()">
+				tal:attributes="href python:'%s/manage_catalogView?filterpath=/'%zmscontext.zcatalog_index.absolute_url()">
 					<i class="icon icon-search fas fa-search"></i> zcatalog_index
 			</a>
 			<button name="btn" class="btn btn-warning" style="margin-right:1em"


### PR DESCRIPTION
At UniBE with over 500,000 records in `zcatalog_index`, we have noticed extremely long run times when accessing `/unibe/zcatalog_index/manage_catalogView` with Products.ZCatalog==6.3.

This seems to be due to the changed behavior of `catalogView.dtml` with `Products.ZCatalog>5.1`:
https://github.com/zopefoundation/Products.ZCatalog/commit/919bdb104173f1cefddf2e800cf2bd216c7acf92

As a workaround we have found the URL paramter `?filterpath=/` which was introduced in https://github.com/zms-publishing/ZMS/commit/22e17356e64b05c3220559583b39220f9e1a4e8b (2021/02/26).

This reduces the run times by a factor of 14 in our environment:

- `/unibe/zcatalog_index/manage_catalogView` =>  5min 11sec (without filterpath) 
- `/unibe/zcatalog_index/manage_catalogView?filterpath=/` => 22sec

Unfortunately the `filterpath` was removed in https://github.com/zms-publishing/ZMS/commit/b6397a7d4781b1b3a41eaeb7b2145fa262df5798 (2021/07/16).

The problem persists even with the latest ZMS and the revised ZMSIndex -- so we'd like to re-enable the workaround if there's nothing wrong with it...

See IDCMS-374, IDCMS-617