### PR TITLE
cleaned doublicated footer element

### DIFF
--- a/Products/zms/conf/metacmd_manager/manage_tab_search/manage_tab_search.zpt
+++ b/Products/zms/conf/metacmd_manager/manage_tab_search/manage_tab_search.zpt
@@ -88,7 +88,7 @@
 	</form>
 </tal:block>
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 <script type="text/javascript" charset="UTF-8" src="/++resource++zms_/ZMS/zmi_body_content_search.js"></script>
 </body>
 </html>

--- a/Products/zms/conf/metacmd_manager/manage_tab_tasks/manage_tab_tasks.zpt
+++ b/Products/zms/conf/metacmd_manager/manage_tab_tasks/manage_tab_tasks.zpt
@@ -73,6 +73,6 @@
 </div>
 </tal:block>
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/import/manage_cachepurge-5.0.0.metacmd.xml
+++ b/Products/zms/import/manage_cachepurge-5.0.0.metacmd.xml
@@ -126,7 +126,7 @@ return '<br />'.join(msg)
 			</div>
 		</form>
 	</div>
-	<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+	<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>]]>
       </item>

--- a/Products/zms/zpt/MediaDb/manage_browse.zpt
+++ b/Products/zms/zpt/MediaDb/manage_browse.zpt
@@ -54,6 +54,6 @@
 </form>
 
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/MediaDb/manage_properties.zpt
+++ b/Products/zms/zpt/MediaDb/manage_properties.zpt
@@ -29,6 +29,6 @@
 		</form>
 	
 	</div><!-- #zmi-tab -->
