### PR TITLE
ZMI: added level as data-attr to body-element

### DIFF
--- a/Products/zms/conf/metaobj_manager/skin_zms5_base/standard_html.zpt
+++ b/Products/zms/conf/metaobj_manager/skin_zms5_base/standard_html.zpt
@@ -62,6 +62,7 @@
 	data-path python:zmscontext.getRootElement().getRefObjPath(here);
 	data-root python:zmscontext.getRootElement().getHome().id;
 	data-client python:zmsclient.getHome().id;
+	data-level python:zmscontext.getLevel();
 	id python:'zmsid_%s'%(zmscontext.id);
 	class python:'zms web %s %s'%(zmscontext.meta_id, attr_dc_type)">
 	<span id="header_nav_toggler" class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#header_nav" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">

--- a/Products/zms/zpt/ZMSContainerObject/manage_main.zpt
+++ b/Products/zms/zpt/ZMSContainerObject/manage_main.zpt
@@ -5,6 +5,7 @@
 	data-path python:here.getRootElement().getRefObjPath(here);
 	data-root python:here.getRootElement().getHome().id;
 	data-client python:here.getHome().id;
+	data-level python:here.getLevel();
 	id python:'zmsid_%s'%(here.id);
 	class python:here.zmi_body_class(id='properties')">
 <header tal:replace="structure python:here.zmi_body_header(here,request)">zmi_body_header</header>

--- a/Products/zms/zpt/ZMSObject/manage_main.zpt
+++ b/Products/zms/zpt/ZMSObject/manage_main.zpt
@@ -15,6 +15,7 @@
 	data-path python:here.getRootElement().getRefObjPath(here);
 	data-root python:here.getRootElement().getHome().id;
 	data-client python:here.getHome().id;
+	data-level python:here.getLevel();
 	data-turbolinks python:here.attr('turbolinks')=='false' and 'false' or None;
 	id python:'zmsid_%s'%(here.id);
 	class python:here.zmi_body_class(id='properties')">

--- a/Products/zms/zpt/ZMSSqlDb/manage_main.zpt
+++ b/Products/zms/zpt/ZMSSqlDb/manage_main.zpt
@@ -8,6 +8,7 @@
 	data-path python:here.getRootElement().getRefObjPath(here);
 	data-root python:here.getRootElement().getHome().id;
 	data-client python:here.getHome().id;
+	data-level python:here.getLevel();
 	id python:'zmsid_%s'%(here.id);
 	class python:here.zmi_body_class(id='properties')">
 <header tal:replace="structure python:here.zmi_body_header(here,request)">zmi_body_header</header>


### PR DESCRIPTION
`body.data-level` as a ZMI-CSS customizing helper for depth-depending GUI details
Ref: https://github.com/idasm-unibe-ch/unibe-cms/issues/308

Example:

```css
body.teaser_container:not(.ZMSAdministrator) select#layout option[value="list"] {
    display: none;
}
body.teaser_container[data-level="1"]:not(.ZMSAdministrator) select#layout option[value="list"] {
    display: unset;
}
```