### PR TITLE
Improving meta-model import gui

### DIFF
--- a/Products/zms/ZMSMetaobjManager.py
+++ b/Products/zms/ZMSMetaobjManager.py
@@ -1272,18 +1272,18 @@ class ZMSMetaobjManager(object):
           immediately = REQUEST.get('immediately', 0)
           overwrite = []
           ids = REQUEST.get('aq_ids', [])
-          for id in ids:
-            if not immediately and id in self.getMetaobjIds():
-              overwrite.append( id)
-            else:
-              self.acquireMetaobj( id)
+          if immediately:
+            for id in ids:
+              self.acquireMetaobj(id)
+            id = ''
+            message = self.getZMILangStr('MSG_INSERTED')%str(len(ids))
+          else:
+            for id in ids:
+              overwrite.append(id)
           if overwrite:
             id = ''
             extra['section'] = 'acquire'
             extra['temp_ids'] = ','.join(overwrite)
-          else:
-            # Return with message.
-            message = self.getZMILangStr('MSG_INSERTED')%str(len(ids))
         
         # Import.
         # -------

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main_acquire.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main_acquire.zpt
@@ -23,14 +23,12 @@
 
 	<tal:block tal:content="structure python:here.zmi_manage_tabs_message(here,request)">zmi_manage_tabs_message</tal:block>
 
-	<form class="form-horizontal card-body pt-4" action="manage_changeProperties" method="post" enctype="multipart/form-data"
-		tal:define="global dummy0 python:acquireObjs.sort()">
-
-		<input type="hidden" name="lang" tal:attributes="value request/lang" />
-		<input type="hidden" name="target" tal:attributes="value python:request['URL'].split('/')[-1]" />
-
-		<!-- Step-1: SELECT configuration file -->
-		<tal:block tal:condition="python:request.get('section')!='acquire'">
+	<!-- Step-1: SELECT configuration file -->
+	<tal:block tal:condition="python:request.get('section')!='acquire'">
+		<form class="form-horizontal card-body pt-4" action="manage_changeProperties" method="post" enctype="multipart/form-data"
+			tal:define="dummy0 python:acquireObjs.sort()">
+			<input type="hidden" name="lang" tal:attributes="value request/lang" />
+			<input type="hidden" name="target" tal:attributes="value python:request['URL'].split('/')[-1]" />
 			<div title="Step-1: SELECT configuration file"
 				class="badge badge-dark position-absolute mr-1"
 				style="top:0;right:0"
@@ -53,16 +51,20 @@
 					</button>
 				</div>
 			</div><!-- .form-group -->
-		</tal:block>
+		</form>
+	</tal:block>
 
-		<!-- Step-2: ACQUIRE configuration file -->
-		<tal:block tal:condition="python:request.get('section')=='acquire'">
+	<!-- Step-2: ACQUIRE configuration file -->
+	<tal:block tal:condition="python:request.get('section')=='acquire'">
+		<form class="form-horizontal card-body pt-4" action="manage_changeProperties" method="post" enctype="multipart/form-data" target="_parent"
+			tal:define="dummy0 python:acquireObjs.sort()">
+			<input type="hidden" name="lang" tal:attributes="value request/lang" />
+			<input type="hidden" name="immediately:int" value="1" />
 			<div title="Step-2: ACQUIRE configuration file"
 				class="badge badge-dark position-absolute mr-1"
 				style="top:0;right:0">
 				Step-2
 			</div>
-			<input type="hidden" name="immediately:int" value="1" />
 			<div class="form-group row my-3 pb-3 border-bottom d-flex justify-content-between align-items-center">
 				<span class="btn btn-secondary" 
 					onclick="zmiToggleSelectionButtonClick(this)"
@@ -101,9 +103,8 @@
 					</button>
 				</div>
 			</div>
-		</tal:block>
-
-	</form>
+		</form>
+	</tal:block>
 
 </body>
 </html>


### PR DESCRIPTION
The acquisition of a content class behaves differently depending on
1. content class exists: a "overwriting" happens after a confirmation form (2nd step)
2. content class does not exist: "immediatly"  acquisition happens without conformation (in 1 step)

_Confrmation forms for "new" acquisitions:_
![zmi_metamodel_acq](https://github.com/zms-publishing/ZMS/assets/29705216/ffe78fb1-cb3c-48b9-a7d2-8e0ce2377e6d)

_Code location "overwrite"_
![zmi_metamodel_acq2](https://github.com/zms-publishing/ZMS/assets/29705216/9515657c-8808-4ea9-b614-6a5ec1887ab1)

UX can be improved if gui behaves monotonously and show a confirmation form in any case.
Moreover the modal win should close after the confirmation (2nd) step and the base form should relaoded and show the resulting alert-message.

