### PR TITLE
Added multiple selection for metacmd import

### DIFF
--- a/Products/zms/ZMSMetacmdProvider.py
+++ b/Products/zms/ZMSMetacmdProvider.py
@@ -569,9 +569,15 @@ class ZMSMetacmdProvider(
             filename = f.filename
             self.importXml(xml=f)
           else:
-            filename = REQUEST['init']
-            self.importConf(filename)
-          message = self.getZMILangStr('MSG_IMPORTED')%('<i>%s</i>'%filename)
+            if isinstance(REQUEST['init'], list):
+              for filename in list(REQUEST['init']):
+                self.importConf(filename)
+              msg_str = ', '.join(REQUEST['init'])
+            else:
+              filename = REQUEST['init']
+              self.importConf(filename)
+              msg_str = filename
+          message = self.getZMILangStr('MSG_IMPORTED')%('<i>%s</i>'%(msg_str))
         
         # Insert.
         # -------

--- a/Products/zms/zpt/ZMSMetacmdProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetacmdProvider/manage_main.zpt
@@ -181,21 +181,38 @@
 		<form class="form-horizontal" tal:attributes="action action" method="post" enctype="multipart/form-data">
 			<input type="hidden" name="lang" tal:attributes="value request/lang">
 			<div class="form-group row">
-				<label class="col-sm-3 control-label" for="file"><i class="far fa-folder-open"></i> <tal:block tal:content="python:here.getZMILangStr('ATTR_FILE')">File</tal:block></label>
-				<div class="col-sm-9">
+				<label class="col-sm-2 control-label" for="file"><i class="far fa-folder-open"></i> <tal:block tal:content="python:here.getZMILangStr('ATTR_FILE')">File</tal:block></label>
+				<div class="col-sm-10">
 					<input class="btn btn-file" name="file" type="file" />
 				</div>
 			</div><!-- .form-group -->
 			<div class="form-group row">
-				<label class="col-sm-3 control-label" for="file" tal:content="python:here.getZMILangStr('OR')">or</label>
-				<div class="col-sm-8">
-					<select id="init" class="form-control" name="init" onfocus="zmiExpandConfFiles(this,'.metacmd.')" onmouseover="zmiExpandConfFiles(this,'.metacmd.')">
+				<label class="col-sm-2 control-label" for="file" tal:content="python:here.getZMILangStr('OR')">or</label>
+				<div class="col-sm-10">
+					<select id="init" name="init" multiple="multiple" class="form-control" 
+						onfocus="zmiExpandConfFiles(this,'.metacmd.');$(this).addClass('expand');" 
+						onmouseover="zmiExpandConfFiles(this,'.metacmd.')">
 						<option value="">--- <tal:block tal:content="python:here.getZMILangStr('BTN_INIT')">Init</tal:block>... ---</option>
 					</select>
 				</div>
+				<style>
+				/*<!-*/
+					#init { 
+						height:2rem;
+						overflow:unset !important;
+						overflow-x: hidden;
+						overflow-y:scroll !important;
+					}
+					#init.expand,
+					#init:focus {
+						transition: height 0.5s ease-in-out;
+						height:20rem;
+					}
+				/*-->*/
+				</style>
 			</div><!-- .form-group -->
-			<div class="form-group row">
-				<div class="col-sm-9">
+			<div class="form-group row mt-5">
+				<div class="controls save">
 					<button name="btn" type="submit" class="btn btn-primary" value="BTN_IMPORT" tal:content="python:here.getZMILangStr('BTN_IMPORT')">Import</button>
 				</div>
 			</div>

--- a/Products/zms/zpt/ZMSMetacmdProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetacmdProvider/manage_main.zpt
@@ -196,7 +196,7 @@
 					</select>
 				</div>
 				<style>
-				/*<!-*/
+				/*<!--*/
 					#init { 
 						height:2rem;
 						overflow:unset !important;


### PR DESCRIPTION
Certain ZMS features (e.g. opensearch interface https://github.com/zms-publishing/ZMS/pull/203) needs the import of multiple config files; now this can be done in one step by importing the needed cmd-files as a selected stack,

![opensearch_import_multiple_metacmds](https://github.com/zms-publishing/ZMS/assets/29705216/2791b78c-f947-4544-828b-4929561afba3)

