### PR TITLE
sort_item(): Type Error

### DIFF
--- a/Products/zms/_globals.py
+++ b/Products/zms/_globals.py
@@ -112,7 +112,7 @@ def sort_item( i):
     elif not isinstance(i, str):
         mapping = umlaut_map
         for key, value in mapping.items():
-            i = i.replace(key, value)
+            i = str(i).replace(key, value)
     return i
 
 


### PR DESCRIPTION
the new _globals.sort_item(i) may apply str.replace() on an int.

![image](https://github.com/zms-publishing/ZMS/assets/29705216/d7445bbf-74ac-4d9a-b12d-c82a4436e3bd)

![image](https://github.com/zms-publishing/ZMS/assets/29705216/9e0aa8f4-5e83-4117-be83-78a90695a8b0)
