### PR TITLE
metobjmanager: show selected obid

### DIFF
--- a/Products/zms/plugins/www/zmi.core.css
+++ b/Products/zms/plugins/www/zmi.core.css
@@ -1350,8 +1350,9 @@ div.pull-left div.single-line.input-append.zmi-nodes textarea {
 .zmi .dropdown-menu .dropdown-header i {
 	color: #fff !important;
 }
-.zmi .dropdown-menu a.dropdown-item:focus, 
-.zmi .dropdown-menu a.dropdown-item:hover {
+.zmi .dropdown-menu a.dropdown-item:focus,
+.zmi .dropdown-menu a.dropdown-item:hover,
+.zmi .dropdown-menu a.dropdown-item.selected {
 	background-color: rgba(53, 79, 103, 0.15);
 }
 .zmi .dropdown-menu a.dropdown-item {

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -106,7 +106,8 @@
 						<tal:block tal:condition="python:metaObjPackage in metaObjPackages">
 							<tal:block tal:condition="metaObjPackage">
 								<tal:block tal:define="metaObj python:here.getMetaobj(metaObjPackage)">
-									<a class="dropdown-item" tal:attributes="href python:'?lang=%s&id=%s'%(request['lang'],metaObj['id'])">
+									<a class="dropdown-item" tal:attributes="href python:'?lang=%s&id=%s'%(request['lang'],metaObj['id']);
+										class python:request.get('id','')==metaObj['id'] and 'dropdown-item selected' or default">
 										<i class="fas fa-briefcase"></i>
 										<strong tal:on-error="string:ERROR metaObjPackage" tal:content="metaObjPackage">id</strong>
 									</a>
@@ -115,7 +116,8 @@
 						</tal:block>
 						<tal:block tal:repeat="metaObj metaObjs">
 							<tal:block tal:condition="python:metaObj['type']!='ZMSPackage' and metaObj.get('package')==metaObjPackage">
-								<a class="dropdown-item" tal:attributes="href python:'?lang=%s&id=%s'%(request['lang'],metaObj['id'])">
+								<a class="dropdown-item" tal:attributes="href python:'?lang=%s&id=%s'%(request['lang'],metaObj['id']);
+									class python:request.get('id','')==metaObj['id'] and 'dropdown-item selected' or default">
 									<i tal:on-error="string:ERROR icon" tal:attributes="class python:zmscontext.zmi_icon(metaObj['id'])"></i>
 									<span tal:on-error="string:ERROR Name" tal:content="metaObj/name">name</span>
 								</a>


### PR DESCRIPTION
Hello @zmsdev,
to improve orientation in long select lists of metaobjs the contextual metaobj-class is highlightet now
 
![selected](https://user-images.githubusercontent.com/29705216/199905839-f29b1732-4744-42bf-8dc2-85f4fd40d109.gif)
