### PR TITLE
try encoding if blob data empty/text

### DIFF
--- a/Products/zms/_blobfields.py
+++ b/Products/zms/_blobfields.py
@@ -53,6 +53,17 @@ def rfc1123_date(dt):
 
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+_blobfields.bytes_hex:
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+def bytes_hex(data):
+    hexdata = None
+    try:
+        hexdata = bytes(data).hex()
+    except:
+        hexdata = bytes(data, encoding='utf-8').hex()
+    return hexdata
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 _blobfields.recurse_downloadRessources:
 
 Download from ZODB to file-system during Export.
@@ -872,7 +883,7 @@ class MyImage(MyBlob, Image):
           if sdata.find('<![CDATA[') < 0 and sdata.find(']]>') < 0:
             hexdata = '<![CDATA[%s]]>'%sdata
         if hexdata is None:
-          hexdata = bytes(data).hex()
+          hexdata = bytes_hex(data)
         data = hexdata
         objtype = ' type="image"'
       else:
@@ -988,7 +999,7 @@ class MyFile(MyBlob, File):
           if sdata.find('<![CDATA[') < 0 and sdata.find(']]>') < 0:
             hexdata = '<![CDATA[%s]]>'%sdata
         if hexdata is None:
-          hexdata = bytes(data).hex()
+          hexdata = bytes_hex(data)
         data = hexdata
         objtype = ' type="file"'
       else:

--- a/Products/zms/_xmllib.py
+++ b/Products/zms/_xmllib.py
@@ -502,7 +502,7 @@ def toXml(self, value, indentlevel=0, xhtml=False, encoding='utf-8'):
           pass
       # Otherwise hexlify
       if cdata is None:
-        cdata = data.hex()
+        cdata = _blobfields.bytes_hex(data)
       xml.append(cdata)
       xml.append('</%s>' % tagname)
 


### PR DESCRIPTION
missing mediafolder file block XML export; the fix prevents that block an missing binarys appear as empty file in the XML stream.

![recordset_pdf_empty](https://user-images.githubusercontent.com/29705216/218263267-0b4ffb57-db45-4cae-b983-6898971f7a7f.gif)
