### PR TITLE
Tix type problem of dict_keys on copy.copy

### DIFF
--- a/Products/zms/_exportable.py
+++ b/Products/zms/_exportable.py
@@ -481,8 +481,9 @@ class Exportable(_filtermanager.FilterItem):
       REQUEST.set('ZMS_PATH_HANDLER', True)
       try:
         
-        # Remember others.
-        others = copy.copy(REQUEST.other.keys())
+        # Remember others to remove them later.
+        # Note: REQUEST.other.keys() reveals not a list but a dict_keys-object!
+        others = copy.copy(list(REQUEST.other.keys()))
         
         root = getattr( obj, '__root__', None)
         if root is not None:
@@ -492,7 +493,7 @@ class Exportable(_filtermanager.FilterItem):
           html = obj.f_index_html( obj, REQUEST)
         
         # Remove new others.
-        for rk in REQUEST.other.keys():
+        for rk in list(REQUEST.other.keys()):
           if rk not in others:
             try:
               del REQUEST.other[rk]


### PR DESCRIPTION
Recursive html export may lead to a type problem in the copy module because request keys are typed as dict_keys. 

```
>>>reductor(4)
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: cannot pickle 'dict_keys' object
```

In the end no html pages are generated. 

![unibe_copycopy_error2](https://github.com/zms-publishing/ZMS/assets/29705216/6c38f11a-1f0c-4a6c-af45-c3e0f78f67ab)


![unibe_copycopy_error3](https://github.com/zms-publishing/ZMS/assets/29705216/ae4f8f98-9461-4187-b702-9d788583f54e)


