### PR TITLE
ZMI: Prevent Error on Iterating over Broken Zope-Objects

### DIFF
--- a/Products/zms/_confmanager.py
+++ b/Products/zms/_confmanager.py
@@ -1047,8 +1047,8 @@ class ConfManager(
     ############################################################################
 
     def getWorkflowManager(self):
-      manager = [x for x in self.getDocumentElement().objectItems() if type(x)!=tuple and x.getId() == 'workflow_manager']
-      if len(manager) == 0:
+      manager = getattr(self.getDocumentElement(),'workflow_manager',None)
+      if manager is None:
         class DefaultManager(object):
           def importXml(self, xml): pass
           def getAutocommit(self): return True
@@ -1058,8 +1058,8 @@ class ConfManager(
           def getActivityDetails(self, id): return None
           def getTransitions(self): return []
           def getTransitionIds(self): return []
-        manager = [DefaultManager()]
-      return manager[0]
+        manager = DefaultManager()
+      return manager
 
 
     ############################################################################

--- a/Products/zms/_confmanager.py
+++ b/Products/zms/_confmanager.py
@@ -1047,7 +1047,7 @@ class ConfManager(
     ############################################################################
 
     def getWorkflowManager(self):
-      manager = [x for x in self.getDocumentElement().objectValues() if x.getId() == 'workflow_manager']
+      manager = [x for x in self.getDocumentElement().objectItems() if type(x)!=tuple and x.getId() == 'workflow_manager']
       if len(manager) == 0:
         class DefaultManager(object):
           def importXml(self, xml): pass

--- a/Products/zms/_objattrs.py
+++ b/Products/zms/_objattrs.py
@@ -687,6 +687,9 @@ class ObjAttrs(object):
           # Start time.
           elif key == 'attr_active_start':
             if value is not None:
+              if isinstance(value, time.struct_time):
+                # Convert time.struct_time to datetime tuple.
+                value = tuple(value[:8]) + (0,)
               dt = datetime.datetime.fromtimestamp(time.mktime(value))
               b = b and now > dt
               if dt > now and self.REQUEST.get('ZMS_CACHE_EXPIRE_DATETIME', dt) >= dt:
@@ -694,6 +697,9 @@ class ObjAttrs(object):
           # End time.
           elif key == 'attr_active_end':
             if value is not None:
+              if isinstance(value, time.struct_time):
+                # Convert time.struct_time to datetime tuple.
+                value = tuple(value[:8]) + (0,)
               dt = datetime.datetime.fromtimestamp(time.mktime(value))
               b = b and dt > now
               if dt > now and self.REQUEST.get('ZMS_CACHE_EXPIRE_DATETIME', dt) >= dt:

--- a/Products/zms/zpt/ZMSContainerObject/manage_system.zpt
+++ b/Products/zms/zpt/ZMSContainerObject/manage_system.zpt
@@ -65,14 +65,14 @@
 	<td class="zmi-object-check">
 		<input type="checkbox" name="ids:list" tal:attributes="value python:item[0]"/>
 	</td>
-	<td class="zmi-object-type" tal:attributes="title python:item[1].meta_type">
+	<td class="zmi-object-type">
 		<tal:block tal:define="icon python:item[1].zmi_icon"
-			tal:on-error="structure string:<i title='Error: No Icon Found' class='far fa-file-alt'></i>">
-			<i tal:attributes="class icon" />
+			tal:on-error="structure string:<i title='Error: No Icon Found' class='fas fa-exclamation-triangle text-danger'></i>">
+			<i tal:attributes="class icon; title python:item[1].meta_type" />
 		</tal:block>
 	</td>
 	<td class="zmi-object-id">
-		<a target="_blank" tal:on-error="string:Error: No URL Found!" 
+		<a target="_blank" tal:on-error="python:'%s (Broken Object!)'%item[0]" 
 			tal:attributes="href python:'%s/manage_workspace'%item[1].absolute_url()">
 			<tal:block tal:content="python:item[0]">the id</tal:block>
 			<tal:block tal:condition="python:item[1].title_or_id()">


### PR DESCRIPTION
Ref:
https://github.com/zms-publishing/ZMS/pull/255
https://github.com/zopefoundation/Zope/issues/311

ZEXP-data transfer will be blocked, if content from branch #fb_sys_conf_repo (PR #255) is transferred to a ZMS running without the new config-manager. The code changes shall avoid broken object-error on iterating Zope nodes for ZMI.

![broken](https://github.com/zms-publishing/ZMS/assets/29705216/7832e390-742d-4679-aaed-2e138d993f31)



```log
2024-02-28 08:13:10 ERROR [waitress:357][waitress-0] Exception while serving /VirtualHostBase/https/zms5.sntl-live.zms.hosting:443/VirtualHostRoot/sites/manage_importObject
Traceback (most recent call last):
  File "/home/zope/virtualenv_zms5/lib/python3.8/site-packages/waitress/channel.py", line 350, in service
    task.service()
  File "/home/zope/virtualenv_zms5/lib/python3.8/site-packages/waitress/task.py", line 171, in service
    self.execute()
  File "/home/zope/virtualenv_zms5/lib/python3.8/site-packages/waitress/task.py", line 441, in execute
    app_iter = self.channel.server.application(environ, start_response)
  File "/home/zope/virtualenv_zms5/src/Zope/src/ZPublisher/httpexceptions.py", line 30, in __call__
    return self.application(environ, start_response)
  File "/home/zope/virtualenv_zms5/lib/python3.8/site-packages/paste/translogger.py", line 69, in __call__
    return self.application(environ, replacement_start_response)
  File "/home/zope/virtualenv_zms5/src/Zope/src/ZPublisher/WSGIPublisher.py", line 391, in publish_module
    response = _publish(request, new_mod_info)
  File "/home/zope/virtualenv_zms5/src/Zope/src/ZPublisher/WSGIPublisher.py", line 285, in publish
    result = mapply(obj,
  File "/home/zope/virtualenv_zms5/src/Zope/src/ZPublisher/mapply.py", line 98, in mapply
    return debug(object, args, context)
  File "/home/zope/virtualenv_zms5/src/Zope/src/ZPublisher/WSGIPublisher.py", line 68, in call_object
    return obj(*args)
  File "/home/zope/virtualenv_zms5/src/Zope/src/OFS/ObjectManager.py", line 653, in manage_importObject
    imported = self._importObjectFromFile(
  File "/home/zope/virtualenv_zms5/src/Zope/src/OFS/ObjectManager.py", line 679, in _importObjectFromFile
    ob = connection.importFile(filepath)
  File "/home/zope/virtualenv_zms5/lib/python3.8/site-packages/ZODB/ExportImport.py", line 78, in importFile
    return self.importFile(fp, clue=clue,
  File "/home/zope/virtualenv_zms5/lib/python3.8/site-packages/ZODB/ExportImport.py", line 95, in importFile
    t.savepoint(optimistic=True)
  File "/home/zope/virtualenv_zms5/lib/python3.8/site-packages/transaction/_transaction.py", line 228, in savepoint
    self._saveAndRaiseCommitishError()  # reraises!
  File "/home/zope/virtualenv_zms5/lib/python3.8/site-packages/transaction/_transaction.py", line 316, in _saveAndRaiseCommitishError
    reraise(t, v, tb)
  File "/home/zope/virtualenv_zms5/lib/python3.8/site-packages/transaction/_compat.py", line 49, in reraise
    raise value
  File "/home/zope/virtualenv_zms5/lib/python3.8/site-packages/transaction/_transaction.py", line 225, in savepoint
    savepoint = Savepoint(self, optimistic, *self._resources)
  File "/home/zope/virtualenv_zms5/lib/python3.8/site-packages/transaction/_transaction.py", line 626, in __init__
    savepoint = savepoint()
  File "/home/zope/virtualenv_zms5/lib/python3.8/site-packages/ZODB/Connection.py", line 997, in savepoint
    self._commit(None)
  File "/home/zope/virtualenv_zms5/lib/python3.8/site-packages/ZODB/Connection.py", line 517, in _commit
    self._importDuringCommit(transaction, *self._import)
  File "/home/zope/virtualenv_zms5/lib/python3.8/site-packages/ZODB/ExportImport.py", line 188, in _importDuringCommit
    pickler.dump(unpickler.load())
  File "/home/zope/virtualenv_zms5/lib/python3.8/site-packages/ZODB/_compat.py", line 62, in find_class
    return super(Unpickler, self).find_class(modulename, name)
ModuleNotFoundError: No module named 'Products.zms._conf'
```

```log
024-02-28 08:20:24 ERROR [Zope.SiteErrorLog:252][waitress-1] 1709104824.27145580.7604786003845395 http://127.0.0.1:8080/sites/sntl_new/content/manage_main
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 181, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 391, in publish_module
  Module ZPublisher.WSGIPublisher, line 285, in publish
  Module ZPublisher.mapply, line 98, in mapply
  Module ZPublisher.WSGIPublisher, line 68, in call_object
  Module Shared.DC.Scripts.Bindings, line 333, in __call__
  Module Shared.DC.Scripts.Bindings, line 370, in _bindAndExec
  Module Products.PageTemplates.PageTemplateFile, line 143, in _exec
  Module Products.PageTemplates.PageTemplate, line 81, in pt_render
  Module zope.pagetemplate.pagetemplate, line 133, in pt_render
  Module Products.PageTemplates.engine, line 365, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module 999690d91b5d34fb5ff78a21025b69a7, line 228, in render
  Module Products.PageTemplates.ZRPythonExpr, line 49, in __call__
   - __traceback_info__: here.manage_container(here,request)
  Module PythonExpr, line 1, in <module>
  Module Shared.DC.Scripts.Bindings, line 333, in __call__
  Module Shared.DC.Scripts.Bindings, line 370, in _bindAndExec
  Module Products.PageTemplates.PageTemplateFile, line 143, in _exec
  Module Products.PageTemplates.PageTemplate, line 81, in pt_render
  Module zope.pagetemplate.pagetemplate, line 133, in pt_render
  Module Products.PageTemplates.engine, line 365, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module ff99e489ddf7480f4f0da8902ab55351, line 1226, in render
  Module Products.PageTemplates.ZRPythonExpr, line 49, in __call__
   - __traceback_info__: childNode.zmi_manage_main_change(childNode,request)
  Module PythonExpr, line 1, in <module>
  Module Shared.DC.Scripts.Bindings, line 333, in __call__
  Module Shared.DC.Scripts.Bindings, line 370, in _bindAndExec
  Module Products.PageTemplates.PageTemplateFile, line 143, in _exec
  Module Products.PageTemplates.PageTemplate, line 81, in pt_render
  Module zope.pagetemplate.pagetemplate, line 133, in pt_render
  Module Products.PageTemplates.engine, line 365, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module c6383807a7e5cd110b3c299809d9f14a, line 382, in render
  Module Products.PageTemplates.ZRPythonExpr, line 49, in __call__
   - __traceback_info__: here.zmi_version_object_state(here,request)
  Module PythonExpr, line 1, in <module>
  Module Shared.DC.Scripts.Bindings, line 333, in __call__
  Module Shared.DC.Scripts.Bindings, line 370, in _bindAndExec
  Module Products.PageTemplates.PageTemplateFile, line 143, in _exec
  Module Products.PageTemplates.PageTemplate, line 81, in pt_render
  Module zope.pagetemplate.pagetemplate, line 133, in pt_render
  Module Products.PageTemplates.engine, line 365, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.utils, line 53, in raise_with_traceback
  Module chameleon.template, line 192, in render
  Module 47dbb4e23b33da34dbdf602329cac170, line 502, in render
  Module Products.PageTemplates.ZRPythonExpr, line 49, in __call__
   - __traceback_info__: not here.getAutocommit() and not request.get('ZMS_VERSION')
  Module PythonExpr, line 1, in <module>
  Module Products.zms.ZMSWorkflowItem, line 31, in getAutocommit
  Module Products.zms._confmanager, line 1050, in getWorkflowManager
  Module Products.zms._confmanager, line 1050, in <listcomp>
AttributeError: 'ZMSSysConf' object has no attribute 'getId'

 - Expression: "python:not here.getAutocommit() and not request.get('ZMS_VERSION')"
 - Filename:   zmi_version_object_state
 - Location:   (line 46: col 27)
 - Expression: "python:here.zmi_version_object_state(here,request)"
 - Filename:   zmi_manage_main_change
 - Location:   (line 24: col 59)
 - Expression: "python:childNode.zmi_manage_main_change(childNode,request)"
 - Filename:   manage_container
 - Location:   (line 89: col 65)
 - Expression: "python:here.manage_container(here,request)"
 - Filename:   manage_main
 - Location:   (line 9: col 62)
 - Arguments:  template: <PageTemplateFile at /sites/sntl_new/content/e2/zmi_version_object_state>
               here: <Products.zms.zmscustom.ZMSCustom object at 0x7f2e02ee80b0 oid 0x56bf7 in <Connection at 7f2e12a06fd0>>
               context: <Products.zms.zmscustom.ZMSCustom object at 0x7f2e02ee80b0 oid 0x56bf7 in <Connection at 7f2e12a06fd0>>
               container: <Products.zms.zmscustom.ZMSCustom object at 0x7f2e02ee80b0 oid 0x56bf7 in <Connection at 7f2e12a06fd0>>
               nothing: None
               options: {'args': (<Products.zms.zmscustom.ZMSCustom object at 0x7f2e02ee80b0 oid 0x56bf7 in <Connection at 7f2e12a06fd0>>, <WSGIRequest, URL=http://127.0.0.1:8080/sites/sntl_new/content/manage_main>)}
               root: <Application at >
               request: <WSGIRequest, URL=http://127.0.0.1:8080/sites/sntl_new/content/manage_main>
               modules: <Products.PageTemplates.ZRPythonExpr._SecureModuleImporter object at 0x7f2e1727cdf0>
               user: <User 'admin'>
               default: <DEFAULT>
               repeat: <Products.PageTemplates.engine.RepeatDictWrapper object at 0x7f2e02bcf740>
               loop: {}
               target_language: None
               translate: <function BaseTemplate.render.<locals>.translate at 0x7f2e02d770d0>
               attrs: {}

```
