### PR TITLE
New CSS class: sticky-controls

### DIFF
--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -2110,9 +2110,19 @@ $ZMI.registerReady(function(){
 // ############################################################################
 // ### BACK-TO-TOP-SCROLL BUTTON
 // ############################################################################
+
+function isScrolledIntoView(elem) {
+	var docViewTop = $(window).scrollTop();
+	var docViewBottom = docViewTop + $(window).height();
+	var elemTop = $(elem).offset().top;
+	var elemBottom = elemTop + $(elem).height();
+	return ((elemBottom <= docViewBottom) && (elemTop >= docViewTop));
+};
+
 $ZMI.registerReady(function(){
 	// Reference: https://getflywheel.com/layout/sticky-back-to-top-button-tutorial/
 	const scrollToTopButton = document.getElementById('js-top');
+	const stickyControls = document.getElementsByClassName('sticky-controls')[0];
 	if ( scrollToTopButton ) {
 		const scrollFunc = () => {
 			let y = window.scrollY;
@@ -2120,6 +2130,14 @@ $ZMI.registerReady(function(){
 				scrollToTopButton.className = "back-to-top show";
 			} else {
 				scrollToTopButton.className = "back-to-top hide";
+			}
+			if (stickyControls) {
+				if ( !isScrolledIntoView(stickyControls) ){
+					stickyControls.classList.add('sticky-controls-activated');
+				}
+				if (y == 0) {
+					stickyControls.classList.remove('sticky-controls-activated');
+				}
 			}
 		};
 		window.addEventListener("scroll", scrollFunc);

--- a/Products/zms/plugins/www/zmi.core.css
+++ b/Products/zms/plugins/www/zmi.core.css
@@ -573,6 +573,21 @@ div[draggable=true].btn:not(:disabled):not(.disabled) {
 		right:unset;
 	}
 }
+/* Stick 'sticky-controls' bar to the top */
+.zmi .sticky-controls {
+	width: 100%;
+	background: white;
+	z-index: 1000;
+	position: relative;
+	box-shadow: unset;
+	transition: box-shadow 0.5s ease-in-out;
+}
+.zmi .sticky-controls.sticky-controls-activated {
+	position: sticky;
+	top: 0;
+	box-shadow: 0 1rem 1rem -0.5rem #0003;
+	transition: box-shadow 0.3s ease-in-out;
+}
 
 /* Showing clientids only to Managers */
 body.zmi ul.portalClients.zmi-container .zmi-item .portalClient .portalClientId.zmi-manage-main-change {

--- a/Products/zms/plugins/www/zmi.core.css
+++ b/Products/zms/plugins/www/zmi.core.css
@@ -575,16 +575,16 @@ div[draggable=true].btn:not(:disabled):not(.disabled) {
 }
 /* Stick 'sticky-controls' bar to the top */
 .zmi .sticky-controls {
+	position: relative;
 	width: 100%;
 	background: white;
-	z-index: 1000;
-	position: relative;
 	box-shadow: unset;
 	transition: box-shadow 0.5s ease-in-out;
 }
 .zmi .sticky-controls.sticky-controls-activated {
 	position: sticky;
 	top: 0;
+	z-index: 999;
 	box-shadow: 0 1rem 1rem -0.5rem #0003;
 	transition: box-shadow 0.3s ease-in-out;
 }

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -90,7 +90,7 @@
 		</tal:block>
 	</select>
 
-	<div class="d-flex flex-row justify-content-between align-items-start py-2">
+	<div class="d-flex flex-row justify-content-between align-items-start py-2 sticky-controls">
 		<div class="btn-group m-2 text-nowrap" role="group" aria-label="Object Class Selector">
 			<div class="zmi-action btn-group dropleft nav-metaobj" tal:attributes="title python:here.getZMILangStr('CAPTION_CHOOSEOBJ')">
 				<input tal:condition="python:metaObj.get('acquired')" type="hidden" name="id" tal:attributes="value metaObj/id">
@@ -361,14 +361,6 @@
 	></div>
 	<!-- EO Usage -->
 
-	<div class="form-row">
-		<div class="controls save text-nowrap">
-			<button type="submit" name="btn" class="btn btn-primary" value="BTN_SAVE" tal:content="python:here.getZMILangStr('BTN_SAVE')">Save</button>
-			<a href="./manage_main" class="btn btn-secondary" value="BTN_BACK" tal:content="python:here.getZMILangStr('BTN_BACK')">Back</a>
-		</div><!-- .controls.save -->
-	</div><!-- .form-row -->
-
-
 	<!-- BO Languages -->
 	<div class="meta-languages mt-3" tal:define="langIds python:here.getLangIds(sort=True)">
 	<table class="table table-sm table-striped table-bordered table-hover">
@@ -564,7 +556,7 @@
 
 </div><!-- #zmi-tab -->
 
-<footer tal:content="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
+<footer tal:replace="structure python:here.zmi_body_footer(here,request)">zmi_body_footer</footer>
 
 <script>
 // <!--


### PR DESCRIPTION
The metobj-manager gui had two sections with its save button: one on the top of the form and the other at the bottom, because the form may be long and the save button may get invisible.
The new css class "sticky-controls" reacts on vertical scrolling and is activated as sticky when leaving the viewport.

![sticky_controls](https://user-images.githubusercontent.com/29705216/210957592-77185a5f-cfe2-48c4-82e5-6c9522185170.gif)
