### PR TITLE
Catalog-Adapter: custom filter-function - only active objects

### DIFF
--- a/Products/zms/ZMSZCatalogConnector.py
+++ b/Products/zms/ZMSZCatalogConnector.py
@@ -303,7 +303,9 @@ class ZMSZCatalogConnector(
       adapter = self.getCatalogAdapter()
       result = {'success':0,'failed':0,'log':[],'next_node':None}
       objects = []
-      nodes, next_node = self.get_next_page(uid, page_size, clients) 
+      def filter_function(x):
+        return x.isActive(REQUEST)
+      nodes, next_node = self.get_next_page(uid, page_size, clients, filter_function) 
       log = []
       for node in nodes:
         node_objects = adapter.get_catalog_objects(self, node, fileparsing)

--- a/Products/zms/zmscontainerobject.py
+++ b/Products/zms/zmscontainerobject.py
@@ -745,7 +745,7 @@ class ZMSContainerObject(
     ###
     ############################################################################
 
-    def get_next_page(self, uid, page_size=100, clients=False):
+    def get_next_page(self, uid, page_size=100, clients=False, filter_function=None):
       nodes, next = [], None
       meta_types = list(self.dGlobalAttrs)
       child_nodes = {}
@@ -754,6 +754,8 @@ class ZMSContainerObject(
         key = str(self)
         if key not in child_nodes:
           child_nodes[key] = self.objectValues(meta_types)
+          if filter_function:
+            child_nodes[key] = [x for x in child_nodes[key] if filter_function(x)]
         return child_nodes[key]
 
       def get_next_node(self, allow_children=True):


### PR DESCRIPTION
Filter may reduce performance massively
https://github.com/idasm-unibe-ch/unibe-cms-opensearch/issues/21
As major reason, inactive sub-trees from catalog should be exluded by default.