### PR TITLE
fix: use global connector if local not available

### DIFF
--- a/Products/zms/ZMSZCatalogAdapter.py
+++ b/Products/zms/ZMSZCatalogAdapter.py
@@ -157,8 +157,16 @@ class ZMSZCatalogAdapter(ZMSItem.ZMSItem):
           for node in nodes:
             if self.matches_ids_filter(node):
               fileparsing = standard.pybool( self.getConfProperty('ZMS.CatalogAwareness.fileparsing', 1))
-              for connector in self.get_connectors():
-                self.reindex(connector, node, recursive=False, fileparsing=fileparsing)
+              if self.get_connectors():
+                # if local connectors are available, use them
+                # Note: if local connectors are used, they must cover all connector types
+                for connector in self.get_connectors():
+                  self.reindex(connector, node, recursive=False, fileparsing=fileparsing)
+              else:
+                # otherwise use global connector
+                root = self.getRootElement()
+                for connector in root.getCatalogAdapter().get_connectors():
+                  self.reindex(connector, node, recursive=False, fileparsing=fileparsing)
         return True
       except:
         standard.writeError( self, "can't reindex_node")


### PR DESCRIPTION
Incremental reindex may fail in a portal-client if there is just a global zcatalog-connector in the portal-master.

![get_connectors](https://github.com/zms-publishing/ZMS/assets/29705216/9ae2449c-9a12-4ba4-a44b-50d64b07d26e)

HINT: the solution works discrete, means in case of multiple connectors, ALL  of the must be available in the "overwriting" client. The proposed fix cannot sum up the ones from a client with the ones from the master.  