### PR TITLE
Stabilize Cropper Function (UniBE DCMS-628)

### DIFF
--- a/Products/zms/plugins/www/objattrs/zmi.blob.ZMSGraphic_extEdit.js
+++ b/Products/zms/plugins/www/objattrs/zmi.blob.ZMSGraphic_extEdit.js
@@ -1,5 +1,20 @@
 // Functions for advanced ZMSGraphic-editing
 
+/**
+ * jquery-cropper - the jQuery Image Cropping Plugin
+ * @see https://github.com/fengyuanchen/jquery-cropper/
+ */
+function runPluginCropper(c) {
+	$.plugin('cropper',{
+		files: [
+			'/++resource++zms_/jquery/cropper/cropper.css',
+			'/++resource++zms_/jquery/cropper/cropper.min.js',
+			'/++resource++zms_/jquery/cropper/jquery-cropper.min.js'
+		]
+	});
+	$.plugin('cropper').get('body',c);
+}
+
 var ZMSGraphic_elName = null;
 var ZMSGraphic_params = null;
 var ZMSGraphic_lang = null;
@@ -16,17 +31,21 @@ var ZMSGraphic_extEdit_slider = false;
 function ZMSGraphic_extEdit_initialize() {
 	$("body").append("<style>div.jcrop-holder input { display:none; visibility:hidden; }</style>");
 	$("#zmiModalZMSGraphic_extEdit_actions #ZMSGraphic_extEdit_crop").click(function() {
-		var cropper_gui = toggle_cropper_gui($(this))
 		$ZMSGraphic_img = $('.modal-body div#ZMSGraphic_extEdit_image img');
+		var cropper_gui = toggle_cropper_gui($(this))
 		if ( cropper_gui == true ) {
 			ZMSGraphic_action = 'crop';
 			// Add Cropper Marker to image
-			changeCropperAvailability(img=$ZMSGraphic_img,available=true,cropping=true);
+			changeCropperAvailability(available=true,cropping=true);
 		} else {
 			// Remove Cropper Marker from image
 			ZMSGraphic_action = null;
-			$ZMSGraphic_img.cropper('clear');
-			$ZMSGraphic_img.cropper('destroy');
+			try {
+				$ZMSGraphic_img.cropper('clear');
+				$ZMSGraphic_img.cropper('destroy');
+			} catch (error) {
+				console.log('ZMSGraphic_extEdit_initialize' +  error)
+			}
 		}
 	});
 	$("#zmiModalZMSGraphic_extEdit_actions #ZMSGraphic_extEdit_preview").click(function() {
@@ -224,7 +243,7 @@ function ZMSGraphic_extEdit_apply() {
 					if (data.length==0) return;
 					var result = eval('('+data+')');
 					var elName = result['elName'];
-					var elParams = 'lang='+escape(result['lang'])+'&key='+escape(result['key'])+'&form_id='+escape(result['form_id']);
+					var elParams = 'lang='+encodeURI(result['lang'])+'&key='+encodeURI(result['key'])+'&form_id='+encodeURI(result['form_id']);
 					ZMSGraphic_extEdit_set(elName,result['src'],result['filename'],result['width'],result['height'],elParams);
 				});
 	}
@@ -280,7 +299,6 @@ function ZMSGraphic_extEdit_apply() {
 			$(`.custom-file label[for="${ZMSGraphic_elName}"]`)
 				.text(new_label)
 				.addClass('new_label');
-
 		}
 	}
 	// Close dialog.
@@ -288,10 +306,11 @@ function ZMSGraphic_extEdit_apply() {
 	return false;
 }
 
