### PR TITLE
Activity during Daylight Saving Times (CEST)

### DIFF
--- a/Products/zms/_objattrs.py
+++ b/Products/zms/_objattrs.py
@@ -690,7 +690,7 @@ class ObjAttrs(object):
               if isinstance(value, time.struct_time):
                 # Convert time.struct_time to datetime tuple.
                 value = tuple(value[:8]) + (0,)
-              dt = datetime.datetime.fromtimestamp(time.mktime(value))
+              dt = datetime.datetime.fromtimestamp(time.mktime(value) - (time.daylight * 3600))
               b = b and now > dt
               if dt > now and self.REQUEST.get('ZMS_CACHE_EXPIRE_DATETIME', dt) >= dt:
                 self.REQUEST.set('ZMS_CACHE_EXPIRE_DATETIME',dt)
@@ -700,7 +700,7 @@ class ObjAttrs(object):
               if isinstance(value, time.struct_time):
                 # Convert time.struct_time to datetime tuple.
                 value = tuple(value[:8]) + (0,)
-              dt = datetime.datetime.fromtimestamp(time.mktime(value))
+              dt = datetime.datetime.fromtimestamp(time.mktime(value) - (time.daylight * 3600))
               b = b and dt > now
               if dt > now and self.REQUEST.get('ZMS_CACHE_EXPIRE_DATETIME', dt) >= dt:
                 self.REQUEST.set('ZMS_CACHE_EXPIRE_DATETIME',dt)

--- a/Products/zms/_objattrs.py
+++ b/Products/zms/_objattrs.py
@@ -669,6 +669,7 @@ class ObjAttrs(object):
       obj_vers = self.getObjVersion(REQUEST)
       obj_attrs = self.getObjAttrs()
       now = datetime.datetime.now()
+      dst = time.daylight == 1 and 1 or 0 # Daylight saving time.
       for key in ['active', 'attr_active_start', 'attr_active_end']:
         if key in obj_attrs:
           obj_attr = obj_attrs[key]
@@ -690,7 +691,7 @@ class ObjAttrs(object):
               if isinstance(value, time.struct_time):
                 # Convert time.struct_time to datetime tuple.
                 value = tuple(value[:8]) + (0,)
-              dt = datetime.datetime.fromtimestamp(time.mktime(value) - (time.daylight * 3600))
+              dt = datetime.datetime.fromtimestamp(time.mktime(value) - (dst * 3600))
               b = b and now > dt
               if dt > now and self.REQUEST.get('ZMS_CACHE_EXPIRE_DATETIME', dt) >= dt:
                 self.REQUEST.set('ZMS_CACHE_EXPIRE_DATETIME',dt)
@@ -700,7 +701,7 @@ class ObjAttrs(object):
               if isinstance(value, time.struct_time):
                 # Convert time.struct_time to datetime tuple.
                 value = tuple(value[:8]) + (0,)
-              dt = datetime.datetime.fromtimestamp(time.mktime(value) - (time.daylight * 3600))
+              dt = datetime.datetime.fromtimestamp(time.mktime(value) - (dst * 3600))
               b = b and dt > now
               if dt > now and self.REQUEST.get('ZMS_CACHE_EXPIRE_DATETIME', dt) >= dt:
                 self.REQUEST.set('ZMS_CACHE_EXPIRE_DATETIME',dt)


### PR DESCRIPTION
The Browser provides datetime-values by "local-time". Computing these tuples to seconds and the to a python struc_time to allow datetime comparison the daylight saving time (DST), actally 1 hour, will be ignored and the result will be standard-time.

![image](https://github.com/user-attachments/assets/34c1144d-9c6e-4af2-ae1d-514c27a49757)


So, in case of  DST one hour has to be subtracted:

```py
- dt = datetime.datetime.fromtimestamp(time.mktime(value))
+ dt = datetime.datetime.fromtimestamp(time.mktime(value) - (time.daylight * 3600))
```
Another option would be to inject the `tm_isdst ` into the time tuple:
Ref: https://stackoverflow.com/questions/1697815/how-do-you-convert-a-time-struct-time-object-into-a-datetime-object
Any comments?