### PR TITLE
ZMI-Sitetree shall expand with current content node

### DIFF
--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -1303,7 +1303,7 @@ ZMIObjectTree.prototype.addPages = function(nodes) {
 		if (node.attr_dc_type) {
 			css.push('type-' + node.attr_dc_type);
 		};
-		html += `<ul data-id="${node.uid}" class="zmi-page ${node.meta_id}${node.is_page_element ? ' is_page_element' :''}">`;
+		html += `<ul data-id="${node.uid}" data-path="${node.getPath}" class="zmi-page ${node.meta_id}${node.is_page_element ? ' is_page_element' :''}">`;
 		html += `<li class="${css.join(' ')}">`;
 		if (!(that.p.params.meta_types == 'ZMS' && node.meta_id == 'ZMS' && !node.has_portal_clients)) {
 			html += `<i class="fas fa-caret-right toggle" title="+" onclick="$ZMI.objectTree.toggleClick(this ${typeof callback=='undefined' ? '' : ',' + callback})"></i> `;

--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -1303,7 +1303,7 @@ ZMIObjectTree.prototype.addPages = function(nodes) {
 		if (node.attr_dc_type) {
 			css.push('type-' + node.attr_dc_type);
 		};
-		html += `<ul data-id="${node.uid}" data-path="${node.getPath}" class="zmi-page ${node.meta_id}${node.is_page_element ? ' is_page_element' :''}">`;
+		html += `<ul data-id="${node.uid}" data-path="${node.getPath}" data-zmsid="${node.id}" class="zmi-page ${node.meta_id}${node.is_page_element ? ' is_page_element' :''}">`;
 		html += `<li class="${css.join(' ')}">`;
 		if (!(that.p.params.meta_types == 'ZMS' && node.meta_id == 'ZMS' && !node.has_portal_clients)) {
 			html += `<i class="fas fa-caret-right toggle" title="+" onclick="$ZMI.objectTree.toggleClick(this ${typeof callback=='undefined' ? '' : ',' + callback})"></i> `;

--- a/Products/zms/zpt/object/manage_menu.zpt
+++ b/Products/zms/zpt/object/manage_menu.zpt
@@ -30,5 +30,33 @@
 
 <tal:block tal:content="structure python:here.zmi_html_foot(here,request)">zmi_html_foot</tal:block>
 <script type="text/javascript" charset="UTF-8" src="/++resource++zms_/object/manage_menu.js"></script>
+<script>
+	// <!--
+	// #############################
+	// @work: to be async-ed
+	// #############################
+	function zmi_objecttree_expand() {
+		pathbase = window.location.pathname.split('/content/')[0]
+		pathfragments = window.location.pathname.split(pathbase+'/')[1].split('/')
+		pathfragments.pop(0);
+		pth = pathbase;
+		var i = 0;
+		(function click_head(i) {
+			setTimeout(function(){
+				pth += `/${pathfragments[i]}`;
+				console.log(pth);
+				$(`ul[data-path="${pth}"] > li:first`).addClass('active');
+				$(`ul[data-path="${pth}"] > li:first > i`).click();
+				if (i < pathfragments.length - 1 ) {
+					click_head(i+1);
+				}
+			}, 1000);
+		})(i)
+	};
+	$(function(){
+		zmi_objecttree_expand();
+	});
+	// -->
+</script>
 </body>
 </html>


### PR DESCRIPTION
Sitetree opens always with client root node, not the current content node (context).
As a 1st step I added a data-path-attribute to the ul-elements:
`$ZMI.objectTree.init() `needs to iterate/click `async/await` through the path fragements

```js
function zmi_objecttree_expand() {
	pathbase = window.location.pathname.split('/content/')[0]
	pathfragments = window.location.pathname.split(pathbase+'/')[1].split('/')
	pathfragments.pop(0);
	pth = pathbase;
	var i = 0;
	(function click_head(i) {
		setTimeout(function(){
			pth += `/${pathfragments[i]}`;
			console.log(pth);
			$(`ul[data-path="${pth}"] > li:first`).addClass('active');
			$(`ul[data-path="${pth}"] > li:first > i`).click();
			if (i < pathfragments.length - 1 ) {
				click_head(i+1);
			}
		}, 1000);
	})(i)
};
```


![tree_expand](https://github.com/zms-publishing/ZMS/assets/29705216/0e2316f0-2bbe-48a7-8405-bf2c970d5362)



Ref: https://github.com/idasm-unibe-ch/unibe-cms/issues/416

