### PR TITLE
fix(zms-index): Show instant change on refresh catalog

### DIFF
--- a/Products/zms/zpt/ZMSObject/input_fields.zpt
+++ b/Products/zms/zpt/ZMSObject/input_fields.zpt
@@ -85,8 +85,9 @@
 								onclick python:'$ZMI.CopyToClipboard(\'{$%s}\')'%(here.get_uid());
 								class python:' '.join(['get_uid']+[['text-danger'],[]][cataloged]);">
 							<tal:block tal:content="python:'ID:%s'%(here.get_uid())">unique-id</tal:block>
-							<tal:block tal:condition="python:request.get('refresh_catalog')">
+							<tal:block tal:condition="python:request.get('refresh_catalog','False')=='True'">
 								<tal:block tal:define="dummy0 python:standard.triggerEvent(here,'*.ObjectMoved')"></tal:block>
+                                <script>location.href='?refresh_catalog=False'</script>
 							</tal:block>
 							<a tal:condition="not:cataloged" 
 								href="javascript:;" title="Refresh Catalog Item"


### PR DESCRIPTION
This PR tries to improve usability on Refresh Catalog Item of a content object if its UID is missing in ZMSIndex.

The page gets now a refresh by javascript again after the event is triggered on red button click -> the cataloged UID is shown in normal black afterwards and not in red with button anymore, which confuses the editors.

