### PR TITLE
Monotonize aggregating page-content by sequencing page-elements' standard_html

### DIFF
--- a/Products/zms/ZMSZCatalogAdapter.py
+++ b/Products/zms/ZMSZCatalogAdapter.py
@@ -362,11 +362,8 @@ class ZMSZCatalogAdapter(ZMSItem.ZMSItem):
         try:
           # ZMSFile.standard_html will work in get_file.
           if not (node.meta_id == 'ZMSFile' and attr_id == 'standard_html'):
-            if attr_id == 'standard_html' and request.get('ZMS_INSERT', None) and node.isPage():
-              # ZMS_INSERT Page: attr('standard_html') does not work.
+            if attr_id == 'standard_html' and node.isPage():
               for child_node in node.getObjChildren('e',request,self.PAGEELEMENTS):
-                # value += child_node.getBodyContent(request) # This would not work.
-                # Explicitly call ob-method to get the correct standard_html:
                 value += self.getMetaobjAttr(child_node.meta_id, 'standard_html')['ob'](zmscontext=child_node)
             else:
               value = node.attr(attr_id)


### PR DESCRIPTION
Ref: 

1. https://github.com/zms-publishing/ZMS/commit/936b091e6317f138dba4999999f79b9c7f80f140 
2. https://github.com/zms-publishing/ZMS/issues/278

Result:

1 Now page content is aggreated the same way for all cases (fullindex, change, insert).
2. In case of indexed attributes (e.g. _standard_html_) are not filled with expected text, delete (misconfigured) search-adapters and start full reindex.
  
![unibe_reindex](https://github.com/zms-publishing/ZMS/assets/29705216/450b1ae4-b41c-4cfe-b908-54c4db53407e)


URLs:

1. CONFIG https://edit.cmstest2.unibe.ch/unibe/content/zcatalog_adapter/manage_main
2. TEST https://edit.cmstest2.unibe.ch/unibe/portal/fak_vetmedizin/a_dept_dkv/inst_kleintier/content/e18883/e750745/e750831/manage_main?lang=ger
3. INDEX https://idcmsosearchint01.id-sys.unibe.ch/app/dev_tools#/console

_ad 3: Snippets_
```
GET /unibe/_search
{
  "query": {
    "match_phrase": {
      "uid": {
      "query": "\"uid:c8b129ae-2f1d-4ad3-83ad-0c7606893394\""
      }
      
    }
  }
}

GET /unibe/_search
{
  "query": {
    "bool": {
      "must": [
        {
          "simple_query_string": {
            "query": "inst_kleintier",
            "fields": ["home_id"]
          }
        },
        {
          "simple_query_string": {
            "query": "ger",
            "fields": ["lang"]
          }
        },
        {
          "simple_query_string": {
            "query": "e18868*",
            "fields": ["zmsid"]
          }
        }
      ]
    }
  }
}

```
