### PR TITLE
Catalog-Adapter: custom filter-function

### DIFF
--- a/Products/zms/ZMSMetaobjManager.py
+++ b/Products/zms/ZMSMetaobjManager.py
@@ -486,6 +486,27 @@ class ZMSMetaobjManager(object):
       ob = obs.get( id)
       return ob
 
+    # --------------------------------------------------------------------------
+    #  ZMSMetaobjManager.getTypedMetaIds:
+    #
+    #  Returns list of all typed meta-ids in model.
+    # --------------------------------------------------------------------------
+    def getTypedMetaIds(self, meta_ids):
+      metaObjIds = self.getMetaobjIds()
+      typed_meta_ids = []
+      # iterate types
+      for meta_id in meta_ids:
+        if meta_id.startswith('type(') and meta_id.endswith(')'):
+          meta_obj_type = meta_id[5:-1]
+          for metaObjId in metaObjIds:
+            metaObj = self.getMetaobj( metaObjId, aq_attrs=['enabled'])
+            if metaObj['type'] == meta_obj_type and metaObj['enabled']:
+              typed_meta_ids.append( metaObj['id'])
+        elif meta_id in metaObjIds:
+          typed_meta_ids.append( meta_id)
+        else:
+          standard.writeError( self, "[getMetaIds]: invalid meta_id \'%s\'"%meta_id)
+      return typed_meta_ids
 
     # --------------------------------------------------------------------------
     #  ZMSMetaobjManager.getMetaobjIds:

--- a/Products/zms/ZMSZCatalogAdapter.py
+++ b/Products/zms/ZMSZCatalogAdapter.py
@@ -186,7 +186,11 @@ class ZMSZCatalogAdapter(ZMSItem.ZMSItem):
     #  ZMSZCatalogAdapter.matches_ids_filter: 
     # --------------------------------------------------------------------------
     def matches_ids_filter(self, node):
-      return standard.dt_py(node, self.getCustomFilterFunction(), {'meta_ids':self.getMetaobjManager().getTypedMetaIds(self.getIds())})
+      if self.getCustomFilterFunction()=='':
+        # Default filter-function.
+        return node.meta_id in self.getMetaobjManager().getTypedMetaIds(self.getIds())
+      else:
+        return standard.dt_py(node, self.getCustomFilterFunction(), {'meta_ids':self.getMetaobjManager().getTypedMetaIds(self.getIds())})
     
     # --------------------------------------------------------------------------
     #  ZMSZCatalogAdapter.ids: 

--- a/Products/zms/ZMSZCatalogAdapter.py
+++ b/Products/zms/ZMSZCatalogAdapter.py
@@ -288,8 +288,8 @@ class ZMSZCatalogAdapter(ZMSItem.ZMSItem):
         if 'catalog_index' in self.getMetaobjAttrIds(node.meta_id):
           for data in node.attr('catalog_index'):
             objects.append(get_catalog_objects(self, connector, node, data, fileparsing))
-        # Catalog only desired meta-ids.
-        if node.meta_id in self.getIds():
+        # Catalog only desired typed meta-ids (resolves type(ZNS...)).
+        if node.meta_id in self.getMetaobjManager().getTypedMetaIds(self.getIds()):
           data = get_default_data(node)
           objects.append(get_catalog_objects(self, connector, node, data, fileparsing))
       return objects

--- a/Products/zms/_zmi_actions_util.py
+++ b/Products/zms/_zmi_actions_util.py
@@ -159,7 +159,7 @@ def zmi_insert_actions(container, context, objAttr, objChildren, objPath=''):
       # dynamic list of types
       if standard.dt_executable('\n'.join(meta_keys)):
         meta_keys = standard.dt_exec(container, '\n'.join(meta_keys))
-      # typed meta-ids (resolves type(ZNS...))
+      # typed meta-ids (resolves type(ZMS...))
       meta_ids = container.getMetaobjManager().getTypedMetaIds(meta_keys)
     else:
       meta_ids.append( objAttr['type'])

--- a/Products/zms/_zmi_actions_util.py
+++ b/Products/zms/_zmi_actions_util.py
@@ -159,19 +159,8 @@ def zmi_insert_actions(container, context, objAttr, objChildren, objPath=''):
       # dynamic list of types
       if standard.dt_executable('\n'.join(meta_keys)):
         meta_keys = standard.dt_exec(container, '\n'.join(meta_keys))
