### PR TITLE
Search: add change_dt/created_dt as default fields

### DIFF
--- a/Products/zms/ZMSZCatalogAdapter.py
+++ b/Products/zms/ZMSZCatalogAdapter.py
@@ -23,6 +23,7 @@
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 import copy
 import time
+from datetime import datetime, timezone
 import zope.interface
 # Product Imports.
 from Products.zms import standard
@@ -45,9 +46,14 @@ def get_default_data(node):
   d['meta_id'] = node.meta_id
   d['index_html'] = node.getHref2IndexHtmlInContext(node.getRootElement(), REQUEST=request)
   d['lang'] = request.get('lang',node.getPrimaryLanguage())
-  d['change_dt'] = node.getLangFmtDate(node.attr('change_dt'),'eng','%Y-%m-%d')
-  d['created_dt'] = node.getLangFmtDate(node.attr('created_dt'),'eng','%Y-%m-%d')
+  d['change_dt'] = get_zoned_dt(node.attr('change_dt'))
+  d['created_dt'] = get_zoned_dt(node.attr('created_dt'))
   return d
+
+def get_zoned_dt(struct_dt):
+  dt = datetime.fromtimestamp(time.mktime(struct_dt))
+  zdt = dt.replace(tzinfo=timezone.utc)
+  return zdt
 
 def get_file(node, d, fileparsing=True):
   """

--- a/Products/zms/ZMSZCatalogAdapter.py
+++ b/Products/zms/ZMSZCatalogAdapter.py
@@ -45,6 +45,8 @@ def get_default_data(node):
   d['meta_id'] = node.meta_id
   d['index_html'] = node.getHref2IndexHtmlInContext(node.getRootElement(), REQUEST=request)
   d['lang'] = request.get('lang',node.getPrimaryLanguage())
+  d['change_dt'] = node.getLangFmtDate(node.attr('change_dt'),'eng','%Y-%m-%d')
+  d['created_dt'] = node.getLangFmtDate(node.attr('created_dt'),'eng','%Y-%m-%d')
   return d
 
 def get_file(node, d, fileparsing=True):

--- a/Products/zms/conf/metaobj_manager/com.zms.catalog.opensearch/opensearch_connector/manage_opensearch_schematize.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.catalog.opensearch/opensearch_connector/manage_opensearch_schematize.py
@@ -53,6 +53,8 @@ def manage_opensearch_schematize( self):
 	properties['meta_id'] = {'type':'keyword'}
 	properties['lang'] = {'type':'keyword'}
 	properties['home_id'] = {'type':'keyword'}
+	properties['created_dt'] = {'type':'date'}
+	properties['change_dt'] = {'type':'date'}
 
 	mappings = {'properties':properties}
 	dictionary = {'mappings':mappings}


### PR DESCRIPTION
Ref: https://github.com/idasm-unibe-ch/unibe-cms-opensearch/issues/51#issuecomment-2079237881

A date is considered as "ZonedDateTime"

![image](https://github.com/zms-publishing/ZMS/assets/29705216/fca5fc3b-f547-437a-b9fc-145817338b19)

```js
GET /_scripts/painless/_execute
{
    "script": {
        "source": """
          // ZonedDateTime.parse(params.x).isBefore(ZonedDateTime.parse(params.y))
          ZonedDateTime.parse('2022-05-15T10:30:00+00:00')
        """,
        "params": {
            "x": "2022-05-15T10:30:00+00:00",
            "y": "2024-05-15T10:30:00+00:00"
        }
    }
}
```

It's not clear, which Py-type should be transfered ny opensearch-py:

![image](https://github.com/zms-publishing/ZMS/assets/29705216/7db9ead4-c800-4f6b-bb15-871db739d5f8)


Test-Snippet painless-script for comparing dates (still not working):

```js
GET myzmsx11/_search
{
  "size": 10,
  "from":0,
  "query": {
    "script_score": {
      "query": {
        "query_string": {
          "query": "Extra"
        }
      },
      "script": {
        "lang":"painless",
        "source": """
          int wght = 1;
          ZonedDateTime limit_dt = ZonedDateTime.parse('2023-05-15T10:30:00+00:00');
          ZonedDateTime doc_dt = ZonedDateTime.parse(doc['change_dt'].value.toInstant());
          if ( doc_dt.isAfter(limit_dt) ) {
            wght += 4;
          }
          return _score * wght;
        """
      }
    }
  }
}
```