-function changeCropperAvailability(img, available, cropping) {
+function changeCropperAvailability(available, cropping) {
+	$ZMSGraphic_img = $('.modal-body div#ZMSGraphic_extEdit_image img');
 	if (available) {
 		runPluginCropper(function() {
-			img.cropper({
+			$ZMSGraphic_img.cropper({
 				allowSelect	: false,
 				setSelect	: [ 0, 0, 25, 25 ],
 				minSize		: [25, 25],
@@ -302,13 +321,13 @@ function changeCropperAvailability(img, available, cropping) {
 						ZMSGraphic_cropcoords = e.detail;
 						$('#zmiModalZMSGraphic_extEdit_actions input#ZMSGraphic_extEdit_width').val( Math.round(ZMSGraphic_cropcoords.width) );
 						$('#zmiModalZMSGraphic_extEdit_actions input#ZMSGraphic_extEdit_height').val( Math.round(ZMSGraphic_cropcoords.height) );
-					} else {
-						img.cropper('clear');
-						img.cropper('destroy');
-					}
+					} 
+					// else {
+					// 	$ZMSGraphic_img.cropper('clear');
+					// 	$ZMSGraphic_img.cropper('destroy');
+					// }
 				}
 			});
-			// $ZMSGraphic_cropper = $ZMSGraphic_img;
 		});
 	}
 }

--- a/Products/zms/plugins/www/objattrs/zmi.blob.ZMSGraphic_extEdit.js
+++ b/Products/zms/plugins/www/objattrs/zmi.blob.ZMSGraphic_extEdit.js
@@ -299,7 +299,7 @@ function changeCropperAvailability(available, cropping) {
 					}
 				}
 			});
-			$ZMSGraphic_cropper = $ZMSGraphic_img;
+			// $ZMSGraphic_cropper = $ZMSGraphic_img;
 		});
 	}
 }

