### PR TITLE
handle missing ext methods in repomanager

### DIFF
--- a/Products/zms/zopeutil.py
+++ b/Products/zms/zopeutil.py
@@ -277,7 +277,11 @@ def addExternalMethod(container, id, title, data):
         if os.path.exists(filepath):
           break
         context = context.getParentNode()
-  ExternalMethod.manage_addExternalMethod( container, id, title, m, f)
+  try:
+    ExternalMethod.manage_addExternalMethod( container, id, title, m, f)
+  except:
+    standard.writeError(container,"[addExternalMethod]: %s does not exist.\n"%id)
+    pass
 
 def addPageTemplate(container, id, title, data):
   """


### PR DESCRIPTION
Acquired External Methods cannot be located by diff processing. This is a quickfix to avoid blocking the Repomanager GUI.

![addExternalMethod1](https://github.com/zms-publishing/ZMS/assets/29705216/9d79ccf9-e111-4c5a-bebf-89c4c82dc74c)
