### PR TITLE
fix manage_analyze

### DIFF
--- a/Products/zms/manage_addzmssqldbform.zpt
+++ b/Products/zms/manage_addzmssqldbform.zpt
@@ -10,43 +10,56 @@
 		<input type="hidden" id="id_prefix" name="id_prefix" tal:attributes="value python:request.get('id_prefix','')" />
 		<input type="hidden" id="ZMS_INSERT" name="ZMS_INSERT" tal:condition="python:request.get('ZMS_INSERT',False)" tal:attributes="value python:request.get('ZMS_INSERT','')" />
 
-		<div class="form-group row"  id="tr_connection_id">
-			<label for="connection_id" class="col-lg-2 control-label mandatory">
+		<div class="form-group row" id="tr_connection_id">
+			<label for="connection_id" class="col-sm-3 col-md-2 control-label mandatory">
 				<span>Connection ID</span>
 			</label>
-			<div class="col-lg-10">
+			<div class="col-sm-9 col-md-10">
 				<div class="btn-group">
-					<select class="form-control" id="connection_id" name="connection_id">
-						<option value="" disabled="disabled" tal:content="python:here.getLangStr('ACTION_SELECT')%'Connection ID'"></option>
+					<button type="button" class="btn btn-secondary" style="min-width:10rem;">Select the SQL-Connection-ID...</button>
+					<button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown">
+						<span class="caret"></span>
+					</button>
+					<div class="dropdown-menu" role="menu">
 						<tal:block tal:repeat="SQLConnectionID python:here.SQLConnectionIDs()">
-							<option tal:attributes="value python:SQLConnectionID[1]">
-								<i class="fas fa-database"></i>
-								<tal:block tal:content="python:SQLConnectionID[1]">SQLConnectionID</tal:block>
-							</option>
+								<a class="dropdown-item" href="javascript:;" tal:attributes="onclick python:'javascript:$(\'#connection_id\').val(\'%s\')\073$(\'button:first\',$(this).parents(\'.btn-group\')).html($(this).html())'%SQLConnectionID[1]">
+									<span tal:attributes="data-url python:getattr(here,SQLConnectionID[1]).absolute_url()">
+										<i class="fas fa-database"></i>
+										<tal:block tal:content="python:SQLConnectionID[1]">SQLConnectionID</tal:block>
+									</span>
+								</a>
 						</tal:block>
-					</select>
+					</div>
 				</div><!-- .btn-group -->
-			</div><!-- .col-lg-10 -->
+			</div>
 		</div><!-- .form-group -->
 		<div class="form-group row"  id="tr_charset">
-			<label for="charset" class="col-lg-2 control-label mandatory">
+			<label for="charset" class="col-sm-3 col-md-2 control-label mandatory">
 				<span>Charset</span>
 			</label>
-			<div class="col-lg-10">
+			<div class="col-sm-9 col-md-10">
 				<select class="form-control" name="charset">
 					<tal:block tal:repeat="charset python:here.enumManager.getValues('charset')">
 						<option tal:attributes="value python:charset[0]; selected python:['','selected'][int(charset[0]=='utf-8')]" tal:content="python:charset[1]">the charset</option>
 					</tal:block>
 				</select>
-			</div><!-- .col-lg-10 -->
+			</div>
+		</div><!-- .form-group -->
+		<div class="form-group row">
+			<label class="col-sm-3 col-md-2 control-label mandatory" for="table_filter"><span>Table-Filter</span></label>
+			<div class="col-sm-9 col-md-10">
+				<input class="form-control" type="text" name="table_filter" placeholder="Please enter RegExp like: (.*?)" tal:attributes="value python:getattr(here,'table_filter','(.*?)')"/>
+			</div>
 		</div><!-- .form-group -->
 		<div class="form-group row"  id="tr_model">
-			<label for="model" class="col-lg-2 control-label mandatory">
+			<label for="model" class="col-sm-3 col-md-2 control-label mandatory">
 				<span>Model</span>
 			</label>
-			<div class="col-lg-10">
-				<textarea class="form-control" name="model" tal:content="python:here.toXmlString([])">the model</textarea>
-			</div><!-- .col-lg-10 -->
+			<div class="col-sm-9 col-md-10">
+				<!-- ACE Editor -->
+				<tal:block tal:on-error="string:ace" tal:content="structure python:here.zmi_ace_editor(here,request,name='model',text=here.toXmlString([]),content_type='text/xml')">ACE Editor</tal:block>
+				<!-- /ACE Editor -->
+			</div>
 		</div><!-- .form-group -->
-	</form><!-- .form-horizontal -->
+	</form>
 </tal:block>

