### PR TITLE
Bugfix: Trigger onChangeObjEvt on Obj move (#157)

### DIFF
--- a/Products/zms/zmsobject.py
+++ b/Products/zms/zmsobject.py
@@ -1417,6 +1417,7 @@ class ZMSObject(ZMSItem.ZMSItem,
       sort_id = self.getSortId()
       self.setSortId(sort_id - 15)
       parent.normalizeSortIds(standard.id_prefix(self.id))
+      standard.triggerEvent(self,'onChangeObjEvt')
       # Return with message.
       message = self.getZMILangStr('MSG_MOVEDOBJUP')%("<i>%s</i>"%self.display_type(REQUEST))
       RESPONSE.redirect('%s/manage_main?lang=%s&manage_tabs_message=%s#zmi_item_%s'%(parent.absolute_url(), lang, standard.url_quote(message), self.id))
@@ -1433,6 +1434,7 @@ class ZMSObject(ZMSItem.ZMSItem,
       sort_id = self.getSortId()
       self.setSortId(sort_id + 15)
       parent.normalizeSortIds(standard.id_prefix(self.id))
+      standard.triggerEvent(self,'onChangeObjEvt')
       # Return with message.
       message = self.getZMILangStr('MSG_MOVEDOBJDOWN')%("<i>%s</i>"%self.display_type(REQUEST))
       RESPONSE.redirect('%s/manage_main?lang=%s&manage_tabs_message=%s#zmi_item_%s'%(parent.absolute_url(), lang, standard.url_quote(message), self.id))
@@ -1459,6 +1461,7 @@ class ZMSObject(ZMSItem.ZMSItem,
           new_sort_id = int(sibling_sort_ids[-1][1:])+1
         self.setSortId(new_sort_id)
         parent.normalizeSortIds(id_prefix)
+        standard.triggerEvent(self,'onChangeObjEvt')
       else:
         id = REQUEST['URL'].split('/')[-2]
         ids = self.getConfProperty('Portal.Clients',[])


### PR DESCRIPTION
If  manage_movexxx is called there is no other method, which triggers onChangeObjEvt, so we added it in each method.  