### PR TITLE
Improved ZMSMetaobjManager GUI

### DIFF
--- a/Products/zms/ZMSMetaobjManager.py
+++ b/Products/zms/ZMSMetaobjManager.py
@@ -1142,7 +1142,21 @@ class ZMSMetaobjManager(object):
           self.setMetaobj( newValue)
           # Change attributes.
           for old_id in REQUEST.get('old_ids', []):
-            attr_id = REQUEST['attr_id_%s'%old_id].strip()
+
+            try:
+              attr_id = REQUEST['attr_id_%s'%old_id].strip()
+            except:
+              if type(REQUEST.get('attr_id_%s'%old_id))==list:
+                # Error: doubled attribute ids
+                standard.writeLog(self, "[ZMSMetaobjManager.manage_changeProperties Doubled Attribute IDs]: %s"%(REQUEST.get('old_ids', [])))
+                message+='IGNORED Doubled ID: attr_id_%s<br/>'%(old_id)
+                attr_id = REQUEST['attr_id_%s'%old_id][0].strip()
+                continue
+              else:
+                standard.writeLog(self, "[ZMSMetaobjManager.manage_changeProperties Key Error]: attr_id_%s"%(old_id))
+                message+='IGNORED Key: attr_id_%s<br/>'%(old_id)
+                continue
+
             newName = REQUEST.get('attr_name_%s'%old_id, '').strip()
             newMandatory = REQUEST.get( 'attr_mandatory_%s'%old_id, 0)
             newMultilang = REQUEST.get( 'attr_multilang_%s'%old_id, 0)

--- a/Products/zms/ZMSMetaobjManager.py
+++ b/Products/zms/ZMSMetaobjManager.py
@@ -1142,21 +1142,7 @@ class ZMSMetaobjManager(object):
           self.setMetaobj( newValue)
           # Change attributes.
           for old_id in REQUEST.get('old_ids', []):
-
-            try:
-              attr_id = REQUEST['attr_id_%s'%old_id].strip()
-            except:
-              if type(REQUEST.get('attr_id_%s'%old_id))==list:
-                # Error: doubled attribute ids
-                standard.writeLog(self, "[ZMSMetaobjManager.manage_changeProperties Doubled Attribute IDs]: %s"%(REQUEST.get('old_ids', [])))
-                message+='IGNORED Doubled ID: attr_id_%s<br/>'%(old_id)
-                attr_id = REQUEST['attr_id_%s'%old_id][0].strip()
-                continue
-              else:
-                standard.writeLog(self, "[ZMSMetaobjManager.manage_changeProperties Key Error]: attr_id_%s"%(old_id))
-                message+='IGNORED Key: attr_id_%s<br/>'%(old_id)
-                continue
-
+            attr_id = REQUEST['attr_id_%s'%old_id].strip()
             newName = REQUEST.get('attr_name_%s'%old_id, '').strip()
             newMandatory = REQUEST.get( 'attr_mandatory_%s'%old_id, 0)
             newMultilang = REQUEST.get( 'attr_multilang_%s'%old_id, 0)

--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -357,7 +357,7 @@ $ZMI.registerReady(function(){
 		}
 	});
 
