### PR TITLE
 Add REQUEST variable is_zmi to limit manage_lang determination

### DIFF
--- a/Products/zms/ZMSItem.py
+++ b/Products/zms/ZMSItem.py
@@ -130,6 +130,7 @@ class ZMSItem(
       RESPONSE.setHeader('Content-Type', 'text/html;charset=%s'%request['ZMS_CHARSET'])
       if not request.get( 'preview'):
         request.set( 'preview', 'preview')
+        request.set( 'is_zmi', True)
       langs = self.getLanguages(request)
       if request.get('lang') not in langs:
         request.set('lang', langs[0])

--- a/Products/zms/_multilangmanager.py
+++ b/Products/zms/_multilangmanager.py
@@ -237,23 +237,20 @@ class MultiLanguageManager(object):
       """
       manage_lang = None
       req = getattr( self, 'REQUEST', None)
-      # Debug
-      req.set('get_manage_lang_cnt', req.get('get_manage_lang_cnt',0)+1)
-      standard.writeBlock( self, 'get_manage_lang_cnt: %s'%(req.get('get_manage_lang_cnt',0)))
-      # /Debug
-      if req is not None and req.get('URL').find('/manage') > 0:
-        sess = standard.get_session(self)
-        if 'manage_lang' in req:
-          manage_lang = req.get('manage_lang')
-        else:
-          if sess is not None and 'reset_manage_lang' not in req.form:
-            manage_lang = sess.get('manage_lang')
-          if manage_lang is None:
-            lang = req.get('lang')
-            if lang in self.getLangIds():
-              manage_lang = self.getLang(lang).get('manage')
-        if sess is not None:
-          sess.set('manage_lang', manage_lang)
+      if req.get( 'is_zmi', False):
+        if req is not None:
+          sess = standard.get_session(self)
+          if 'manage_lang' in req:
+            manage_lang = req.get('manage_lang')
+          else:
+            if sess is not None and 'reset_manage_lang' not in req.form:
+              manage_lang = sess.get('manage_lang')
+            if manage_lang is None:
+              lang = req.get('lang')
+              if lang in self.getLangIds():
+                manage_lang = self.getLang(lang).get('manage')
+          if sess is not None:
+            sess.set('manage_lang', manage_lang)
       if manage_lang is None:
         manage_lang = 'eng'
       return manage_lang

--- a/Products/zms/_multilangmanager.py
+++ b/Products/zms/_multilangmanager.py
@@ -237,7 +237,11 @@ class MultiLanguageManager(object):
       """
       manage_lang = None
       req = getattr( self, 'REQUEST', None)
-      if req is not None and [x for x in req.get('URL','/manage').split('/') if x.find('manage')]:
+      # Debug
+      req.set('get_manage_lang_cnt', req.get('get_manage_lang_cnt',0)+1)
+      standard.writeBlock( self, 'get_manage_lang_cnt: %s'%(req.get('get_manage_lang_cnt',0)))
+      # /Debug
+      if req is not None and req.get('URL').find('/manage') > 0:
         sess = standard.get_session(self)
         if 'manage_lang' in req:
           manage_lang = req.get('manage_lang')

--- a/Products/zms/_multilangmanager.py
+++ b/Products/zms/_multilangmanager.py
@@ -237,7 +237,7 @@ class MultiLanguageManager(object):
       """
       manage_lang = None
       req = getattr( self, 'REQUEST', None)
-      if req is not None:
+      if req is not None and [x for x in req.get('URL','/manage').split('/') if x.find('manage')]:
         sess = standard.get_session(self)
         if 'manage_lang' in req:
           manage_lang = req.get('manage_lang')

--- a/Products/zms/_objinputs.py
+++ b/Products/zms/_objinputs.py
@@ -50,7 +50,7 @@ class ObjInputs(object):
   #	@return String
   # ----------------------------------------------------------------------------
   def getDateTimeInput(self, fmName, elName, size=8, value=None, enabled=True, fmt_str='DATETIME_FMT', css='form-control'):
-    manage_lang = self.get_manage_lang()
+    manage_lang = self.REQUEST['manage_lang']
     html = []
     input_type = 'date'
     if not isinstance(value, str):

--- a/Products/zms/_objinputs.py
+++ b/Products/zms/_objinputs.py
@@ -50,7 +50,7 @@ class ObjInputs(object):
   #	@return String
   # ----------------------------------------------------------------------------
   def getDateTimeInput(self, fmName, elName, size=8, value=None, enabled=True, fmt_str='DATETIME_FMT', css='form-control'):
-    manage_lang = self.REQUEST['manage_lang']
+    manage_lang = self.REQUEST.get('manage_lang', self.getPrimaryLanguage())
     html = []
     input_type = 'date'
     if not isinstance(value, str):


### PR DESCRIPTION
3rd-view templates may implicitly ask for the variable manage_lang and thus induce creation of a session object and a session cookie as a side-effect. So it should be determined, whether MultiLanguageManager.get_manage_lang()  ist called from ZMI or not. An added REQUEST-variable "is_zmi" may limit the session effect to ZMI. 

To be discussed: remove or use standard.isManagementInterface(request)