-	<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+	<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/ZMS/manage_customize.zpt
+++ b/Products/zms/zpt/ZMS/manage_customize.zpt
@@ -389,6 +389,6 @@
 	</div>
 
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/ZMS/manage_customizelanguagesform.zpt
+++ b/Products/zms/zpt/ZMS/manage_customizelanguagesform.zpt
@@ -197,6 +197,6 @@ function zmiFormSubmit(sender,d) {
 </tal:block>
 
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/ZMS/manage_users.zpt
+++ b/Products/zms/zpt/ZMS/manage_users.zpt
@@ -597,7 +597,7 @@ function zmiModalInsertUserOpen(context) {
 </tal:block>
 
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 
 <script>
 	function zmiSynchronizeUsers(sender){

--- a/Products/zms/zpt/ZMSContainerObject/manage_importexport.zpt
+++ b/Products/zms/zpt/ZMSContainerObject/manage_importexport.zpt
@@ -136,6 +136,6 @@ function onExportFormatChange(el) {
 </tal:block>
 
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/ZMSContainerObject/manage_importexportdebugfilter.zpt
+++ b/Products/zms/zpt/ZMSContainerObject/manage_importexportdebugfilter.zpt
@@ -175,6 +175,6 @@
 </tal:block>
 
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/ZMSContainerObject/manage_main.zpt
+++ b/Products/zms/zpt/ZMSContainerObject/manage_main.zpt
@@ -113,6 +113,6 @@
 
 </tal:block>
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/ZMSContainerObject/manage_system.zpt
+++ b/Products/zms/zpt/ZMSContainerObject/manage_system.zpt
@@ -101,6 +101,6 @@
 </form>
 
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/ZMSFilterManager/manage_main.zpt
+++ b/Products/zms/zpt/ZMSFilterManager/manage_main.zpt
@@ -518,7 +518,7 @@ $(function(){
 </tal:block>
 
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>
 </tal:block>

--- a/Products/zms/zpt/ZMSFormatProvider/manage_charformats.zpt
+++ b/Products/zms/zpt/ZMSFormatProvider/manage_charformats.zpt
@@ -205,6 +205,6 @@ $ZMI.registerReady(function(){
 
 </script>
 
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/ZMSFormatProvider/manage_textformats.zpt
+++ b/Products/zms/zpt/ZMSFormatProvider/manage_textformats.zpt
@@ -207,6 +207,6 @@ $(function(){
 
 </script>
 
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/ZMSIndex/manage_main.zpt
+++ b/Products/zms/zpt/ZMSIndex/manage_main.zpt
@@ -405,7 +405,7 @@ $(function() {
 
 </form>
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>
 </tal:block>

--- a/Products/zms/zpt/ZMSLinkElement/manage_refform.zpt
+++ b/Products/zms/zpt/ZMSLinkElement/manage_refform.zpt
@@ -32,6 +32,6 @@
 </tal:block>
 
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/ZMSMetacmdProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetacmdProvider/manage_main.zpt
@@ -383,6 +383,6 @@ $(function(){
 //-->
 </script>
 
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_metas.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_metas.zpt
@@ -215,6 +215,6 @@ function zmiFormSubmit(sender,d) {
 </form>
 
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/ZMSObject/manage_main.zpt
+++ b/Products/zms/zpt/ZMSObject/manage_main.zpt
@@ -38,7 +38,7 @@
 </tal:block>
 
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>
 </tal:block>

--- a/Products/zms/zpt/ZMSRepositoryManager/manage_main.zpt
+++ b/Products/zms/zpt/ZMSRepositoryManager/manage_main.zpt
@@ -177,6 +177,6 @@
 </div><!-- .tab-content -->
 
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/ZMSSqlDb/manage_configuration.zpt
+++ b/Products/zms/zpt/ZMSSqlDb/manage_configuration.zpt
@@ -318,6 +318,6 @@ function mms_normalize_rows(el_tbody) {
 </tal:block>
 
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/ZMSSqlDb/manage_main.zpt
+++ b/Products/zms/zpt/ZMSSqlDb/manage_main.zpt
@@ -220,6 +220,6 @@
 </tal:block>
 
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/ZMSSqlDb/manage_properties.zpt
+++ b/Products/zms/zpt/ZMSSqlDb/manage_properties.zpt
@@ -82,6 +82,6 @@
 </form>
 
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/ZMSTrashcan/manage_properties.zpt
+++ b/Products/zms/zpt/ZMSTrashcan/manage_properties.zpt
@@ -42,6 +42,6 @@
 </form>
 
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/ZMSWorkflowProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSWorkflowProvider/manage_main.zpt
@@ -605,7 +605,7 @@
 </div><!-- .tab-content -->
 
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>
 </tal:block>

--- a/Products/zms/zpt/ZMSWorkflowProvider/manage_main_acquired.zpt
+++ b/Products/zms/zpt/ZMSWorkflowProvider/manage_main_acquired.zpt
@@ -50,6 +50,6 @@
 </form>
 
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/ZMSZCatalogAdapter/manage_main.zpt
+++ b/Products/zms/zpt/ZMSZCatalogAdapter/manage_main.zpt
@@ -371,6 +371,6 @@ $(function() {
 //-->
 </script>
 
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/objattrs/manage_propertiesform.zpt
+++ b/Products/zms/zpt/objattrs/manage_propertiesform.zpt
@@ -37,6 +37,6 @@
 </form>
 
 </div><!-- #zmi-tab -->
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 </body>
 </html>

--- a/Products/zms/zpt/versionmanager/manage_undoversionform.zpt
+++ b/Products/zms/zpt/versionmanager/manage_undoversionform.zpt
@@ -195,7 +195,7 @@
 	
 </style>
 
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 <script type="text/javascript" charset="UTF-8" src="/++resource++zms_/jquery/diff/diff_match_patch.js"></script>
 <script type="text/javascript" charset="UTF-8" src="/++resource++zms_/jquery/diff/jquery.pretty-text-diff.min.js"></script>
 </body>


### PR DESCRIPTION
The footer section was systematically doublicated due to `<footer tal:content=... >` instead of `<footer tal:replace=... >`