--- a/Products/zms/plugins/www/objattrs/zmi.blob.ZMSGraphic_extEdit.js
+++ b/Products/zms/plugins/www/objattrs/zmi.blob.ZMSGraphic_extEdit.js
@@ -14,31 +14,19 @@ var ZMSGraphic_act_height = null;
 var ZMSGraphic_extEdit_slider = false;
 
 function ZMSGraphic_extEdit_initialize() {
-	$("body").append("<style>div.jcrop-holder input {display:none;visibility:hidden;}</style>");
+	$("body").append("<style>div.jcrop-holder input { display:none; visibility:hidden; }</style>");
 	$("#zmiModalZMSGraphic_extEdit_actions #ZMSGraphic_extEdit_crop").click(function() {
-		if ( $(this).prop('disabled') == undefined || $(this).prop('disabled') == false ) {
-			$(this).prop("disabled",true);
-			$(this).removeClass('btn-secondary').addClass('btn-dark');
-			$("#zmiModalZMSGraphic_extEdit_actions input#ZMSGraphic_extEdit_slider").prop("disabled",true);
-			$("#zmiModalZMSGraphic_extEdit_actions input#ZMSGraphic_extEdit_width").prop("disabled",true);
-			$("#zmiModalZMSGraphic_extEdit_actions input#ZMSGraphic_extEdit_height").prop("disabled",true);
-			$("#zmiModalZMSGraphic_extEdit_actions input#ZMSGraphic_extEdit_proportional").prop("disabled",true);
+		var cropper_gui = toggle_cropper_gui($(this))
+		$ZMSGraphic_img = $('.modal-body div#ZMSGraphic_extEdit_image img');
+		if ( cropper_gui == true ) {
 			ZMSGraphic_action = 'crop';
-			changeCropperAvailability(true,true);
+			// Add Cropper Marker to image
+			changeCropperAvailability(img=$ZMSGraphic_img,available=true,cropping=true);
 		} else {
-			if ($ZMSGraphic_cropper != null) {
-				// $ZMSGraphic_cropper.clear();
-				$ZMSGraphic_cropper.cropper('clear');
-				$ZMSGraphic_cropper.cropper('destroy');
-				$ZMSGraphic_cropper = null;
-				$(this).prop("disabled",false);
-				$(this).removeClass('btn-dark').addClass('btn-secondary');
-				$("#zmiModalZMSGraphic_extEdit_actions input#ZMSGraphic_extEdit_slider").prop("disabled",false);
-				$("#zmiModalZMSGraphic_extEdit_actions input#ZMSGraphic_extEdit_width").prop("disabled",false);
-				$("#zmiModalZMSGraphic_extEdit_actions input#ZMSGraphic_extEdit_height").prop("disabled",false);
-				$("#zmiModalZMSGraphic_extEdit_actions input#ZMSGraphic_extEdit_proportional").prop("disabled",false);
-			}
+			// Remove Cropper Marker from image
 			ZMSGraphic_action = null;
+			$ZMSGraphic_img.cropper('clear');
+			$ZMSGraphic_img.cropper('destroy');
 		}
 	});
 	$("#zmiModalZMSGraphic_extEdit_actions #ZMSGraphic_extEdit_preview").click(function() {
@@ -48,6 +36,24 @@ function ZMSGraphic_extEdit_initialize() {
 		}
 		ZMSGraphic_action = null;
 	});
+}
+
+function toggle_cropper_gui(e) {
+	var cropper_gui = false;
+	if ( e.prop('disabled') == undefined || e.prop('disabled') == false ) {
+		// Set Cropper GUI to active status
+		cropper_gui = true;
+		e.addClass('active')
+	} else {
+		e.removeClass('active')
+	}
+	// If Cropper GUI should get active, some other interfering inputs must get deactivated
+	e.prop("disabled",cropper_gui);
+	$("#zmiModalZMSGraphic_extEdit_actions input#ZMSGraphic_extEdit_slider").prop("disabled",cropper_gui);
+	$("#zmiModalZMSGraphic_extEdit_actions input#ZMSGraphic_extEdit_width").prop("disabled",cropper_gui);
+	$("#zmiModalZMSGraphic_extEdit_actions input#ZMSGraphic_extEdit_height").prop("disabled",cropper_gui);
+	$("#zmiModalZMSGraphic_extEdit_actions input#ZMSGraphic_extEdit_proportional").prop("disabled",cropper_gui);
+	return cropper_gui
 }
 
 /**
@@ -160,7 +166,7 @@ function ZMSGraphic_extEdit_action( elName, elParams, pil) {
 				},
 				beforeClose:function() {
 					$('div#ZMSGraphic_extEdit_image').html('');
-					changeCropperAvailability(false);
+					changeCropperAvailability(img=null, available=true,cropping=true);
 				},
 		});
 }
@@ -282,10 +288,10 @@ function ZMSGraphic_extEdit_apply() {
 	return false;
 }
 
-function changeCropperAvailability(available, cropping) {
+function changeCropperAvailability(img, available, cropping) {
 	if (available) {
 		runPluginCropper(function() {
-			$ZMSGraphic_img.cropper({
+			img.cropper({
 				allowSelect	: false,
 				setSelect	: [ 0, 0, 25, 25 ],
 				minSize		: [25, 25],
@@ -296,6 +302,9 @@ function changeCropperAvailability(available, cropping) {
 						ZMSGraphic_cropcoords = e.detail;
 						$('#zmiModalZMSGraphic_extEdit_actions input#ZMSGraphic_extEdit_width').val( Math.round(ZMSGraphic_cropcoords.width) );
 						$('#zmiModalZMSGraphic_extEdit_actions input#ZMSGraphic_extEdit_height').val( Math.round(ZMSGraphic_cropcoords.height) );
+					} else {
+						img.cropper('clear');
+						img.cropper('destroy');
 					}
 				}
 			});


### PR DESCRIPTION
ZMSGraphic/img input might drop Cropper. It is not reproduceable for sure. The movie shows the effect:
 https://nextcloud.sntl-publishing.com/s/RcErG52J5d8TQ4m/download
 Removing line
 https://github.com/zms-publishing/ZMS/blob/31d7c71330f77367b502ffd22637a1f56f6c8820/Products/zms/plugins/www/objattrs/zmi.blob.ZMSGraphic_extEdit.js#L302
 seems to solve the problem. Any idea, why? Or why this line was needed?