### PR TITLE
Paged Indexing: Ensure JSON Format on Response

### DIFF
--- a/Products/zms/ZMSZCatalogConnector.py
+++ b/Products/zms/ZMSZCatalogConnector.py
@@ -300,8 +300,6 @@ class ZMSZCatalogConnector(
     # --------------------------------------------------------------------------
     def reindex_page(self, uid, page_size, clients=False, fileparsing=True, REQUEST=None, RESPONSE=None):
       """ reindex_page """
-      RESPONSE.setHeader('Cache-Control', 'no-cache')
-      RESPONSE.setHeader('Content-Type', 'application/json; charset=utf-8')
       adapter = self.getCatalogAdapter()
       count = 0
       node = self.getLinkObj(uid)
@@ -317,6 +315,8 @@ class ZMSZCatalogConnector(
         result['next_node'] = None if not node else '{$%s}'%node.get_uid()
         count += 1
       result['success'], result['failed'] = self.manage_objects_add(objects)
+      RESPONSE.setHeader('Cache-Control', 'no-cache')
+      RESPONSE.setHeader('Content-Type', 'application/json; charset=utf-8')
       return json.dumps(result,indent=2)
 
     ############################################################################

--- a/Products/zms/conf/metacmd_manager/manage_zmsindex_reindex_paged/manage_zmsindex_reindex_paged.py
+++ b/Products/zms/conf/metacmd_manager/manage_zmsindex_reindex_paged/manage_zmsindex_reindex_paged.py
@@ -45,7 +45,6 @@ def manage_zmsindex_reindex_paged( self):
   # REST Endpoints  
   if request.get('json'):
     import json
-    request.RESPONSE.setHeader("Content-Type","text/json")
     root_node = self.getLinkObj(request['root_node'])
     clients = standard.pybool(request['clients'])
     data = {'pid':self.Control_Panel.process_id(),'root_node':request['root_node'],'clients':request['clients']}
@@ -63,6 +62,7 @@ def manage_zmsindex_reindex_paged( self):
       data['next_node'] = None
       handler = ZMSIndexReindexHandler(zmsindex,catalog)
       traverse(data,root_node,clients,node,handler,page_size)
+    request.RESPONSE.setHeader("Content-Type","text/json")
     return json.dumps(data)
   
   prt = []


### PR DESCRIPTION
If the batch list is not returned as JSON the indexing process cannot controlled anymore by the JS frontend and will stop. The fix sets the setHeader() call as late as possible (to overwrite header setting due to content rendering etc.)

_[1] The batch-controlling JSON code it responded as `content-type = application/json`_

![unibe_opensearch_block3](https://github.com/zms-publishing/ZMS/assets/29705216/af6c70c3-eae0-4618-8d7e-9883328668a7)

_[2] Certain circumstances may interfere with the content-type-Header and reset it to html; in this case the JS code for index-batching cannot process the resonse anymore_

![unibe_opensearch_block4](https://github.com/zms-publishing/ZMS/assets/29705216/985522df-2299-44e1-aef0-df79b0d1b44f)

_[3] rendering inner-page code may result in a change of the response format _

![image](https://github.com/zms-publishing/ZMS/assets/29705216/d6e7177e-5e42-4d7b-ad1e-e76aff068365)

_ [4] patched code overwrites the header manipulation_

![image](https://github.com/zms-publishing/ZMS/assets/29705216/561cbd7c-521d-4241-b8f0-8bcf992f39db)





