### PR TITLE
fix 'items' as object-id in breadcrumbs_obj_path

### DIFF
--- a/Products/zms/plugins/www/zmi.core.css
+++ b/Products/zms/plugins/www/zmi.core.css
@@ -1166,9 +1166,6 @@ div.pull-left div.single-line.input-append.zmi-nodes textarea {
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
-.zmi .breadcrumb li.breadcrumb-item.active a {
-	color:#999fa5;
-}
 .zmi .breadcrumb li.breadcrumb-item:hover a {
 	color: #999fa5;
 	text-decoration:none;

--- a/Products/zms/zmsobject.py
+++ b/Products/zms/zmsobject.py
@@ -658,8 +658,18 @@ class ZMSObject(ZMSItem.ZMSItem,
     def breadcrumbs_obj_path(self, portalMaster=True):
       # Handle This.
       phys_path = list(self.getPhysicalPath())
-      phys_path = phys_path[phys_path.index('content'):]
-      rtn = [getattr(self, id) for id in phys_path]
+      phys_path.reverse()
+      rtn = []
+      ob = self
+      for id in phys_path:
+        while ob is not None:
+          ob_path = ob.getPhysicalPath()
+          if id not in ob_path:
+            break
+          if ob_path[-1] == id:
+            rtn.insert(0, ob)
+            break
+          ob = ob.getParentNode()
       # Handle Portal Master.
       if portalMaster and self.getConfProperty('Portal.Master', ''):
         try:

--- a/Products/zms/zmsobject.py
+++ b/Products/zms/zmsobject.py
@@ -656,21 +656,13 @@ class ZMSObject(ZMSItem.ZMSItem,
     #  ZMSObject.breadcrumbs_obj_path:
     # --------------------------------------------------------------------------
     def breadcrumbs_obj_path(self, portalMaster=True):
+      def is_reserved_name(name):
+        import keyword
+        return keyword.iskeyword(name) or name in dir(__builtins__)
       # Handle This.
       phys_path = list(self.getPhysicalPath())
       phys_path = phys_path[phys_path.index('content'):]
-      phys_path.reverse()
-      rtn = []
-      ob = self
-      for id in phys_path:
-        while ob is not None:
-          ob_path = ob.getPhysicalPath()
-          if id not in ob_path:
-            break
-          if ob_path[-1] == id:
-            rtn.insert(0, ob)
-            break
-          ob = ob.getParentNode()
+      rtn = [is_reserved_name(id) and getattr(self.getParentNode(),id) or getattr(self, id) for id in phys_path]
       # Handle Portal Master.
       if portalMaster and self.getConfProperty('Portal.Master', ''):
         try:

--- a/Products/zms/zmsobject.py
+++ b/Products/zms/zmsobject.py
@@ -658,6 +658,7 @@ class ZMSObject(ZMSItem.ZMSItem,
     def breadcrumbs_obj_path(self, portalMaster=True):
       # Handle This.
       phys_path = list(self.getPhysicalPath())
+      phys_path = phys_path[phys_path.index('content'):]
       phys_path.reverse()
       rtn = []
       ob = self

--- a/Products/zms/zpt/common/zmi_breadcrumbs_obj_path.zpt
+++ b/Products/zms/zpt/common/zmi_breadcrumbs_obj_path.zpt
@@ -14,8 +14,7 @@
 		dummy0 python:request.set('lang',zmscontext.get_request_context(request,'lang',request['lang']));
 		middot python:options.get('middot','metaobj_manager/manage_main?lang=%s&id=%s'%(request['lang'],zmscontext.meta_id));
 		childNodes python:zmscontext.breadcrumbs_obj_path()"
-	><li tal:repeat="childNode childNodes"
-		tal:attributes="class python:' '.join(['breadcrumb-item']+[['','active'][int(childNode==childNodes[-1])]])"
+	><li tal:repeat="childNode childNodes" class="breadcrumb-item"
 		><span tal:omit-tag="python:not request['AUTHENTICATED_USER'].has_permission('ZMS Administrator',zmscontext)"
 			tal:attributes="onclick python:'javascript:window.open(\'%s/%s\',\'MetaObjectManagerWindow\')'%(zmscontext.getDocumentElement().getAbsoluteUrlInContext(here),middot)"
 			><tal:block tal:condition="python:childNode==childNodes[-1]"


### PR DESCRIPTION
Ref: https://github.com/zms-publishing/ZMS/issues/295

`getattr()`  does not work with complex zms-objects containing an sub-object named like a python keywords/function, like 'items':
https://github.com/zms-publishing/ZMS/issues/295#issuecomment-2248933656
