### PR TITLE
[idasm-unibe-ch/unibe-cms-opensearch] Toptreffer: Fehler beim Filtern (Issue #88)

### DIFF
--- a/Products/zms/zmscustom.py
+++ b/Products/zms/zmscustom.py
@@ -281,7 +281,7 @@ class ZMSCustom(zmscontainerobject.ZMSContainerObject):
         REQUEST.set('masterRow', masterRows[0])
       # init filter from request.
       index = 0
-      for filterIndex in range(100):
+      for filterIndex in range(10):
         for filterStereotype in ['attr', 'op', 'value']:
           requestkey = 'filter%s%i'%(filterStereotype, filterIndex)
           sessionkey = '%s_%s'%(requestkey, self.id)

--- a/Products/zms/zmscustom.py
+++ b/Products/zms/zmscustom.py
@@ -265,6 +265,7 @@ class ZMSCustom(zmscontainerobject.ZMSContainerObject):
       standard.set_session_value(self,sessionattr, REQUEST.form.get(filterattr, standard.get_session_value(self,sessionattr, '')))
       standard.set_session_value(self,sessionvalue, REQUEST.form.get(filtervalue, standard.get_session_value(self,sessionvalue, '')))
       if REQUEST.get('btn')=='BTN_RESET':
+        REQUEST.set('qindex', 0)
         standard.set_session_value(self,sessionattr, '')
         standard.set_session_value(self,sessionvalue, '')
       if standard.get_session_value(self,sessionattr, '') != '' and \

--- a/Products/zms/zpt/ZMSRecordSet/main.zpt
+++ b/Products/zms/zpt/ZMSRecordSet/main.zpt
@@ -35,6 +35,9 @@ recordSet_Interface*:interface will only be display for grid-view (UzK)
 				x['id'] not in ['__sort_id']
 				and x['type'] in here.metaobj_manager.valid_types+here.getMetaobjIds()
 				and x['type'] not in ['password','resource']];
+		row python:res_abs[request['qindex']];
+		dummy0 python:request.set('qindex',res.index(row) if row in res else -1);
+		dummy0 python:standard.set_session_value(here,'qindex_%s'%here.id,request.get('qindex'));
 		metaObjAttrs python:[x for x in filter_columns if x.get('custom')]">
 
 <tal:block tal:condition="python:request.get('action') not in ['updateForm','insertForm']">

--- a/Products/zms/zpt/ZMSRecordSet/main.zpt
+++ b/Products/zms/zpt/ZMSRecordSet/main.zpt
@@ -35,9 +35,12 @@ recordSet_Interface*:interface will only be display for grid-view (UzK)
 				x['id'] not in ['__sort_id']
 				and x['type'] in here.metaobj_manager.valid_types+here.getMetaobjIds()
 				and x['type'] not in ['password','resource']];
-		row python:res_abs[request['qindex']];
+		qindex python:int(request.get('qindex',-1));
+		res request/res;
+		res_abs request/res_abs;
+		row python:res_abs[qindex] if qindex >= 0 and qindex < len(res_abs) else {};
 		dummy0 python:request.set('qindex',res.index(row) if row in res else -1);
-		dummy0 python:standard.set_session_value(here,'qindex_%s'%here.id,request.get('qindex'));
+		dummy0 python:standard.set_session_value(here,'qindex_%s'%here.id,request['qindex']);
 		metaObjAttrs python:[x for x in filter_columns if x.get('custom')]">
 
 <tal:block tal:condition="python:request.get('action') not in ['updateForm','insertForm']">


### PR DESCRIPTION
The fix tries to ensure that qindex from absolute result-set points at the right element in the filtered and sorted result-set.