--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -1643,7 +1643,9 @@ ZMIActionList.prototype.exec = function(sender, label, target, meta_id='') {
 				$('#addCancelBtn').click(function() {
 					zmiModal("hide");
 				});
-				if($('#zmiIframeAddDialog .form-group:not([class*="activity"]) .form-control').length==0) {
+				// Auto-Insert on models without attributes but not ZMSSqlDb or ZMSTable
+				if ( ['ZMSSqlDb','ZMSTable'].indexOf($('#ZMS_INSERT').val())==-1 && 
+					$('#zmiIframeAddDialog .form-group:not([class*="activity"]) .form-control').length==0 ) {
 					$('#addInsertBtn').click();
 				}
 			},

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_analyze.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_analyze.zpt
@@ -39,68 +39,83 @@
 
 	<legend class="navbar navbar-nav navbar-expand navbar-dark" 
 		tal:content="python:'%s (%s)'%(meta_id,here.display_type(request,meta_id))">the display-type</legend>
+
 	<table class="table">
-	<thead>
-	<tr>
-		<th class="meta_id">&nbsp;</th>
-		<th class="usage">Usage [%/Abs.]</th>
-		<th class="empty">Empty [%/Abs.]</th>
-	</tr>
-	</thead>
-	<tbody>
-	<tal:block tal:repeat="key python:attrIds+subObjectIds">
-		<tr tal:define="global metaObjAttr python:here.getMetaobjAttr(meta_id,key)">
-			<td class="meta_id">
-				<tal:block tal:content="structure metaObjAttr/name">the name</tal:block>
-				(<tal:block tal:content="metaObjAttr/id">the id</tal:block>: <tal:block tal:content="metaObjAttr/type">the type</tal:block>)
-			</td>
-			<td class="usage">
-				<a tal:attributes="href python:'javascript:toggleElement(\'img_%s1\',\'ol_%s1\')'%(metaObjAttr['id'],metaObjAttr['id'])" style="text-decoration:none;">
-					<i tal:attributes="id python:'img_%s1'%metaObjAttr['id']" class="fas fa-caret-right toggle"></i>
-					<tal:block tal:on-error="string: 0"
-						tal:content="python:round(100*len(stat1[metaObjAttr['id']])/len(res))">perc</tal:block>% (<tal:block tal:content="python:len(stat1[metaObjAttr['id']])">abs</tal:block>)
-				</a>
-				<ol tal:attributes="id python:'ol_%s1'%metaObjAttr['id']" style="visibility:hidden;display:none;">
-					<li tal:repeat="ob python:stat1[metaObjAttr['id']]"><a tal:attributes="href python:'%s/manage_main'%ob['abs_url']" target="_blank" tal:content="python:ob['abs_url']">the url</a></li>
-				</ol>
-			</td>
-			<td class="empty">
-				<a tal:attributes="href python:'javascript:toggleElement(\'img_%s0\',\'ol_%s0\')'%(metaObjAttr['id'],metaObjAttr['id'])"  style="text-decoration:none;">
-					<i tal:attributes="id python:'img_%s1'%metaObjAttr['id']" class="fas fa-caret-right toggle"></i>
-					<tal:block tal:on-error="string: 0"
-						tal:content="python:100*len(stat0[metaObjAttr['id']])/len(res)">perc</tal:block>% (<tal:block tal:content="python:len(stat0[metaObjAttr['id']])">abs</tal:block>)
-				</a>
-				<ol tal:attributes="id python:'ol_%s0'%metaObjAttr['id']" style="visibility:hidden;display:none;">
-					<li tal:repeat="ob python:stat0[metaObjAttr['id']]"><a tal:attributes="href python:'%s/manage_main'%ob['abs_url']" target="_blank" tal:content="python:ob['abs_url']">the url</a></li>
-				</ol>
-			</td>
-		</tr>
-	</tal:block>
-	<tr>
-		<td>Total:</td>
-		<td><tal:block tal:content="python:len(res)">the total</tal:block></td>
-		<td>&nbsp;</td>
-	</tr>
-	</tbody>
+		<thead>
+			<tr>
+				<th class="meta_id">&nbsp;</th>
+				<th class="usage">Usage [%/Abs.]</th>
+				<th class="empty">Empty [%/Abs.]</th>
+			</tr>
+		</thead>
+		<tbody tal:define="keys python:attrIds+subObjectIds">
+			<tr tal:repeat="key keys">
+				<tal:block tal:define="metaObjAttr python:here.getMetaobjAttr(meta_id,key)">
+					<td class="meta_id">
+						<tal:block tal:content="structure metaObjAttr/name">the name</tal:block>
+						(<tal:block tal:content="metaObjAttr/id">the id</tal:block>: <tal:block tal:content="metaObjAttr/type">the type</tal:block>)
+					</td>
+					<td class="usage">
+						<a tal:attributes="href python:'javascript:toggleElement(\'img_%s1\',\'ol_%s1\')'%(metaObjAttr['id'],metaObjAttr['id'])" style="text-decoration:none;">
+							<i tal:attributes="id python:'img_%s1'%metaObjAttr['id']" class="fas fa-caret-right toggle"></i>
+							<tal:block tal:on-error="string: 0"
+								tal:content="python:round(100*len(stat1[metaObjAttr['id']])/len(res))">perc</tal:block>% (<tal:block tal:content="python:len(stat1[metaObjAttr['id']])">abs</tal:block>)
+						</a>
+						<ol tal:attributes="id python:'ol_%s1'%metaObjAttr['id']" style="visibility:hidden;display:none;">
+							<li tal:repeat="ob python:stat1[metaObjAttr['id']]"><a tal:attributes="href python:'%s/manage_main'%ob['abs_url']" target="_blank" tal:content="python:ob['abs_url']">the url</a></li>
+						</ol>
+					</td>
+					<td class="empty">
+						<a tal:attributes="href python:'javascript:toggleElement(\'img_%s0\',\'ol_%s0\')'%(metaObjAttr['id'],metaObjAttr['id'])"  style="text-decoration:none;">
+							<i tal:attributes="id python:'img_%s1'%metaObjAttr['id']" class="fas fa-caret-right toggle"></i>
+							<tal:block tal:on-error="string: 0"
+								tal:content="python:100*len(stat0[metaObjAttr['id']])/len(res)">perc</tal:block>% (<tal:block tal:content="python:len(stat0[metaObjAttr['id']])">abs</tal:block>)
+						</a>
+						<ol tal:attributes="id python:'ol_%s0'%metaObjAttr['id']" style="visibility:hidden;display:none;">
+							<li tal:repeat="ob python:stat0[metaObjAttr['id']]"><a tal:attributes="href python:'%s/manage_main'%ob['abs_url']" target="_blank" tal:content="python:ob['abs_url']">the url</a></li>
+						</ol>
+					</td>
+				</tal:block>
+			</tr>
+			<tr tal:condition="python:attrIds+subObjectIds==[]">
+				<td class="meta_id"></td>
+				<td class="usage">
+					<ol class="pl-0">
+						<li tal:repeat="ob res" style="list-style-position: inside;"
+							><a href="#" target="_blank" 
+							tal:attributes="href python:'%s/manage_main'%ob['getPath']" 
+							tal:content="python:ob['getPath'].replace('/gpoh/kinderkrebsinfo/','/mysites/mysite').replace('/gpoh','/mysites/mysite')">the path</a></li>
+					</ol>
+				</td>
+				<td class="empty"></td>
+			</tr>
+			<tr>
+				<td>Total:</td>
+				<td><tal:block tal:content="python:len(res)">the total</tal:block></td>
+				<td>&nbsp;</td>
+			</tr>
+		</tbody>
 	</table>
 </form>
 
 <tal:block tal:content="structure python:here.zmi_html_foot(here,request)">zmi_html_foot</tal:block>
 
 <script language="JavaScript">
-function toggleElement( sender, id) {
-	var speed = "normal";
-	var img = $('#'+sender);
-	var el = $('#'+id);
-	if ( el.css("display").toLowerCase()=="none") {
-		img.attr( { class: "fas fa-caret-down toggle", title: "-"});
-		el.css({'visibility':'visible','display':''});
+//<!--
+	function toggleElement( sender, id) {
+		var speed = "normal";
+		var img = $('#'+sender);
+		var el = $('#'+id);
+		if ( el.css("display").toLowerCase()=="none") {
+			img.attr( { class: "fas fa-caret-down toggle", title: "-"});
+			el.css({'visibility':'visible','display':''});
+		}
+		else {
+			img.attr( { class: "fas fa-caret-right toggle", title: "+"});
+			el.css({'visibility':'hidden','display':'none'});
+		}
 	}
-	else {
-		img.attr( { class: "fas fa-caret-right toggle", title: "+"});
-		el.css({'visibility':'hidden','display':'none'});
-	}
-}
+//-->
 </script>
 <style>
 	.zmi.analyze form.card legend {

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_analyze.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_analyze.zpt
@@ -84,7 +84,7 @@
 						<li tal:repeat="ob res" style="list-style-position: inside;"
 							><a href="#" target="_blank" 
 							tal:attributes="href python:'%s/manage_main'%ob['getPath']" 
-							tal:content="python:ob['getPath'].replace('/gpoh/kinderkrebsinfo/','/mysites/mysite').replace('/gpoh','/mysites/mysite')">the path</a></li>
+							tal:content="python:ob['getPath']">the path</a></li>
 					</ol>
 				</td>
 				<td class="empty"></td>


### PR DESCRIPTION
hi @zmsdev ,
there is a prohibitive issue with the analysis/listing of certain object classes that miss certain attributes. Any instance of these classes  e.g. ZMSSQLDB, is not shown in the analysis-list, because the current code generates with `attrIds+subObjectIds` an empty list. 
This although the objects actually have editable attrs like titlealt.
I cannot really find a plausible reason for that  (too restrictive?) filtering, but give a simple fix:
in case of an empty attr list, now these obj node are systematically listed without declaring any attribute. Thus these content instances can be found.

_Screen Image: top without fix, bottom with fix_
![manage_analyze](https://user-images.githubusercontent.com/29705216/200131085-912552b1-cf02-470d-8b8e-820129da1730.gif)
