### PR TITLE
Publishing ZMI CSS/JS-Resources

### DIFF
--- a/Products/zms/_accessmanager.py
+++ b/Products/zms/_accessmanager.py
@@ -105,6 +105,10 @@ def updateVersion(root):
           else:
            del nodes[nodekey]
       root.setConfProperty('ZMS.security.users', d)
+    # View management screens
+    if root.getConfProperty('ZMS.security.build', 0) == 3:
+      root.setConfProperty('ZMS.security.build', 4)
+      root.initRoleDefs()
 
 # ------------------------------------------------------------------------------
 #  _accessmanager.user_folder_meta_types:

--- a/Products/zms/_accessmanager.py
+++ b/Products/zms/_accessmanager.py
@@ -120,10 +120,10 @@ user_folder_meta_types = ['LDAPUserFolder', 'User Folder', 'Simple User Folder',
 # ------------------------------------------------------------------------------
 role_defs = {
    'ZMSAdministrator':['*']
-  ,'ZMSEditor':['Access contents information', 'Add ZMSs', 'Add Documents, Images, and Files', 'Copy or Move', 'Delete objects', 'Manage properties', 'Use Database Methods', 'View', 'ZMS Author']
-  ,'ZMSAuthor':['Access contents information', 'Add ZMSs', 'Copy or Move', 'Delete objects', 'Use Database Methods', 'View', 'ZMS Author']
+  ,'ZMSEditor':['View management screens', 'Access contents information', 'Add ZMSs', 'Add Documents, Images, and Files', 'Copy or Move', 'Delete objects', 'Manage properties', 'Use Database Methods', 'View', 'ZMS Author']
+  ,'ZMSAuthor':['View management screens', 'Access contents information', 'Add ZMSs', 'Copy or Move', 'Delete objects', 'Use Database Methods', 'View', 'ZMS Author']
   ,'ZMSSubscriber':['Access contents information', 'View']
-  ,'ZMSUserAdministrator':['Access contents information', 'View', 'ZMS UserAdministrator']
+  ,'ZMSUserAdministrator':['View management screens', 'Access contents information', 'View', 'ZMS UserAdministrator']
 }
 
 # ------------------------------------------------------------------------------

--- a/Products/zms/configure.zcml
+++ b/Products/zms/configure.zcml
@@ -10,6 +10,15 @@
       directory="plugins/www"
       />
 
+  <!-- If ZMI resources need to be published, -->
+  <!-- register the resources dir as public   -->
+  <!-- 
+    <browser:resourceDirectory
+      name="zmi"
+      directory="~/virtualenv/src/zope/src/zmi/styles/resources"
+      permission="zope.Public" /> 
+  -->
+
   <configure
       xmlns:cmf="http://namespaces.zope.org/cmf"
       xmlns:zcml="http://namespaces.zope.org/zcml"


### PR DESCRIPTION
Added a ZCML snippet to ZMS-configure.zcml for publishing ZMI CSS/JS-resources.

Since https://github.com/zopefoundation/Zope/pull/1166 general GUI resources are not public anymore but limited to the `ViewManagementScreensPermission`. If using bootstrap.css or fontawesome for the website-design, these resources can get accessed by changing its permisson by adding the path to a overrides.zcml for ZMS:

```
<browser:resourceDirectory
      name="zmi"
      directory="~/virtualenv_demo/src/zope/src/zmi/styles/resources"
      permission="zope.Public" />
```
[overrides.zip](https://github.com/zms-publishing/ZMS/files/15149540/overrides.zip)

The `directory`-directive has to be adopted to the local installation path (this is not convenient!).

A late Zope-PR https://github.com/zopefoundation/Zope/pull/1204 may have removed the permission to any non-manage-user; thus the upper enhancement is not only needed for 3rd-view but for ZMSEditor etc. accessing ZMS-ZMI.
Actually this is a litle bit too complicated; any other ideas?
I doubt that adding the ViewManagementScreen-permission to the ZMS*-roles (except Subscriber) is a good solution, because the user should work in ZMS-ZMI and not Zope-ZMI.

ZMI Access Error
![image](https://github.com/zms-publishing/ZMS/assets/29705216/e81a54c6-94ad-4c2f-81dc-4d8f4b64cae2)
