### PR TITLE
fixed access for Zope UnrestrictedUser

### DIFF
--- a/Products/zms/_accessmanager.py
+++ b/Products/zms/_accessmanager.py
@@ -347,11 +347,11 @@ class AccessableObject(object):
                 v = creds[x]
                 if self.getUserAttr(auth_user,name,v) != v:
                   self.setUserAttr(auth_user,name,v)
-      # manage must not be accessible for Anonymous
+      # manage must not be accessible for Anonymous (cave: <UnrestrictedUser>.has_role()==1 )
       if request['URL0'].find('/manage') >= 0:
         lower = self.getUserAttr(auth_user,'attrActiveStart','')
         upper = self.getUserAttr(auth_user,'attrActiveEnd','')
-        if not standard.todayInRange(lower, upper) or auth_user.has_role('Anonymous'):
+        if not standard.todayInRange(lower, upper) or ('Anonymous' in request['AUTHENTICATED_USER'].getRolesInContext(request)):
           import zExceptions
           raise zExceptions.Unauthorized
       # manage may be registrable for Authenticated without permissions
@@ -740,8 +740,8 @@ class AccessManager(AccessableContainer):
         for userName in userFldr.getUserNames():
           if without_node_check or (local_userFldr == userFldr) or self.get_local_roles_for_userid(userName):
             if (exact_match and search_term==userName) or \
-               search_term == '' or \
-               search_term.find(userName) >= 0:
+              search_term == '' or \
+              str(search_term).find(userName) >= 0:
               users.append({'name':userName})
       for user in users:
         login_name = user[login_attr]

--- a/Products/zms/zpt/common/zmi_navbar_brand.zpt
+++ b/Products/zms/zpt/common/zmi_navbar_brand.zpt
@@ -1,7 +1,7 @@
 <a tal:condition="python:here.getConfProperty('ZMS.branding','ZMS5') in ['ZMS5','']"
 		class="navbar-brand"
 		href="javascript:;" onclick="window.open('http://www.zms-publishing.com');"
-		title="ZMS5 - Python-based Content Management System for Science, Technology and Medicine, &#169; 2000-2021 HOFFMANN+LIEBENBERG"
+		title="ZMS5 - Python-based Content Management System for Science, Technology and Medicine, &#169; 2000-2023 HOFFMANN+LIEBENBERG"
 	><span class="product">ZMS5</span><span class="slogan d-none d-lg-inline">Python-based Content Management System for Science, Technology and Medicine</span>
 </a>
 <span tal:condition="python:here.getConfProperty('ZMS.branding','ZMS5')!='ZMS5'"


### PR DESCRIPTION
Ref: https://github.com/zms-publishing/ZMS3/commit/478405499868d1ab045215de66b58ee6f2995016

For UnrestrictedUser/Emergency User Zope returns on has_role() constantly True/1:
https://github.com/zopefoundation/AccessControl/blob/f9ae58816f0712eb6ea97459b4ccafbf4662d9db/src/AccessControl/users.py#L311-L312
In this case has_role() prohibits ZMI access.
Actually in Inability to create content is conformant to the idea of Emergency User:
https://zope.readthedocs.io/en/latest/zopebook/Security.html#zope-emergency-user
but not prohibiting ZMI-View
