### PR TITLE
Prevent Recursions of bodyContentZMSLib_page (DESY)

### DIFF
--- a/Products/zms/conf/metaobj_manager/com.zms.foundation/ZMSLib/bodyContentZMSLib_page.zpt
+++ b/Products/zms/conf/metaobj_manager/com.zms.foundation/ZMSLib/bodyContentZMSLib_page.zpt
@@ -1,15 +1,18 @@
 <!-- bodyContentZMSLib_page -->
-
-<tal:block tal:condition="python:here.meta_id in ['ZMS','ZMSFolder','ZMSDocument']" 
-	tal:define="global childNodes python:[ob for ob in here.getObjChildren('e',request,here.PAGEELEMENTS) if ob.meta_id not in ['bt_carousel']]">
-	<tal:block tal:repeat="childNode childNodes" tal:content="structure python:childNode.getBodyContent(request)">
-		The page-element body-content
+<tal:block tal:define="
+	do_count_recursions python:request.set('count_bodyContentZMSLib_page', int(request.get('count_bodyContentZMSLib_page',-1))+1);
+	recursions python:int(request.get('count_bodyContentZMSLib_page',0))"
+	tal:condition="python:not bool(recursions)">
+	<tal:block tal:condition="python:here.meta_id in ['ZMS','ZMSFolder','ZMSDocument']" tal:define="global 
+		childNodes python:[ob for ob in here.getObjChildren('e',request,here.PAGEELEMENTS) if ob.meta_id not in ['bt_carousel']]">
+		<tal:block tal:repeat="childNode childNodes" tal:content="structure python:childNode.getBodyContent(request)">
+			The page-element body-content
+		</tal:block>
+	</tal:block>
+	<tal:block tal:condition="python:here.meta_id not in ['ZMS','ZMSFolder','ZMSDocument']">
+		<tal:block tal:content="structure python:here.getBodyContent(request)">
+			The body-content
+		</tal:block>
 	</tal:block>
 </tal:block>
-<tal:block tal:condition="python:here.meta_id not in ['ZMS','ZMSFolder','ZMSDocument']">
-	<tal:block tal:content="structure python:here.getBodyContent(request)">
-		The body-content
-	</tal:block>
-</tal:block>
-
 <!-- /bodyContentZMSLib_page -->


### PR DESCRIPTION
Defining a PAGE-like content class may mislead to use a standard_html like the one of ZMSDocument and calling the  default template for _page content sequencing_ `bodyContentZMSLib_page`
 
```
<!-- ZMSDocument.standard_html -->
<tal:block tal:define="global 
		zmscontext options/zmscontext"
		tal:content="structure python:zmscontext.bodyContentZMSLib_page(zmscontext,request)">
	The page-content
</tal:block>
<!-- /ZMSDocument.standard_html -->
```
This will end up in a recursion if the page rendering default template is not prepared with the new content class.

To avoid the recursive calling of the _page content sequencing template_ it is suggested to add a name specific counter to the request object plus a check.
