### PR TITLE
SimpleMDE: Added condition to render markdown

### DIFF
--- a/Products/zms/_textformatmanager.py
+++ b/Products/zms/_textformatmanager.py
@@ -97,11 +97,12 @@ class TextFormatObject(object):
         text = getattr(self, name)(context=self, key=key, text=text, REQUEST=REQUEST)
     except:
       standard.writeError( self, '[renderText]: can\'t %s'%name)
-    try:
-      import markdown
-      text = markdown.markdown(text)
-    except:
-      pass
+    if self.getConfProperty('ZMS.richtext.plugin', '') == 'simplemde':
+      try:
+        import markdown
+        text = markdown.markdown(text)
+      except:
+        pass
     # Return.
     return text
 


### PR DESCRIPTION
In #125 the SimpleMDE / Markdown Editor was introduced as additional RTE.

To avoid unintended rendering of existing text content as Markdown, I suggest adding a condition.

However, the `ConfProperties` are set for the entire ZMS client, so existing text content in this client will still to be affected.

An additional condition to check the paragraph format or something similar would prevent this...