### PR TITLE
REST-API: avoid heterolingual titlealt reset

### DIFF
--- a/Products/zms/rest_api.py
+++ b/Products/zms/rest_api.py
@@ -118,20 +118,19 @@ def get_attrs(node):
     data['home_id'] = node.getHome().id
     data['level'] = node.getLevel()
     data['restricted'] = node.hasRestrictedAccess()
+    general_keys = data.keys()
     obj_attrs = node.getObjAttrs()
     metaobj_attrs = node.getMetaobjManager().getMetaobjAttrs(node.meta_id)
     for metaobj_attr in metaobj_attrs:
         id = metaobj_attr['id']
-        if id in obj_attrs:
+        if id in obj_attrs and not id in general_keys:
             if metaobj_attr['multilang']:
                 for lang in langs:
                     request.set('lang',lang)
-                    if get_attr(node,id):
-                        data[id if monolang else '%s_%s'%(id,lang)] = get_attr(node,id)
+                    data[id if monolang else '%s_%s'%(id,lang)] = get_attr(node,id)
             else:
-                if get_attr(node,id):
-                    data[id] = get_attr(node,id)
-    #print("data",data)
+                data[id] = get_attr(node,id)
+    # print("data",data)
     return data
 
 

--- a/Products/zms/rest_api.py
+++ b/Products/zms/rest_api.py
@@ -126,9 +126,11 @@ def get_attrs(node):
             if metaobj_attr['multilang']:
                 for lang in langs:
                     request.set('lang',lang)
-                    data[id if monolang else '%s_%s'%(id,lang)] = get_attr(node,id)
+                    if get_attr(node,id):
+                        data[id if monolang else '%s_%s'%(id,lang)] = get_attr(node,id)
             else:
-                data[id] = get_attr(node,id)
+                if get_attr(node,id):
+                    data[id] = get_attr(node,id)
     #print("data",data)
     return data
 
@@ -142,7 +144,7 @@ class RestApiController(object):
         if context and TraversalRequest:
             self.context = context
             self.method = TraversalRequest['REQUEST_METHOD']
-            self.path_to_handle = copy.copy(TraversalRequest['path_to_handle']) 
+            self.path_to_handle = copy.copy(TraversalRequest['path_to_handle'])
             self.ids = [x for x in self.path_to_handle if x != '++rest_api'] # remove ++rest_api as first element
             while self.ids:
                 id = self.ids[0]
@@ -190,7 +192,7 @@ class RestApiController(object):
             REQUEST.RESPONSE.setHeader('Content-Type',decoration['content_type'])
             return json.dumps(data)
         return None
-    
+
     @api(tag="zmsindex", pattern="/zmsindex", content_type="application/json")
     def zmsindex(self, context):
         request = _get_request(context)

--- a/Products/zms/zmsobject.py
+++ b/Products/zms/zmsobject.py
@@ -373,7 +373,7 @@ class ZMSObject(ZMSItem.ZMSItem,
     #  ZMSObject.getTitlealt
     # --------------------------------------------------------------------------
     def getTitlealt( self, REQUEST):
-      s = self.getObjProperty('titlealt', REQUEST)
+      s = self.getObjProperty('titlealt', REQUEST) or self.getObjProperty('titlealt', {'lang':self.getPrimaryLanguage()})
       if not s: 
         s = self.display_type()
       if not s:


### PR DESCRIPTION
Ref: https://github.com/idasm-unibe-ch/unibe-cms/issues/394

![tree2](https://github.com/zms-publishing/ZMS/assets/29705216/e6bf37f3-ca79-4cae-aee8-865cfbc35d43)


![tree4](https://github.com/zms-publishing/ZMS/assets/29705216/667fdf95-c480-42c0-8837-53992d6ee629)


To discuss: maybe the primary-lang value would be an alternative to the metatype-Keyord:

![image](https://github.com/zms-publishing/ZMS/assets/29705216/7b84aa6c-2270-4145-879d-524f8f22589f)



Hint: besides fix L129 there some whitespace fixes (trailing spaces etc.) automatically added 




