### PR TITLE
Adding pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Ref: https://github.com/idasm-unibe-ch/zms-base/issues/3
Ref: https://github.com/zms-publishing/ZMS/blob/276b695799f94ade7a1a527cef793a0154fc6cb3/pyproject.toml

A file `pyproject.toml `allows pip to install Python modules in _editable_-mode. The e-option will be removed from in the future. Actually the presence of that file 
https://github.com/zms-publishing/ZMS/commit/276b695799f94ade7a1a527cef793a0154fc6cb3
will constantly induce  an error on starting Zope,

![err](https://github.com/user-attachments/assets/fe78acb1-b982-4a65-865b-b1d3e9f32fcc)



The error can be reproduced when starting
1. the UniBE `docker-compose` after setting backend/zms-core to zms.main/latest and adding the  file https://github.com/zms-publishing/ZMS/blob/828cd8a11bc96aa958ccdf4dfd2371d9246d54ec/requirements-unibe.txt
2. the ZMS Ubuntu Docker image 
https://github.com/zms-publishing/ZMS/blob/main/docker/ubuntu/dockerfile
with a ZMS-commit that contains the file `pyproject.toml`
https://github.com/zms-publishing/ZMS/commit/276b695799f94ade7a1a527cef793a0154fc6cb3

```log
2024-09-03 17:30:05 INFO [chameleon.config:40][MainThread] directory cache: /home/zope/venv/instance/zms5/var/cache.
Traceback (most recent call last):
  File "/home/zope/venv/bin/runwsgi", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/zope/venv/lib/python3.12/site-packages/Zope2/Startup/serve.py", line 251, in main
    return command.run()
           ^^^^^^^^^^^^^
  File "/home/zope/venv/lib/python3.12/site-packages/Zope2/Startup/serve.py", line 189, in run
    app = self.loadapp(app_spec, name=app_name, relative_to=base,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zope/venv/lib/python3.12/site-packages/Zope2/Startup/serve.py", line 220, in loadapp
    return loadapp(app_spec, name=name, relative_to=relative_to, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zope/venv/lib/python3.12/site-packages/paste/deploy/loadwsgi.py", line 246, in loadapp
    return loadobj(APP, uri, name=name, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zope/venv/lib/python3.12/site-packages/paste/deploy/loadwsgi.py", line 271, in loadobj
    return context.create()
           ^^^^^^^^^^^^^^^^
  File "/home/zope/venv/lib/python3.12/site-packages/paste/deploy/loadwsgi.py", line 738, in create
    return self.object_type.invoke(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zope/venv/lib/python3.12/site-packages/paste/deploy/loadwsgi.py", line 198, in invoke
    app = context.app_context.create()
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zope/venv/lib/python3.12/site-packages/paste/deploy/loadwsgi.py", line 738, in create
    return self.object_type.invoke(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zope/venv/lib/python3.12/site-packages/paste/deploy/loadwsgi.py", line 136, in invoke
    return fix_call(context.object, context.global_conf, **context.local_conf)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zope/venv/lib/python3.12/site-packages/paste/deploy/util.py", line 61, in fix_call
    val = callable(*args, **kw)
          ^^^^^^^^^^^^^^^^^^^^^
  File "/home/zope/venv/lib/python3.12/site-packages/Zope2/Startup/run.py", line 61, in make_wsgi_app
    starter.prepare()
  File "/home/zope/venv/lib/python3.12/site-packages/Zope2/Startup/starter.py", line 38, in prepare
    self.startZope()
  File "/home/zope/venv/lib/python3.12/site-packages/Zope2/Startup/starter.py", line 94, in startZope
    Zope2.startup_wsgi()
  File "/home/zope/venv/lib/python3.12/site-packages/Zope2/__init__.py", line 36, in startup_wsgi
    _startup()
  File "/home/zope/venv/lib/python3.12/site-packages/Zope2/App/startup.py", line 70, in startup
    OFS.Application.import_products()
  File "/home/zope/venv/lib/python3.12/site-packages/OFS/Application.py", line 432, in import_products
    for priority, product_name, index, product_dir in get_products():
                                                      ^^^^^^^^^^^^^^
  File "/home/zope/venv/lib/python3.12/site-packages/OFS/Application.py", line 419, in get_products
    product_names = os.listdir(product_dir)
                    ^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'Products'
```