### PR TITLE
default manage permissions

### DIFF
--- a/Products/zms/zopeutil.py
+++ b/Products/zms/zopeutil.py
@@ -221,6 +221,9 @@ def initPermissions(container, id, permissions={}):
   ob = getObject(container, id)
   if ob is None: return
   
+  # default manage permissions
+  if id.startswith('manage') and not permissions:
+    permissions = {'Authenticated':['Access contents information', 'View']}
   # apply proxy-roles
   ob._proxy_roles=('Authenticated','Manager')
   # apply permissions for roles
@@ -233,9 +236,7 @@ def initPermissions(container, id, permissions={}):
   manager_permissions = [x['name'] for x in ob.permissionsOfRole('Manager')]
   acquired_permissions = [x for x in manager_permissions if x not in role_permissions]
   ob.manage_acquiredPermissions(acquired_permissions)
-  ### Debug Zope object import here on unexpected errors due to (hidden) attrs 
-  # if hasattr(ob, '_owner'):
-    # del ob._owner
+
 
 def addDTMLMethod(container, id, title, data):
   """
@@ -282,6 +283,7 @@ def addExternalMethod(container, id, title, data):
   except:
     standard.writeError(container,"[addExternalMethod]: %s does not exist.\n"%id)
     pass
+  initPermissions(container, id)
 
 def addPageTemplate(container, id, title, data):
   """
@@ -290,6 +292,7 @@ def addPageTemplate(container, id, title, data):
   ZopePageTemplate.manage_addPageTemplate( container, id, title=title, text=data)
   ob = getattr( container, id)
   ob.output_encoding = 'utf-8'
+  initPermissions(container, id)
 
 def addPythonScript(container, id, title, data):
   """

--- a/Products/zms/zopeutil.py
+++ b/Products/zms/zopeutil.py
@@ -212,6 +212,9 @@ def removeObject(container, id, removeFile=True):
         os.remove(filepath)
     container.manage_delObjects(ids=[id])
 
+def is_manage(id):
+  return re.match(r'manage(_.*)?$', id)
+
 security.declarePublic('initPermissions')
 def initPermissions(container, id, permissions={}):
   """
@@ -222,7 +225,7 @@ def initPermissions(container, id, permissions={}):
   if ob is None: return
   
   # default manage permissions
-  if id.startswith('manage') and not permissions:
+  if is_manage(id) and not permissions:
     permissions = {'Authenticated':['Access contents information', 'View']}
   # apply proxy-roles
   ob._proxy_roles=('Authenticated','Manager')

--- a/tests/test_zopeutil.py
+++ b/tests/test_zopeutil.py
@@ -1,0 +1,17 @@
+# encoding: utf-8
+
+import unittest
+from Products.zms import zopeutil
+
+# /Products/zms> python -m unittest discover -s unit_tests
+# /Products/zms> python -m unittest tests.test_zopeutil.ZopeUtilTest
+class ZopeUtilTest(unittest.TestCase):
+
+    def test_is_manage(self):
+        self.assertFalse(zopeutil.is_manage('foo'))
+        self.assertFalse(zopeutil.is_manage('bar'))
+        self.assertFalse(zopeutil.is_manage('manager'))
+        self.assertFalse(zopeutil.is_manage('topmanagement'))
+        self.assertTrue(zopeutil.is_manage('manage'))
+        self.assertTrue(zopeutil.is_manage('manage_main'))
+        self.assertTrue(zopeutil.is_manage('manage_opensearch_test'))


### PR DESCRIPTION
default manage permissions for native zope-objects with id matching 'manage(.*?)':
'Access contents information' and 'View' for 'Authenticated'