### PR TITLE
Fix resolving error on default URL {$}

### DIFF
--- a/Products/zms/_zreferableitem.py
+++ b/Products/zms/_zreferableitem.py
@@ -395,9 +395,10 @@ class ZReferableItem(object):
           path = url.replace('@','/content/')
           l = path.split('/') 
           ob = self.getDocumentElement()
-          [l.pop(0) for x in ob.getPhysicalPath() if l[0] == x]
-          for id in [x for x in l if x]:
-            ob = getattr(ob,id,None)
+          if l[0] != '':
+            [l.pop(0) for x in ob.getPhysicalPath() if l[0] == x]
+            for id in [x for x in l if x]:
+              ob = getattr(ob,id,None)
       # Prepare request
       ids = self.getPhysicalPath()
       if ob is not None and ob.id not in ids:


### PR DESCRIPTION
Fix for Issue #172 
The content-class modelling gui shows a JS error on AJAX request for getting the breadcrumbs path of a default object path {$}

Due to: https://github.com/zms-publishing/ZMS/commit/566d24365c6c474faa6d6fac246cc7f5a978cbb3#diff-f187caa3a7d3bf290f667b9c8a6611ceb315d737d36985ddbebfdd7ad1f4cb41