-      # iterate types
-      metaobj_manager = container.getMetaobjManager()
-      for meta_id in meta_keys:
-        if meta_id.startswith('type(') and meta_id.endswith(')'):
-          meta_obj_type = meta_id[5:-1]
-          for metaObjId in metaObjIds:
-            metaObj = metaobj_manager.getMetaobj( metaObjId, aq_attrs=['enabled'])
-            if metaObj['type'] == meta_obj_type and metaObj['enabled']:
-              meta_ids.append( metaObj['id'])
-        elif meta_id in metaObjIds:
-          meta_ids.append( meta_id)
-        else:
-          container.writeError( '[zmi_insert_actions]: %s.%s contains invalid meta_id \'%s\''%(container.meta_id, objAttr['id'], meta_id))
+      # typed meta-ids (resolves type(ZNS...))
+      meta_ids = container.getMetaobjManager().getTypedMetaIds(meta_keys)
     else:
       meta_ids.append( objAttr['type'])
     for meta_id in meta_ids:

--- a/Products/zms/zpt/ZMSZCatalogAdapter/manage_main.zpt
+++ b/Products/zms/zpt/ZMSZCatalogAdapter/manage_main.zpt
@@ -19,6 +19,33 @@
 	<div class="well">On every change the content is automatically indexed in the catalog.</div>
 </div>
 
+<div class="help d-none" data-for="custom_filter_function">
+	<div class="well">
+		<p>
+			The indexing filter consists of python code that works with two parameters: <br/>
+			1. <code>context</code> is the currently iterated object to be indexed<br/>
+			2. <code>meta_ids</code> is the list of content-classes that should be indexed. <br/>
+			<br/>
+			The applied code can define rules based on the context's attributes values whether indexing shall happen or not. 
+			The returning value of the filter rules must be <code>True</code> or <code>False</code>.
+			A simple example will illustrate how it can be applied; the intention would be 
+			"<i>Do not index any ZMSFolder having a title "Folder" and even not its children</i>".
+			<div class="zmi-code card p-2 highlight">
+				##<br/>
+				return (context.meta_id in meta_ids) \<br/>
+				&nbsp;&nbsp;and context.attr('title')!='Folder' \<br/>
+				&nbsp;&nbsp;and context.getParentNode().attr('title')!='Folder'<br/>
+			</div>
+			<br/>
+			<p class="small">
+				HINT: The introducing ##-comments marks the code as Python for the editor gui.
+				Actually only Python code will work here. 
+			</p>
+		</p>
+	</div>
+</div>
+
+
 <div class="help d-none" data-for="catalog_model">
 	<div class="well">
 		<p>
@@ -38,7 +65,7 @@
 			##<br/>
 			<br/>
 			return [{<br/>
-				<code tal:repeat="attr_id python:here.getAttrIds()" tal:content="structure python:'&nbsp;&nbsp;\'%s\':\'...\',<br/>'%(attr_id)" />
+			<code tal:repeat="attr_id python:here.getAttrIds()" tal:content="structure python:'&nbsp;&nbsp;\'%s\':\'...\',<br/>'%(attr_id)" />
 			}]
 		</div>
 	</div>

--- a/Products/zms/zpt/ZMSZCatalogAdapter/manage_main.zpt
+++ b/Products/zms/zpt/ZMSZCatalogAdapter/manage_main.zpt
@@ -26,15 +26,17 @@
 			1. <code>context</code> is the currently iterated object to be indexed<br/>
 			2. <code>meta_ids</code> is the list of content-classes that should be indexed. <br/>
 			<br/>
-			The applied code can define rules based on the context's attributes values whether indexing shall happen or not. 
-			The returning value of the filter rules must be <code>True</code> or <code>False</code>.
+			The applied code can define rules based on the context's attributes values whether 
+			indexing shall happen or not. The returning value of the filter rules must be 
+			<code>True</code> or <code>False</code>.
 			A simple example will illustrate how it can be applied; the intention would be 
-			"<i>Do not index any ZMSFolder having a title "Folder" and even not its children</i>".
-			<div class="zmi-code card p-2 highlight">
+			"<i>Do not index any inactive node, it's descendants and nodes having type-attribute 
+			set to 'Resource'</i>".
+			<div class="zmi-code card p-2 highlight text-nowrap" style="overflow-x: scroll;">
 				##<br/>
 				return (context.meta_id in meta_ids) \<br/>
-				&nbsp;&nbsp;and context.attr('title')!='Folder' \<br/>
-				&nbsp;&nbsp;and context.getParentNode().attr('title')!='Folder'<br/>
+				&nbsp;&nbsp;and not [ob for ob in context.breadcrumbs_obj_path() if not ob.isActive(context.REQUEST)] \<br/>
+				&nbsp;&nbsp;and not context.attr('attr_dc_type')=='Resource'<br/>
 			</div>
 			<br/>
 			<p class="small">