-	// Double-Clickable
+	// Double-Clickable (TODO: to be specified for data grids that lead row-wise to a dataset form!)
 	$('table.table-hover tbody tr')
 		.dblclick( function(evt) {
 			var href = null;

--- a/Products/zms/plugins/www/zmi.core.css
+++ b/Products/zms/plugins/www/zmi.core.css
@@ -988,7 +988,6 @@ li.zmi-item span.zmi-ids {
 .zmi table.table td.meta-sort .btn.btn-secondary i.fas.fa-times,
 .zmi table.table td.meta-default .btn.btn-secondary i.fas.fa-key,
 .zmi table.table td.meta-default .btn.btn-secondary i.fas.fa-ellipsis-v,
-.zmi .meta-languages .single-line.input-group i.fas,
 .zmi table.table .single-line.input-group .input-group-append i.fas {
 	color: #999;
 }

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -814,8 +814,8 @@ $(function(){
 		// Set variables
 		let table_id = $(this).closest('table').attr('id'); // meta_properties or meta_languages
 		let new_row_name = `new_row_${table_id}_${new_row_counter}`;
-		let new_btn_html = `
-			<input type="hidden" name="old_ids:list" value="new${new_row_counter}">
+		let old_id_html = (table_id != 'meta_languages') ? `<input type="hidden" name="old_ids:list" value="new${new_row_counter}">` : ``;
+		let new_btn_html = `${old_id_html}
 			<span class="btn btn-default btn-sm mr-1" style="color:#999" 
 				onclick="javascript:$(this).closest('tr').remove()">
 				<i class="fas fa-times"></i>
@@ -839,7 +839,7 @@ $(function(){
 					case 'meta_languages':
 						newname = defname.replace('_0', '_' + (lang_count + new_row_counter));
 						break
-					default:  // meta_properties with :int suffix for checkboxes
+					default:  // meta_properties
 						newname = `attr_${newname}_new${new_row_counter}`
 						newname = defname.includes(':') ? `${newname}:int` : newname;
 				};
@@ -862,7 +862,7 @@ $(function(){
 			});
 		});
 
-		// Process td:first-child
+		// Process td:first-child of the clone
 		$new_row.find('td.meta-sort').html(new_btn_html);
 		$new_row.removeAttr('class').attr('id',new_row_name);
 

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -844,7 +844,7 @@ $(function(){
 					$(this).attr('name',$(this).attr('name').replace('_0', '_' + (lang_count + new_row_counter)));
 				};
 				// Transfer values to clone
-				if ( $(this).prop('tagName') == 'INPUT'||'TEXTAREA') {
+				if ( ['TEXTAREA', 'INPUT'].includes(tagname) ) {
 					if (newname.includes(':')) {
 						// Checkboxes (:int-suffix)
 						$(this).val($(this).val()=='1' ? 1 : 0 );
@@ -852,7 +852,7 @@ $(function(){
 						// String Inputs
 						$(this).val($(this).val()=='' ? ('new'+new_row_counter) : $(this).val());
 					};
-				} else if ( $(this).prop('tagName') == 'SELECT' ) {
+				} else if ( tagname == 'SELECT' ) {
 					let selected = $("option:selected", $('.row_insert select')).val();
 					if (selected!='') {
 						$('option[value="' + selected +'"]',$(this)).prop('selected', true);
@@ -860,9 +860,10 @@ $(function(){
 				}
 			})
 		});
+
 		// Process td:first-child
 		$new_row.find('td.meta-sort').html(new_btn_html);
-		$new_row.attr('id',new_row_name).removeAttr('class');
+		$new_row.removeAttr('class').attr('id',new_row_name);
 
 		// Insert the new row
 		$new_row.insertBefore($where_insert);

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -315,7 +315,7 @@
 				</tal:block>
 			</tr>
 			<tr class="row_insert">
-				<td class="meta-sort text-right"><span class="btn btn-add"><i class="fas fa-plus')"></i></span></td>
+				<td class="meta-sort text-right"><span class="btn btn-add mr-1"><i class="fas fa-plus"></i></span></td>
 				<td class="meta-id"><input class="form-control form-control-sm" type="text" name="attr_id"/></td>
 				<td class="meta-name"><input class="form-control form-control-sm" type="text" name="attr_name"/></td>
 				<td class="meta-type">
@@ -357,31 +357,32 @@
 	<!-- EO Usage -->
 
 	<!-- BO Languages -->
-	<div class="meta-languages mt-3" tal:define="langIds python:here.getLangIds(sort=True)">
-	<table class="table table-sm table-striped table-bordered table-hover">
-	<thead>
-	<tr>
-		<th tal:content="python:here.getZMILangStr('ATTR_DICTIONARY')"></th>
-		<th tal:content="python:here.getZMILangStr('ATTR_KEY')">Key</th>
-		<th tal:repeat="langId langIds" tal:content="python:here.getLanguageLabel(langId)">Language-Label</th>
-	</tr>
-	</thead>
-	<tbody>
-	<tal:block tal:repeat="langDict python:here.getLangDict()">
-	<tr tal:condition="python:langDict['key'].startswith(request['id'])" tal:define="i python:repeat['langDict'].index+1">
-		<td class="text-center"></td>
-		<td><input type="text" class="form-control form-control-sm" tal:attributes="name python:'_lang_dict_key_%i'%i; value python:langDict['key'][len(request['id'])+1:];"></td>
-		<td tal:repeat="langId langIds"><div class="single-line"><textarea class="form-control form-control-sm" tal:attributes="name python:'_lang_dict_value_%i_%s'%(i,langId);" tal:content="python:langDict.get(langId,'')"></textarea></div></td>
-	</tr>
-	</tal:block>
-	<tr class="row_insert" tal:define="i python:0">
-		<td class="text-center"><i class="fas fa-plus"></i></td>
-		<td><input class="form-control form-control-sm" type="text" tal:attributes="name python:'_lang_dict_key_%i'%i" /></td>
-		<td tal:repeat="langId langIds"><div class="single-line"><textarea class="form-control form-control-sm" tal:attributes="name python:'_lang_dict_value_%i_%s'%(i,langId)"></textarea></div></td>
-	</tr>
-	</tbody>
+	<table id="meta_languages" 
+		tal:define="langIds python:here.getLangIds(sort=True)"
+		class="table table-sm table-striped table-bordered table-hover mt-3">
+		<thead>
+			<tr>
+				<th class="meta-sort"></th>
+				<th tal:content="python:'%s - %s'%(here.getZMILangStr('ATTR_DICTIONARY'), here.getZMILangStr('ATTR_KEY'))">Key</th>
+				<th tal:repeat="langId langIds" tal:content="python:here.getLanguageLabel(langId)">Language-Label</th>
+			</tr>
+		</thead>
+		<tbody>
+		<tal:block tal:repeat="langDict python:here.getLangDict()">
+			<tr tal:condition="python:langDict['key'].startswith(request['id'])" tal:define="i python:repeat['langDict'].index+1">
+				<td class="meta-sort"></td>
+				<td><input type="text" class="form-control form-control-sm" tal:attributes="name python:'_lang_dict_key_%i'%i; value python:langDict['key'][len(request['id'])+1:];"></td>
+				<td tal:repeat="langId langIds"><div class="single-line"><textarea class="form-control form-control-sm" tal:attributes="name python:'_lang_dict_value_%i_%s'%(i,langId);" tal:content="python:langDict.get(langId,'')"></textarea></div></td>
+			</tr>
+		</tal:block>
+		<tr class="row_insert" tal:define="i python:0">
+			<td class="meta-sort text-right"><span class="btn btn-add mr-1"><i class="fas fa-plus"></i></span></td>
+			<td><input class="form-control form-control-sm" type="text" tal:attributes="name python:'_lang_dict_key_%i'%i" /></td>
+			<td tal:repeat="langId langIds"><div class="single-line"><textarea class="form-control form-control-sm" tal:attributes="name python:'_lang_dict_value_%i_%s'%(i,langId)"></textarea></div></td>
+		</tr>
+		</tbody>
 	</table>
-	</div>
+	<!-- EO Languages -->
 
 	<!-- BO Access -->
 	<div class="meta-access">
@@ -793,6 +794,56 @@ $(function(){
 var zmi_code_default_btn = '<i onclick="set_zmi_code_default(event)" title=\"Replace by Default-Code-Template\" class=\"zmi-code-default icon-repeat fas fa-redo-alt text-primary text-center\" style=\"cursor:pointer;display:block;position:absolute;text-align:right !important;right:0.75em;padding:0.5em;\"></i>';
 $(function(){
 	$('#meta_properties input[name="attr_type_standard_html"] ~ .zmi-code').prepend( zmi_code_default_btn);
+
+
+	// ++++++++++++
+	// Add rows to tables #meta_properties or #meta_languages on button click
+	// ++++++++++++
+	let new_row_counter = 0;
+	// Determine the number of language terms
+	let lang_count = Object.keys(JSON.parse(ZMI.prototype.getCachedValue('get_lang_dict'))).length
+
+	// Add Event to Add-Buttons
+	$(".row_insert .btn-add").click(function(){
+		new_row_counter++;
+
+		// Where to insert the new row 
+		let $where_insert = $(this).closest('tr');
+
+		// Determine the container table id  #meta_properties or #meta_languages
+		let table_id = $(this).closest('table').attr('id');
+		let new_name = `new_row_${table_id}_${new_row_counter}`;
+
+		// Clone(true) to get a deep copy including select options
+		let $new_row = $where_insert.clone(true);
+
+		// Prepare the clone to work as an "old" row
+		$new_row.removeAttr('class');
+		$new_row.find('.btn-add').remove();
+		$new_row.attr('id',new_name);
+		$new_row.find('td.meta-sort').html('<input type="hidden" name="old_ids:list" value="new'+ new_row_counter +'"><span style="color:#999" class="btn btn-default btn-sm mr-1" onclick="javascript:$(this).closest(\'tr\').remove()"><i class="fas fa-times"></i></span>');
+		$new_row.find('input[name="attr_id"]').attr('name','attr_id_new'+new_row_counter)
+		if ( $new_row.find('input[name="attr_id_new'+ new_row_counter +'"]').val()=='' ) {
+			$new_row.find('input[name="attr_id_new'+ new_row_counter +'"]').val('new'+new_row_counter);
+		};
+		$new_row.find('input[name="attr_name"]').attr('name','attr_name_new'+new_row_counter)
+		if ( $new_row.find('input[name="attr_name_new'+ new_row_counter +'"]').val()=='' ) {
+			$new_row.find('input[name="attr_name_new'+ new_row_counter +'"]').val('new'+new_row_counter);
+		};
+		// TODO: selected option should be shown in the cloned row
+		$new_row.find('select[name="_type"]').attr('name','attr_type_new'+ new_row_counter);
+		$new_row.find('input[name="_mandatory:int"]').attr('name','attr_mandatory_new' + new_row_counter + ':int');
+		$new_row.find('input[name="_multilang:int]').attr('name','attr_multilang_new' + new_row_counter + ':int');
+		$new_row.find('input[name="_repetitive:int]').attr('name','attr_repetitive_new' + new_row_counter + ':int');
+		$new_row.find('[name^="_lang_dict_"]').each(function(){
+			let new_lang_dict_count = lang_count + new_row_counter;
+			$(this).attr('name',$(this).attr('name').replace('_0', '_' + new_lang_dict_count ));
+		});
+
+		// Insert the new row
+		$new_row.insertBefore($where_insert);
+	});
+
 });
 // -->
 </script>

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -792,18 +792,19 @@ $(function(){
 }
 // Add Execute Button for TAL-Code-Regeneration om a ZPT-Method named standard_html
 var zmi_code_default_btn = '<i onclick="set_zmi_code_default(event)" title=\"Replace by Default-Code-Template\" class=\"zmi-code-default icon-repeat fas fa-redo-alt text-primary text-center\" style=\"cursor:pointer;display:block;position:absolute;text-align:right !important;right:0.75em;padding:0.5em;\"></i>';
+
+// Execute on DOM-Ready
 $(function(){
 	$('#meta_properties input[name="attr_type_standard_html"] ~ .zmi-code').prepend( zmi_code_default_btn);
-
 
 	// ++++++++++++
 	// Add rows to tables #meta_properties or #meta_languages on button click
 	// ++++++++++++
 	let new_row_counter = 0;
-	// Determine the number of language terms
+	// Get number of language terms
 	let lang_count = Object.keys(JSON.parse(ZMI.prototype.getCachedValue('get_lang_dict'))).length
 
-	// Add Event to Add-Buttons
+	// Add click event function to add-buttons
 	$(".row_insert .btn-add").click(function(){
 		new_row_counter++;
 
@@ -828,17 +829,23 @@ $(function(){
 		$new_row.find('td').each(function() {
 			$(this).find('input,select,textarea').each(function() {
 				let tagname = $(this).prop('tagName');
-				let rename =  $(this).attr('name').split('_')[1];
-				let rename_type =  rename.includes(':') && ':int' || '';
-				// Set new names
+				let newname =  $(this).attr('name').split('_')[1];
+
+				// Set new form elemnt names
 				if (table_id=='meta_properties') {
-					$(this).attr('name', `attr_${rename}_new${new_row_counter}${rename_type}`);
+					switch (newname.includes(':')) {
+						case true:
+							$(this).attr('name', `attr_${newname.split(':')[0]}_new${new_row_counter}:${newname.split(':')[1]}`);
+							break;
+						default:
+							$(this).attr('name', `attr_${newname}_new${new_row_counter}`);
+					}
 				} else if (table_id=='meta_languages') {
 					$(this).attr('name',$(this).attr('name').replace('_0', '_' + (lang_count + new_row_counter)));
 				};
 				// Transfer values to clone
-				if ( $(this).prop('tagName') != 'SELECT') {
-					$(this).val($(this).val()=='' && ('new'+new_row_counter) || $(this).val());
+				if ( $(this).prop('tagName') != 'SELECT' && !newname.includes(':') ) {
+					$(this).val($(this).val()=='' ? ('new'+new_row_counter) : $(this).val());
 				} else {
 					let selected = $("option:selected", $('.row_insert select')).val();
 					if (selected!='') {
@@ -853,7 +860,7 @@ $(function(){
 
 		// Insert the new row
 		$new_row.insertBefore($where_insert);
-		// Reset the cloned row
+		// Reset the clone template
 		$where_insert.find('input,select,textarea').each(function() {
 			$(this).val('');
 		});

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -831,34 +831,41 @@ $(function(){
 				let tagname = $(this).prop('tagName');
 				let newname =  $(this).attr('name').split('_')[1];
 
-				// Set new form elemnt names
-				if (table_id=='meta_properties') {
-					switch (newname.includes(':')) {
-						case true: // Checkboxes (:int-suffix)
-							$(this).attr('name', `attr_${newname.split(':')[0]}_new${new_row_counter}:${newname.split(':')[1]}`);
-							break;
-						default: // String Inputs
-							$(this).attr('name', `attr_${newname}_new${new_row_counter}`);
-					}
-				} else if (table_id=='meta_languages') {
-					$(this).attr('name',$(this).attr('name').replace('_0', '_' + (lang_count + new_row_counter)));
-				};
-				// Transfer values to clone
-				if ( ['TEXTAREA', 'INPUT'].includes(tagname) ) {
-					if (newname.includes(':')) {
-						// Checkboxes (:int-suffix)
-						$(this).val($(this).val()=='1' ? 1 : 0 );
-					} else {
-						// String Inputs
-						$(this).val($(this).val()=='' ? ('new'+new_row_counter) : $(this).val());
-					};
-				} else if ( tagname == 'SELECT' ) {
-					let selected = $("option:selected", $('.row_insert select')).val();
-					if (selected!='') {
-						$('option[value="' + selected +'"]',$(this)).prop('selected', true);
-					}
+				// #### NAMES: Set new form elemnt names according to table_id
+				switch (table_id) {
+					case 'meta_properties':
+						console.log(newname.includes(':'));
+						console.log(newname.split(':')[0]);
+						switch (newname.includes(':')) {
+							case true: // Checkboxes (:int-suffix)
+								$(this).attr('name', `attr_${newname.split(':')[0]}_new${new_row_counter}:${newname.split(':')[1]}`);
+								break
+							default: // String Inputs
+								$(this).attr('name', `attr_${newname}_new${new_row_counter}`);
+						};
+					case 'meta_languages':
+						$(this).attr('name',$(this).attr('name').replace('_0', '_' + (lang_count + new_row_counter)));
 				}
-			})
+
+				// #### VALUES: Transfer values from template to clone according to tag-name
+				switch (tagname) {
+					case 'INPUT':
+						switch (newname.includes(':')) {
+							case true: // Checkboxes (:int-suffix)
+								$(this).val($(this).val()=='1' ? 1 : 0 );
+								break
+							default: // String Inputs
+								$(this).val($(this).val()=='' ? ('new'+new_row_counter) : $(this).val());
+						};
+					case 'SELECT':
+						let selected = $("option:selected", $('.row_insert select')).val();
+						if (selected!='') {
+							$('option[value="' + selected +'"]',$(this)).prop('selected', true);
+						};
+					case 'TEXTAREA':
+						$(this).val($(this).val()=='' ? ('new'+new_row_counter) : $(this).val());
+				}
+			});
 		});
 
 		// Process td:first-child

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -834,8 +834,6 @@ $(function(){
 				// #### NAMES: Set new form elemnt names according to table_id
 				switch (table_id) {
 					case 'meta_properties':
-						console.log(newname.includes(':'));
-						console.log(newname.split(':')[0]);
 						switch (newname.includes(':')) {
 							case true: // Checkboxes (:int-suffix)
 								$(this).attr('name', `attr_${newname.split(':')[0]}_new${new_row_counter}:${newname.split(':')[1]}`);

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -834,19 +834,25 @@ $(function(){
 				// Set new form elemnt names
 				if (table_id=='meta_properties') {
 					switch (newname.includes(':')) {
-						case true:
+						case true: // Checkboxes (:int-suffix)
 							$(this).attr('name', `attr_${newname.split(':')[0]}_new${new_row_counter}:${newname.split(':')[1]}`);
 							break;
-						default:
+						default: // String Inputs
 							$(this).attr('name', `attr_${newname}_new${new_row_counter}`);
 					}
 				} else if (table_id=='meta_languages') {
 					$(this).attr('name',$(this).attr('name').replace('_0', '_' + (lang_count + new_row_counter)));
 				};
 				// Transfer values to clone
-				if ( $(this).prop('tagName') != 'SELECT' && !newname.includes(':') ) {
-					$(this).val($(this).val()=='' ? ('new'+new_row_counter) : $(this).val());
-				} else {
+				if ( $(this).prop('tagName') == 'INPUT'||'TEXTAREA') {
+					if (newname.includes(':')) {
+						// Checkboxes (:int-suffix)
+						$(this).val($(this).val()=='1' ? 1 : 0 );
+					} else {
+						// String Inputs
+						$(this).val($(this).val()=='' ? ('new'+new_row_counter) : $(this).val());
+					};
+				} else if ( $(this).prop('tagName') == 'SELECT' ) {
 					let selected = $("option:selected", $('.row_insert select')).val();
 					if (selected!='') {
 						$('option[value="' + selected +'"]',$(this)).prop('selected', true);
@@ -861,7 +867,7 @@ $(function(){
 		// Insert the new row
 		$new_row.insertBefore($where_insert);
 		// Reset the clone template
-		$where_insert.find('input,select,textarea').each(function() {
+		$where_insert.find('input:not([type="checkbox"]),select,textarea').each(function() {
 			$(this).val('');
 		});
 	});

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -810,38 +810,53 @@ $(function(){
 		// Where to insert the new row 
 		let $where_insert = $(this).closest('tr');
 
-		// Determine the container table id  #meta_properties or #meta_languages
-		let table_id = $(this).closest('table').attr('id');
-		let new_name = `new_row_${table_id}_${new_row_counter}`;
+		// Set variables
+		let table_id = $(this).closest('table').attr('id'); // meta_properties or meta_languages
+		let new_row_name = `new_row_${table_id}_${new_row_counter}`;
+		let new_btn_html = `
+			<input type="hidden" name="old_ids:list" value="new${new_row_counter}">
+			<span class="btn btn-default btn-sm mr-1" style="color:#999" 
+				onclick="javascript:$(this).closest('tr').remove()">
+				<i class="fas fa-times"></i>
+			</span>
+			`;
 
 		// Clone(true) to get a deep copy including select options
 		let $new_row = $where_insert.clone(true);
 
-		// Prepare the clone to work as an "old" row
-		$new_row.removeAttr('class');
-		$new_row.find('.btn-add').remove();
-		$new_row.attr('id',new_name);
-		$new_row.find('td.meta-sort').html('<input type="hidden" name="old_ids:list" value="new'+ new_row_counter +'"><span style="color:#999" class="btn btn-default btn-sm mr-1" onclick="javascript:$(this).closest(\'tr\').remove()"><i class="fas fa-times"></i></span>');
-		$new_row.find('input[name="attr_id"]').attr('name','attr_id_new'+new_row_counter)
-		if ( $new_row.find('input[name="attr_id_new'+ new_row_counter +'"]').val()=='' ) {
-			$new_row.find('input[name="attr_id_new'+ new_row_counter +'"]').val('new'+new_row_counter);
-		};
-		$new_row.find('input[name="attr_name"]').attr('name','attr_name_new'+new_row_counter)
-		if ( $new_row.find('input[name="attr_name_new'+ new_row_counter +'"]').val()=='' ) {
-			$new_row.find('input[name="attr_name_new'+ new_row_counter +'"]').val('new'+new_row_counter);
-		};
-		// TODO: selected option should be shown in the cloned row
-		$new_row.find('select[name="_type"]').attr('name','attr_type_new'+ new_row_counter);
-		$new_row.find('input[name="_mandatory:int"]').attr('name','attr_mandatory_new' + new_row_counter + ':int');
-		$new_row.find('input[name="_multilang:int]').attr('name','attr_multilang_new' + new_row_counter + ':int');
-		$new_row.find('input[name="_repetitive:int]').attr('name','attr_repetitive_new' + new_row_counter + ':int');
-		$new_row.find('[name^="_lang_dict_"]').each(function(){
-			let new_lang_dict_count = lang_count + new_row_counter;
-			$(this).attr('name',$(this).attr('name').replace('_0', '_' + new_lang_dict_count ));
+		// Process table cells of the clone like "old" row
+		$new_row.find('td').each(function() {
+			$(this).find('input,select,textarea').each(function() {
+				let tagname = $(this).prop('tagName');
+				let rename =  $(this).attr('name').split('_')[1];
+				let rename_type =  rename.includes(':') && ':int' || '';
+				// Set new names
+				if (table_id=='meta_properties') {
+					$(this).attr('name', `attr_${rename}_new${new_row_counter}${rename_type}`);
+				} else if (table_id=='meta_languages') {
+					$(this).attr('name',$(this).attr('name').replace('_0', '_' + (lang_count + new_row_counter)));
+				};
+				// Transfer values to clone
+				if ( $(this).prop('tagName') != 'SELECT') {
+					$(this).val($(this).val()=='' && ('new'+new_row_counter) || $(this).val());
+				} else {
+					let selected = $("option:selected", $('.row_insert select')).val();
+					if (selected!='') {
+						$('option[value="' + selected +'"]',$(this)).prop('selected', true);
+					}
+				}
+			})
 		});
+		// Process td:first-child
+		$new_row.find('td.meta-sort').html(new_btn_html);
+		$new_row.attr('id',new_row_name).removeAttr('class');
 
 		// Insert the new row
 		$new_row.insertBefore($where_insert);
+		// Reset the cloned row
+		$where_insert.find('input,select,textarea').each(function() {
+			$(this).val('');
+		});
 	});
 
 });

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -829,39 +829,35 @@ $(function(){
 		$new_row.find('td').each(function() {
 			$(this).find('input,select,textarea').each(function() {
 				let tagname = $(this).prop('tagName');
-				let newname =  $(this).attr('name').split('_')[1];
+				let defname = $(this).attr('name')
+				let deftype = $(this).attr('type')
+				let newname = $(this).attr('name').split('_')[1].split(':')[0];
+				let newval  = $(this).val();
 
-				// #### NAMES: Set new form elemnt names according to table_id
+				// #### NAMES: Set new form element names according to table_id
 				switch (table_id) {
-					case 'meta_properties':
-						switch (newname.includes(':')) {
-							case true: // Checkboxes (:int-suffix)
-								$(this).attr('name', `attr_${newname.split(':')[0]}_new${new_row_counter}:${newname.split(':')[1]}`);
-								break
-							default: // String Inputs
-								$(this).attr('name', `attr_${newname}_new${new_row_counter}`);
-						};
 					case 'meta_languages':
-						$(this).attr('name',$(this).attr('name').replace('_0', '_' + (lang_count + new_row_counter)));
-				}
+						newname = defname.replace('_0', '_' + (lang_count + new_row_counter));
+						break
+					default:  // meta_properties with :int suffix for checkboxes
+						newname = `attr_${newname}_new${new_row_counter}`
+						newname = defname.includes(':') ? `${newname}:int` : newname;
+				};
+				$(this).attr('name',newname);
 
-				// #### VALUES: Transfer values from template to clone according to tag-name
-				switch (tagname) {
-					case 'INPUT':
-						switch (newname.includes(':')) {
-							case true: // Checkboxes (:int-suffix)
-								$(this).val($(this).val()=='1' ? 1 : 0 );
-								break
-							default: // String Inputs
-								$(this).val($(this).val()=='' ? ('new'+new_row_counter) : $(this).val());
-						};
-					case 'SELECT':
-						let selected = $("option:selected", $('.row_insert select')).val();
-						if (selected!='') {
-							$('option[value="' + selected +'"]',$(this)).prop('selected', true);
-						};
-					case 'TEXTAREA':
-						$(this).val($(this).val()=='' ? ('new'+new_row_counter) : $(this).val());
+				// #### VALUES: Transfer values from template to clone
+				if ( tagname == 'SELECT') {
+					let selected = $("option:selected", $('.row_insert select')).val();
+					if (selected!='') {
+						$('option[value="' + selected +'"]',$(this)).prop('selected', true);
+					};
+				} else {
+					if (deftype == 'checkbox') {
+						newval = newval =='1' ? 1 : 0;
+					} else {
+						newval = newval =='' ? ('new'+new_row_counter) : newval;
+					};
+					$(this).val(newval);
 				}
 			});
 		});

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -845,7 +845,7 @@ $(function(){
 				};
 				$(this).attr('name',newname);
 
-				// #### VALUES: Transfer values from template to clone
+				// #### VALUES: Transfer initially entered values from template to clone
 				if ( tagname == 'SELECT') {
 					let selected = $("option:selected", $('.row_insert select')).val();
 					if (selected!='') {
@@ -870,7 +870,7 @@ $(function(){
 		$new_row.insertBefore($where_insert);
 		// Reset the clone template
 		$where_insert.find('input:not([type="checkbox"]),select,textarea').each(function() {
-			$(this).val('');
+			$(this).val(undefined);
 		});
 	});
 


### PR DESCRIPTION
Hello @zmsdev 
Intermediate saving on adding new attributes to the content model  may not match the user's expectations. Actually it is not very fast. So the ZMI should alllow just a "final" Saving. The code proposal works with JS-cloning of the "add"-row. The cloned TR-element is used as a template that is changed by JS so that it can work like the "old" rows. Thus the backend code can handle it. 

![ZMS5_INSERT_ROW](https://github.com/zms-publishing/ZMS/assets/29705216/75488713-16ba-4b29-9c44-5672b6e9115c)

About the JS Code:
The crucial point is that the JS-cloning has to be done _inside_ the  click-event function and the added TR needs an unique ID, to get it selected in the DOM.
A cloning in advance, means outside the funktion, generates one global object which on button-click  will instanciated into itself, so that in the end only one new attribute row can be added.

BTW: the processing of the attributes may hardened against entering identical attribute ids
https://github.com/zms-publishing/ZMS/blob/751c21a52b6dd3dc410f72c3c497b33c6c5562c3/Products/zms/ZMSMetaobjManager.py#L1146-L1158
