### PR TITLE
REST API: force json values to string

### DIFF
--- a/Products/zms/rest_api.py
+++ b/Products/zms/rest_api.py
@@ -191,7 +191,7 @@ class RestApiController(object):
             else:
                 data = {'ERROR':'Not Found','context':str(self.context),'path_to_handle':self.path_to_handle,'ids':self.ids}
             REQUEST.RESPONSE.setHeader('Content-Type',decoration['content_type'])
-            return json.dumps(data)
+            return json.dumps(data, default=lambda x: str(x))
         return None
 
     @api(tag="zmsindex", pattern="/zmsindex", content_type="application/json")

--- a/Products/zms/rest_api.py
+++ b/Products/zms/rest_api.py
@@ -191,7 +191,7 @@ class RestApiController(object):
             else:
                 data = {'ERROR':'Not Found','context':str(self.context),'path_to_handle':self.path_to_handle,'ids':self.ids}
             REQUEST.RESPONSE.setHeader('Content-Type',decoration['content_type'])
-            return json.dumps(data, default=lambda x: str(x))
+            return json.dumps(data)
         return None
 
     @api(tag="zmsindex", pattern="/zmsindex", content_type="application/json")
@@ -200,7 +200,7 @@ class RestApiController(object):
         catalog = context.get_catalog()
         q = {k.replace('[]',''):v for k,v in request.form.items() if v != ''}
         l = catalog(q)
-        return [{item_name:r[item_name] for item_name in catalog.schema()} for r in l]
+        return [{item_name:(r[item_name] or '') for item_name in catalog.schema()} for r in l]
 
     @api(tag="metamodel", pattern="/metaobj_manager", content_type="application/json")
     def metaobj_manager(self, context):


### PR DESCRIPTION
The fix prevents occasional Type-Errors with `json.dumps()` _Object of type Missing is not JSON serializable_:

![DESY_restapi](https://github.com/zms-publishing/ZMS/assets/29705216/10ceaab5-bba9-43e2-b94f-524dac3ad600)

Traceback:
```
2024-01-09 15:25:16 ERROR [waitress:435][waitress-0] Exception while serving /sites/content/++rest_api/zcatalog_adapter/elasticsearch_connector/zmsindex
Traceback (most recent call last):
  File "/home/zope/instances/ZMS5_zeo_prod/venv/lib/python3.8/site-packages/waitress/channel.py", line 428, in service
    task.service()
  File "/home/zope/instances/ZMS5_zeo_prod/venv/lib/python3.8/site-packages/waitress/task.py", line 168, in service
    self.execute()
  File "/home/zope/instances/ZMS5_zeo_prod/venv/lib/python3.8/site-packages/waitress/task.py", line 434, in execute
    app_iter = self.channel.server.application(environ, start_response)
  File "/home/zope/instances/ZMS5_zeo_prod/venv/lib/python3.8/site-packages/ZPublisher/httpexceptions.py", line 30, in __call__
    return self.application(environ, start_response)
  File "/home/zope/instances/ZMS5_zeo_prod/venv/lib/python3.8/site-packages/paste/translogger.py", line 69, in __call__
    return self.application(environ, replacement_start_response)
  File "/home/zope/instances/ZMS5_zeo_prod/venv/lib/python3.8/site-packages/ZPublisher/WSGIPublisher.py", line 376, in publish_module
    response = _publish(request, new_mod_info)
  File "/home/zope/instances/ZMS5_zeo_prod/venv/lib/python3.8/site-packages/ZPublisher/WSGIPublisher.py", line 271, in publish
    result = mapply(obj,
  File "/home/zope/instances/ZMS5_zeo_prod/venv/lib/python3.8/site-packages/ZPublisher/mapply.py", line 85, in mapply
    return debug(object, args, context)
  File "/home/zope/instances/ZMS5_zeo_prod/venv/lib/python3.8/site-packages/ZPublisher/WSGIPublisher.py", line 68, in call_object
    return obj(*args)
  File "/home/zope/instances/ZMS5_zeo_prod/venv/src/ZMS5/Products/zms/rest_api.py", line 194, in __call__
    return json.dumps(data)
  File "/usr/lib/python3.8/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python3.8/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.8/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type Missing is not JSON serializable

```
 