### PR TITLE
Using Zope's .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,39 @@
+# Generated from:
+# https://github.com/zopefoundation/meta/tree/master/config/zope-product
+#
+# EditorConfig Configuration file, for more details see:
+# http://EditorConfig.org
+# EditorConfig is a convention description, that could be interpreted
+# by multiple editors to enforce common coding conventions for specific
+# file types
+
+# top-most EditorConfig file:
+# Will ignore other EditorConfig files in Home directory or upper tree level.
+root = true
+
+
+[*]  # For All Files
+# Unix-style newlines with a newline ending every file
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+# Set default charset
+charset = utf-8
+# Indent style default
+indent_style = space
+# Max Line Length - a hard line wrap, should be disabled
+max_line_length = off
+
+[*.{py,cfg,ini}]
+# 4 space indentation
+indent_size = 4
+
+[*.{yml,zpt,pt,dtml,zcml}]
+# 2 space indentation
+indent_size = 2
+
+[{Makefile,.gitmodules}]
+# Tab indentation (no size specified, but view as 4 spaces)
+indent_style = tab
+indent_size = unset
+tab_width = unset

--- a/.editorconfig
+++ b/.editorconfig
@@ -30,7 +30,7 @@ indent_size = 4
 
 [*.{yml,zpt,pt,dtml,zcml}]
 # 2 space indentation
-indent_size = 2
+indent_size = 4
 
 [{Makefile,.gitmodules}]
 # Tab indentation (no size specified, but view as 4 spaces)

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
 	"python.defaultInterpreterPath": "~/vpy38/bin/python3",
 	"python.linting.enabled": false,
 	"[python]": {
-		"editor.defaultFormatter": "ms-python.autopep8"
+		"editor.defaultFormatter": "ms-python.python"
 	},
 	"python.formatting.provider": "none",
 

--- a/Products/zms/plugins/www/common/zmi_ace_editor.js
+++ b/Products/zms/plugins/www/common/zmi_ace_editor.js
@@ -102,7 +102,7 @@ function show_ace_editor(e, toggle=false) {
 		editor.setTheme('ace/theme/eclipse');
 		editor.getSession().setMode('ace/mode/'+mode);
 		editor.getSession().setValue(value);
-		editor.getSession().setOptions({ tabSize: 4, useSoftTabs: false });
+		editor.getSession().setOptions({ tabSize: 4, useSoftTabs: true });
 		editor.getSession().on('change',function() {
 			$textarea.val(editor.getSession().getValue()).change();
 		});


### PR DESCRIPTION
For homogeneous syntax Zope's editorconfig-files may be used. Some typical file types are added (css,html,js,xml)  to "4 space indentation".
Actually I am not sure about the "2 space indentation" for zpt/dtml, because the readibility is worse (but lines are shorter).

Refs:
INFO https://editorconfig.org/
VSCode-Ext: https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig