### PR TITLE
fix(sql-gui): add pk-value to grid-context

### DIFF
--- a/Products/zms/zmssqldb.py
+++ b/Products/zms/zmssqldb.py
@@ -461,6 +461,8 @@ class ZMSSqlDb(zmscustom.ZMSCustom):
         handle_record__roles__ = None
         def handle_record(self, r):
           context = self.parent
+          primary_key = context.getEntityPK(tableName)
+          colNames.append(primary_key)
           d = {}
           if len(colNames)>0:
             r = { k: r[k] for k in r if standard.operator_contains(colNames,k,ignorecase=True) }
@@ -485,7 +487,6 @@ class ZMSSqlDb(zmscustom.ZMSCustom):
             except:
               standard.writeError( self, '[getEntityRecordHandler]: can\'t %s'%k)
             d[k] = value
-          primary_key = context.getEntityPK(tableName)
           rowid = standard.operator_getitem(r, primary_key, ignorecase=True)
           d['__id__'] = rowid
           d['params'] = {'rowid':rowid}


### PR DESCRIPTION
The sql grid may not provide the details-link if pk is configured not invisible for the grid view.