### PR TITLE
Ensure Reindexing Context's Page Container on Change/Insert

### DIFF
--- a/Products/zms/_versionmanager.py
+++ b/Products/zms/_versionmanager.py
@@ -628,6 +628,9 @@ class VersionItem(object):
       self.synchronizePublicAccess()
       # Synchronize search.
       self.getCatalogAdapter().reindex_node(self)
+      # .. by reindexing not only self/object but maybe it's parent/page too.
+      # if not self.isPage():
+      #    self.getCatalogAdapter().reindex_node(parent)
       # Return flag for deleted objects.
       standard.writeLog( self, '[commitObjChanges]: done (in '+str(int((time.time()-t0)*100.0)/100.0)+' secs.)')
       return delete

--- a/Products/zms/_versionmanager.py
+++ b/Products/zms/_versionmanager.py
@@ -628,9 +628,6 @@ class VersionItem(object):
       self.synchronizePublicAccess()
       # Synchronize search.
       self.getCatalogAdapter().reindex_node(self)
-      # .. by reindexing not only self/object but maybe it's parent/page too.
-      # if not self.isPage():
-      #    self.getCatalogAdapter().reindex_node(parent)
       # Return flag for deleted objects.
       standard.writeLog( self, '[commitObjChanges]: done (in '+str(int((time.time()-t0)*100.0)/100.0)+' secs.)')
       return delete


### PR DESCRIPTION
Ref: https://github.com/idasm-unibe-ch/unibe-cms-opensearch/issues/50

## Problem

Reindexing does not refer to the correct node. This fix shall identify the context's page container and/or the lowest content class of the path to be indexed.

The first commit improves the sponateous page contaner indexing on INSERT.

[1]
![opensearch_increment](https://github.com/zms-publishing/ZMS/assets/29705216/58ece743-d9ba-44c9-bdee-fb5a187bb196)

But there is a problem with INSERT of Pageelements: it does not trigger the container to be indexed because the context-breadcrumb misses the last level 

[2]
![opensearch_insert3](https://github.com/zms-publishing/ZMS/assets/29705216/5318ec4e-0a14-4f1a-bcd5-b7065e3ce72c)

If an existing pageelement is saved, reindexing works

[3]
![opensearch_insert4](https://github.com/zms-publishing/ZMS/assets/29705216/b2c81ebf-8736-42dc-93d7-b7410d3c2c6c)

## Task

the refactored `reindex_node`-Function tries to identify the node/context's page container and in special cases (e.g. ZMSFile) both nodes have to be reindexed. 
The current code status does not reindex correctly on inserting a pagelement [3]. Supposingly it is not a race condition but the container is not correctly identified when inserting a pageelement.  Inserting a PAGE will result in correct indexing.

https://github.com/zms-publishing/ZMS/blob/ce79c479e4267951ab7a1e5bb37129edb0b75551/Products/zms/ZMSZCatalogAdapter.py#L167-L201