--- a/Products/zms/zpt/ZMSZCatalogAdapter/manage_main.zpt
+++ b/Products/zms/zpt/ZMSZCatalogAdapter/manage_main.zpt
@@ -122,6 +122,12 @@
 				<input type="checkbox" value="1" id="catalog_awareness_active" name="catalog_awareness_active:int" tal:attributes="checked python:['','checked'][int(here.getConfProperty('ZMS.CatalogAwareness.active',1)==1)]"/>
 			</div><!-- .col-sm-10 -->
 		</div><!-- .form-group -->
+		<div class="form-group row align-items-start">
+			<label class="col-sm-2 control-label" for="custom_filter_function"><span>Custom Filter-Function</span></label>
+			<div class="col-sm-10">
+				<textarea tal:replace="structure python:here.zmi_ace_editor(here,request,name='custom_filter_function',id='custom_filter_function',text=here.getCustomFilterFunction())">ACE Editor</textarea>
+			</div>
+		</div>
 		<div class="form-group row align-items-baseline">
 			<label class="col-sm-2 control-label" for="catalog_model"><span>Model</span></label>
 			<div class="col-sm-10"

--- a/Products/zms/zpt/ZMSZCatalogAdapter/manage_main.zpt
+++ b/Products/zms/zpt/ZMSZCatalogAdapter/manage_main.zpt
@@ -50,7 +50,7 @@
 	<input type="hidden" id="getIds" tal:attributes="value python:','.join(here.getIds())" />
 	<span class="d-none" id="getAttrs" tal:content="python:here.str_json(here.getAttrs())"></span>
 
-	<tal:block tal:condition="python:here.getLevel()==0">
+	<tal:block tal:condition="python:here.breadcrumbs_obj_path().index(here.getDocumentElement())==0">
 	<legend>Connectors</legend>
 	<div class="card-body" tal:define="
 		connectors python:here.get_connectors();
@@ -144,7 +144,6 @@
 						<tbody>
 							<tr>
 								<td class="p-0">
-
 									<table class="table table-sm table-borderless" id="meta_types">
 										<tbody>
 											<tal:block tal:repeat="metaObjPackage python:here.sort_list(metaObjPackages+metaObjPackages2)">
@@ -198,7 +197,6 @@
 											</tal:block>
 										</tbody>
 									</table>
-
 								</td>
 								<td class="p-0">
 									<table class="table table-sm table-borderless" id="indexes">
@@ -208,7 +206,6 @@
 							</tr>
 						</tbody>
 					</table>
-
 			</div><!-- .col-sm-10 -->
 		</div><!-- .form-group -->
 		<div class="form-group row">
@@ -218,13 +215,11 @@
 			</div><!-- .controls.save -->
 		</div><!-- .form-group.row -->
 	</div><!-- .card-body -->
-
 </form>
 
 </div><!-- #zmi-tab -->
 
 <script>
-// <!--
 
 function toggleMetaobj() {
 	var selected = {};
@@ -236,7 +231,7 @@ function toggleMetaobj() {
 	});
 	var metaObjAttrs = {};
 	$("form input[name='ids:list']:checked").each(function() {
-		if(!$(this).prop("disabled")) {
+		if(!$(this).prop("disabled") && $(this).attr("data-attrs")) {
 			var dataAttrs = $(this).attr("data-attrs").split(",");
 			for (var i = 0; i < dataAttrs.length; i++) {
 				var dataAttr = dataAttrs[i];
@@ -244,7 +239,7 @@ function toggleMetaobj() {
 					id:dataAttr.substring(0,dataAttr.indexOf("(")),
 					type:dataAttr.substring(dataAttr.indexOf("(")+1,dataAttr.indexOf(")"))
 				};
-				if (typeof metaObjAttrs[metaObjAttr.id] == 'undefined') {
+				if (!metaObjAttr.id.indexOf("_") == 0 && typeof metaObjAttrs[metaObjAttr.id] == 'undefined') {
 					metaObjAttrs[metaObjAttr.id] = metaObjAttr;
 				}
 			}


### PR DESCRIPTION
Ref: https://github.com/idasm-unibe-ch/unibe-cms-opensearch/issues/21

The indexing filter consists of python code that works with two parameters:
1. context is the currently iterated object to be indexed
2. meta_ids is the list of content-classes that should be indexed.

The applied code can define rules based on the context's attributes values whether indexing shall happen or not. The returning value of the filter rules must be True or False. A simple example will illustrate how it can be applied; the intention would be "Do not index any inactive node, it's descendants and nodes having type-attribute set to 'Resource'".

```
##
return (context.meta_id in meta_ids) \
  and not [ob for ob in context.breadcrumbs_obj_path() if not ob.isActive(context.REQUEST)] \
  and not context.attr('attr_dc_type')=='Resource'
```

**default:**
```
##
return context.meta_id in meta_ids
```