### PR TITLE
Added readme html page

### DIFF
--- a/Products/zms/ZMSMetamodelProvider.py
+++ b/Products/zms/ZMSMetamodelProvider.py
@@ -72,6 +72,7 @@ class ZMSMetamodelProvider(
     manage_analyze = PageTemplateFile('zpt/ZMSMetamodelProvider/manage_analyze', globals())
     manage_metas = PageTemplateFile('zpt/ZMSMetamodelProvider/manage_metas', globals())
     manage_readme = PageTemplateFile('zpt/ZMSMetamodelProvider/manage_readme', globals())
+    manage_readme_iframe = PageTemplateFile('zpt/ZMSMetamodelProvider/manage_readme_iframe', globals())
 
     # Management Permissions.
     # -----------------------

--- a/Products/zms/plugins/www/zmi.core.css
+++ b/Products/zms/plugins/www/zmi.core.css
@@ -2716,6 +2716,7 @@ ul.pagination .page-item {
 		margin-top: 1.75rem;
 	}
 }
+#zmiIframereadme h1:before,
 #zmiModalreadme .modal-title:before {
 	content: "\f059";
 	font-family: 'Font Awesome 5 Free';
@@ -2734,6 +2735,14 @@ ul.pagination .page-item {
 #zmiModalreadme .modal-body h1 {
 	display: none !important;
 }
+#zmiIframereadme h1 {
+	font-size: 18px !important;
+	border-bottom:1px solid silver;
+	font-weight: bold !important;
+	padding:.75rem 0;
+	margin:1.25rem 0 1rem;
+}
+#zmiIframereadme h2,
 #zmiModalreadme .modal-body h2 {
 	font-size: 18px !important;
 	font-weight: bold !important;

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -267,7 +267,7 @@
 								</tal:block>
 							</div>
 							<span tal:condition="python:objAttr['id']=='readme'" 
-								title="Readme" class="zmi-readme text-info float-right pt-1 pr-3 d-none d-lg-block"
+								title="Readme" class="zmi-readme text-info float-right btn-sm mr-2 d-none d-lg-block"
 								tal:attributes="onclick python:'window.open(\'./metaobj_manager/%s.readme/manage_readme_iframe\')'%(id)">
 								<i class="far fa-question-circle"></i>
 							</span>
@@ -796,7 +796,7 @@ $(function(){
 
 }
 // Add Execute Button for TAL-Code-Regeneration om a ZPT-Method named standard_html
-var zmi_code_default_btn = '<i onclick="set_zmi_code_default(event)" title=\"Replace by Default-Code-Template\" class=\"zmi-code-default d-block position-absolute fas fa-sync text-primary pt-2 pr-3 mr-2\" style=\"cursor:pointer;right:0\"></i>';
+var zmi_code_default_btn = '<i onclick="set_zmi_code_default(event)" title=\"Replace by Default-Code-Template\" class=\"zmi-code-default fas fa-sync text-primary btn-lg mr-2 position-absolute\" style=\"cursor:pointer;right:0\"></i>';
 
 // Execute on DOM-Ready
 $(function(){

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -266,6 +266,11 @@
 									</a>
 								</tal:block>
 							</div>
+							<span tal:condition="python:objAttr['id']=='readme'" 
+								title="Readme" class="zmi-readme text-info float-right pt-1 pr-3 d-none d-lg-block"
+								tal:attributes="onclick python:'window.open(\'./metaobj_manager/%s.readme/manage_readme_iframe\')'%(id)">
+								<i class="far fa-question-circle"></i>
+							</span>
 						</td>
 					</tal:block>
 
@@ -791,7 +796,7 @@ $(function(){
 
 }
 // Add Execute Button for TAL-Code-Regeneration om a ZPT-Method named standard_html
-var zmi_code_default_btn = '<i onclick="set_zmi_code_default(event)" title=\"Replace by Default-Code-Template\" class=\"zmi-code-default icon-repeat fas fa-redo-alt text-primary text-center\" style=\"cursor:pointer;display:block;position:absolute;text-align:right !important;right:0.75em;padding:0.5em;\"></i>';
+var zmi_code_default_btn = '<i onclick="set_zmi_code_default(event)" title=\"Replace by Default-Code-Template\" class=\"zmi-code-default d-block position-absolute fas fa-sync text-primary pt-2 pr-3 mr-2\" style=\"cursor:pointer;right:0\"></i>';
 
 // Execute on DOM-Ready
 $(function(){

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_readme_iframe.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_readme_iframe.zpt
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en" tal:define="zmscontext python:here.getSelf(); standard modules/Products.zms/standard">
+<tal:block tal:content="structure python:zmscontext.zmi_html_head(here,request)">zmi_html_head</tal:block>
+<body id="zmiIframereadme"
+	tal:attributes="class python:zmscontext.zmi_body_class(id='container')"
+	tal:content="structure python:context.manage_readme(context,request)">
+	<!-- Readme: markdown formatted, optional 'readme' resource attribute rendered as HTML -->
+</body>
+</html>


### PR DESCRIPTION
To use the content-model readme-file as styled html page, e.g. in a iframe, a new ZMSMetamodelProvider-template was added: 
Products/zms/zpt/ZMSMetamodelProvider/manage_readme_iframe.zpt
This template utilizes manage_readme.zpt and makes a zmi-html page of it.  
The readme-attribute gets (simmilar to the editorial gui) a button to call that readme-page.

 
![markdown_readme3](https://github.com/zms-publishing/ZMS/assets/29705216/4560e0b9-82b1-4b36-821b-80767713114c)
