### PR TITLE
MetaObj XML-Import: XML-Parsing of list-like attrs (e.g. autocomplete) may results in removed py-indents

### DIFF
--- a/Products/zms/_xmllib.py
+++ b/Products/zms/_xmllib.py
@@ -116,9 +116,9 @@ def getXmlType(v):
 def getXmlTypeSaveValue(v, attrs):
   # Strip.
   if isinstance(v, str):
-    while len(v) > 0 and v[0] <= ' ':
+    while len(v) > 0 and v[0] <= ' ' and v[0] != '\t':
       v = v[1:]
-    while len(v) > 0 and v[-1] <= ' ':
+    while len(v) > 0 and v[-1] <= ' ' and v[-1] != '\t':
       v = v[:-1]
   # Type.
   t = attrs.get('type', '?')


### PR DESCRIPTION
fixed XML-Parsing

Ref: https://github.com/zms-publishing/ZMS/issues/230
