### PR TITLE
ZMI: Improved performance of meta-attribute-table

### DIFF
--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -61,35 +61,6 @@
 	<input type="hidden" name="key" value="all"/>
 	<input type="hidden" name="lang" tal:attributes="value request/lang"/>
 
-	<select id="populate_type" class="d-none" style="display:none">
-		<option id="type_primitive" value="" tal:content="python:'--- %s ---'%here.getZMILangStr('ATTR_PRIMITIVE')"></option>
-		<tal:block tal:repeat="type python:here.valid_datatypes">
-			<option tal:attributes="value type; class python:' '.join([['','deprecated'][int(type in here.deprecated_types)]])" tal:content="type">type</option>
-		</tal:block>
-		<tal:block tal:condition="metaObjRecordSet">
-			<option id="type_objects" value="" tal:content="python:'--- %s ---'%here.getZMILangStr('ATTR_FK')"></option>
-			<tal:block tal:repeat="metaObj python:[x for x in metaObjs if x['type']=='ZMSRecordSet' and x.get('package')==metaObj.get('package')]">
-				<option tal:attributes="value metaObj/id" tal:content="python:here.display_type(meta_id=metaObj['id'])">type</option>
-			</tal:block>
-		</tal:block>
-		<tal:block tal:condition="not:metaObjRecordSet">
-			<option id="type_metadata" value="" tal:content="python:'--- %s ---'%here.getZMILangStr('TAB_METADATA')"></option>
-			<tal:block tal:repeat="metaAttrId python:here.getMetadictAttrs()">
-				<option tal:attributes="value metaAttrId" tal:content="python:here.getMetadictAttr(metaAttrId)['name']">type</option>
-			</tal:block>
-			<option id="type_objects" value="" tal:content="python:'--- %s ---'%here.getZMILangStr('ATTR_OBJECTS')"></option>
-			<tal:block tal:repeat="metaObj python:[x for x in metaObjs if x['type'] != 'ZMSPackage']">
-				<option tal:attributes="value python:metaObj['id']" tal:content="python:here.display_type(meta_id=metaObj['id'])">type</option>
-			</tal:block>
-			<option id="type_objects_sequence" value="" tal:content="python:'--- %s ---'%here.getZMILangStr('ATTR_SEQUENCE')"></option>
-			<option value="*" tal:content="python:'%s (*)'%here.getZMILangStr('ATTR_CUSTOM')">*</option>
-		</tal:block>
-		<option id="type_zope" value="" tal:content="python:'--- %s ---'%'Zope'"></option>
-		<tal:block tal:repeat="type python:here.valid_zopetypes">
-			<option tal:attributes="value type; class python:' '.join([['','deprecated'][type in here.deprecated_types]])" tal:content="type">type</option>
-		</tal:block>
-	</select>
-
 	<div class="d-flex flex-row justify-content-between align-items-start py-2 sticky-controls">
 		<div class="btn-group m-2 text-nowrap" role="group" aria-label="Object Class Selector">
 			<div class="zmi-action btn-group dropleft nav-metaobj" tal:attributes="title python:here.getZMILangStr('CAPTION_CHOOSEOBJ')">
@@ -288,17 +259,26 @@
 
 					<tal:block tal:condition="not:python:objAttr['type'] in ['interface','method','py','resource','zpt']+here.valid_zopetypes">
 						<td class="meta-type input-group-sm" tal:attributes="title python:here.getZMILangStr('ATTR_TYPE')">
-							<select tal:attributes="name python:'attr_type_%s'%objAttrId; class python:['form-control form-control-sm','form-control form-control-sm zmi-element-disabled'][isMetaDictAttr]">
-								<option tal:condition="python:objAttr.get('meta_type') in here.getMetadictAttrs()"
-										tal:attributes="value python:objAttr.get('meta_type')" selected="selected">
-									<tal:block tal:content="python:here.getMetadictAttr(objAttr.get('meta_type'))['name']">type</tal:block>
+							<select tal:attributes="name python:'attr_type_%s'%objAttrId; 
+								class python:['form-control form-control-sm','form-control form-control-sm zmi-element-disabled'][isMetaDictAttr]">
+								<option selected="selected" 
+									tal:condition="python:objAttr.get('meta_type') in here.getMetadictAttrs()"
+									tal:attributes="value python:objAttr.get('meta_type')" 
+									tal:content="python:here.getMetadictAttr(objAttr.get('meta_type'))['name']">type
 								</option>
-								<option tal:condition="not:python:objAttr.get('meta_type') in here.getMetadictAttrs()"
-										tal:attributes="value python:objAttr['type']" selected="selected">
-									<tal:block tal:condition="python:objAttr['type'] in here.valid_datatypes" tal:content="python:objAttr['type']">type</tal:block>
-									<tal:block tal:condition="python:objAttr['type'] == '*'" tal:content="python:'%s (*)'%here.getZMILangStr('ATTR_CUSTOM')">type</tal:block>
-									<tal:block tal:condition="python:objAttr['type'] in metaObjIds" tal:content="python:here.getMetaobj(objAttr['type'])['name']">type</tal:block>
-								</option>
+								<option selected="selected"
+									tal:condition="not:python:objAttr.get('meta_type') in here.getMetadictAttrs()"
+									tal:attributes="value python:objAttr['type']"
+									><tal:block 
+										tal:condition="python:objAttr['type'] in here.valid_datatypes" tal:content="python:objAttr['type']">type
+									</tal:block
+									><tal:block 
+										tal:condition="python:objAttr['type'] == '*'" tal:content="python:'%s (*)'%here.getZMILangStr('ATTR_CUSTOM')">type
+									</tal:block
+									><tal:block 
+										tal:condition="python:objAttr['type'] in metaObjIds" tal:content="python:here.getMetaobj(objAttr['type'])['name']">type
+									</tal:block
+								></option>
 							</select>
 						</td>
 						<td class="meta-mandatory input-group-sm" tal:attributes="title python:here.getZMILangStr('ATTR_MANDATORY')"><input type="checkbox" tal:attributes="name python:'attr_mandatory_%s:int'%objAttr['id']; checked python:['','checked'][objAttr.get('mandatory',0) in [1,True]]" value="1"/></td>
@@ -331,13 +311,39 @@
 
 				</tal:block>
 			</tr>
+			<!-- row_insert-template -->
 			<tr class="row_insert form-group">
 				<td class="meta-sort text-right"><span class="btn btn-secondary btn-sm btn-add mr-1 w-100"><i class="fas fa-plus"></i></span></td>
 				<td class="meta-id"><input class="form-control form-control-sm" type="text" name="attr_id"/></td>
 				<td class="meta-name"><input class="form-control form-control-sm" type="text" name="attr_name"/></td>
 				<td class="meta-type">
-					<select class="form-control form-control-sm" name="_type">
-						<option tal:content="python:'--- %s ---'%here.getZMILangStr('ATTR_PRIMITIVE')">type</option>
+					<select id="populate_type" class="form-control form-control-sm" name="_type">
+						<option id="type_primitive" value="" tal:content="python:'--- %s ---'%here.getZMILangStr('ATTR_PRIMITIVE')"></option>
+						<tal:block tal:repeat="type python:here.valid_datatypes">
+							<option tal:attributes="value type; class python:' '.join([['','deprecated'][int(type in here.deprecated_types)]])" tal:content="type">type</option>
+						</tal:block>
+						<tal:block tal:condition="metaObjRecordSet">
+							<option id="type_objects" value="" tal:content="python:'--- %s ---'%here.getZMILangStr('ATTR_FK')"></option>
+							<tal:block tal:repeat="metaObj python:[x for x in metaObjs if x['type']=='ZMSRecordSet' and x.get('package')==metaObj.get('package')]">
+								<option tal:attributes="value metaObj/id" tal:content="python:here.display_type(meta_id=metaObj['id'])">type</option>
+							</tal:block>
+						</tal:block>
+						<tal:block tal:condition="not:metaObjRecordSet">
+							<option id="type_metadata" value="" tal:content="python:'--- %s ---'%here.getZMILangStr('TAB_METADATA')"></option>
+							<tal:block tal:repeat="metaAttrId python:here.getMetadictAttrs()">
+								<option tal:attributes="value metaAttrId" tal:content="python:here.getMetadictAttr(metaAttrId)['name']">type</option>
+							</tal:block>
+							<option id="type_objects" value="" tal:content="python:'--- %s ---'%here.getZMILangStr('ATTR_OBJECTS')"></option>
+							<tal:block tal:repeat="metaObj python:[x for x in metaObjs if x['type'] != 'ZMSPackage']">
+								<option tal:attributes="value python:metaObj['id']" tal:content="python:here.display_type(meta_id=metaObj['id'])">type</option>
+							</tal:block>
+							<option id="type_objects_sequence" value="" tal:content="python:'--- %s ---'%here.getZMILangStr('ATTR_SEQUENCE')"></option>
+							<option value="*" tal:content="python:'%s (*)'%here.getZMILangStr('ATTR_CUSTOM')">*</option>
+						</tal:block>
+						<option id="type_zope" value="" tal:content="python:'--- %s ---'%'Zope'"></option>
+						<tal:block tal:repeat="type python:here.valid_zopetypes">
+							<option tal:attributes="value type; class python:' '.join([['','deprecated'][type in here.deprecated_types]])" tal:content="type">type</option>
+						</tal:block>
 					</select>
 				</td>
 				<td class="meta-mandatory"><input type="checkbox" name="_mandatory:int" value="1"/></td>
@@ -346,6 +352,7 @@
 				<td class="meta-repetitive" tal:condition="not:metaObjRecordSet"><input type="checkbox" name="_repetitive:int" value="1"/></td>
 				<td>&nbsp;</td>
 			</tr>
+			<!-- /row_insert-template -->
 		</tbody>
 	</table>
 
@@ -607,14 +614,15 @@
 </style>
 <script>
 // <!--
-/**
- *
- */
-function zmiEnabledBtnClick(sender) {
-	var $sender = $(sender);
-	var $container = $sender.closest("span");
-	var id = $container.attr("id");
-	var b = $container.hasClass("enabled")?0:1;
+
+	/**
+	 * Enable Button-Click.
+	 */
+	function zmiEnabledBtnClick(sender) {
+		var $sender = $(sender);
+		var $container = $sender.closest("span");
+		var id = $container.attr("id");
+		var b = $container.hasClass("enabled")?0:1;
 		// Set wait-cursor.
 		$ZMI.setCursorWait("zmiEnabledBtnClick");
 		// JQuery.AJAX.get
@@ -632,332 +640,336 @@ function zmiEnabledBtnClick(sender) {
 				$('.enabled-toggle',$container).removeClass("fa-check-square").addClass("fa-square");
 			}
 		});
-}
+	}
 
-/**
- * Export xml.
- */
-function zmiExportBtnClick(sender) {
-	var $fm = $(sender).closest("form");
-	var href = $fm.attr('action')+'?lang='+getZMILang()+'&btn=BTN_EXPORT';
-	$('input[name="id"]:text,input[name="ids:list"]:checked',$fm).each(function(){
+	/**
+	 * Export xml.
+	 */
+	function zmiExportBtnClick(sender) {
+		var $fm = $(sender).closest("form");
+		var href = $fm.attr('action')+'?lang='+getZMILang()+'&btn=BTN_EXPORT';
+		$('input[name="id"]:text,input[name="ids:list"]:checked',$fm).each(function(){
 			href += '&ids:list='+$(this).val();
 		});
-	window.open(href);
-	return false;
-}
-
-/**
- * Delete object.
- */
-function zmiDeleteObjBtnClick(sender,d) {
-	if (confirm(getZMILangStr('MSG_CONFIRM_DELOBJ'))) {
-		zmiFormSubmit(sender,d);
+		window.open(href);
+		return false;
 	}
-}
 
-/**
- * Submit form with given parameters.
- */
-function zmiFormSubmit(sender,d) {
-	var $fm = $(sender).closest("form");
-	var html = '';
-	for (var i in d) {
-		$('input[name="' + i + '"]',$fm).remove();
-		html += '<input type="hidden" name="' + i + '" value="' + d[i] +'"/>';
-	}
-	$fm
-		.append(html)
-		.submit();
-}
-
-/**
- * Populate type.
- */
-function zmiPopulateTypeSelect(sender) {
-	if ( sender.options.length <= 1) {
-		var selectedValue = '';
-		if ( sender.options.length == 1) {
-			selectedValue = sender.options[0].value;
+	/**
+	 * Delete object.
+	 */
+	function zmiDeleteObjBtnClick(sender,d) {
+		if (confirm(getZMILangStr('MSG_CONFIRM_DELOBJ'))) {
+			zmiFormSubmit(sender,d);
 		}
-		sender.options.length = 0;
-		$("select#populate_type option").each(function() {
+	}
+
+	/**
+	 * Submit form with given parameters.
+	 */
+	function zmiFormSubmit(sender,d) {
+		var $fm = $(sender).closest("form");
+		var html = '';
+		for (var i in d) {
+			$('input[name="' + i + '"]',$fm).remove();
+			html += '<input type="hidden" name="' + i + '" value="' + d[i] +'"/>';
+		}
+		$fm
+			.append(html)
+			.submit();
+	}
+
+	/**
+	 * Transfer selected object to node list.
+	 */
+	function selectObject(ignoredUrl, ignoredTitle, nodeName) {
+		var form = $('form.form-initialized');
+		var textArea = form.find('textarea.url-input');
+		var newVal = textArea.val() + '\n' + nodeName;
+		textArea.val(newVal).trigger('change');
+	}
+
+
+	/**
+	 * ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+	 * Generator for Default-ZPT-Code.
+	 * Cave: ZPT Processing in Zope5 requires $$
+	 * for JS String Templates
+	 * ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+	 */
+	function set_zmi_code_default(event) {
+		var confirmed = confirm("The Generator for Default-ZPT-Code asks:\nReally Reset to Default-Code?");
+		if (!confirmed == true) {
+			return false;
+		}
+		var $target = $('textarea.zpt',event.srcElement.parentNode);
+		var meta_model = {}; // meta_model = {meta_id:{'meta_type':meta_type,'meta_repetitive':meta_repetitive}, ...}
+		const meta_id_ignored = ['standard_html','check_constraints'];
+		const meta_type_ignored = ['delimiter','interface','constant'];
+
+		var meta_obj_id = $('table#meta_properties .row_metadata #id').val();
+		var target_id = $('.meta-id input', event.srcElement.parentNode.parentNode.parentNode).val();
+		var comment0 = `<!\-\- ${meta_obj_id}.${target_id} \-\->`;
+		var comment1 =  `<!\-\- ${meta_obj_id}.${target_id} \-\->`;
+
+		// Generate Model based on GUI-Form
+		$('#meta_properties tbody:nth-child(2) tr').each( function() {
+			var meta_id = $('.meta-id input', this).val();
+			var meta_type = $('.meta-type > :first-child', this).val();
+			if (!meta_type ) {
+				meta_type = $('.meta-code > :first-child', this).val();
+			}
+			var meta_repetitive = $('.meta-repetitive > :first-child', this).prop('checked');
+			if (
+				meta_id &&
+				meta_type &&
+				meta_id_ignored.indexOf(meta_id)==-1 &&
+				meta_type_ignored.indexOf(meta_type)==-1
+				) {
+				meta_model[meta_id] = { 'meta_type':meta_type,'meta_repetitive':meta_repetitive };
+			}
+		});
+
+		function shorten_id(str) {
+			// Remove namespace ornaments from meta_id name
+			str = str.split('attr_').reverse()[0];
+			str = str.split('dc_').reverse()[0];
+			str = str.split('/').reverse()[0];
+			return str
+		}
+
+		// ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+		// Construct TAL-Code-Template Parts: [1] Variable Definitions, [2] Content
+		// ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+		var tal_defs='';
+		var tal_content='';
+
+		// [1] Variable Definitions
+		function tal_def_render(item) {
+			var id = String(item);
+			var sid = shorten_id(id);
+			if ( meta_model[id]['meta_type'] =='url' ) {
+				// ATTRTYPE URL
+				tal_defs += `\n\t\t${sid} python:zmscontext.attr('${id}');`
+				tal_defs += `\n\t\t${sid}_obj python:'{' in ${sid} and zmscontext.getLinkObj(${sid},request) or None;`
+				tal_defs += `\n\t\t${sid}_target python:${sid}_obj and ${sid}_obj.getHref2IndexHtml(request) or ${sid};`
+			} else if ( meta_model[id]['meta_repetitive'] ) {
+				// ATTRTYPE COMPLEX/REPETITIVE
+				if (meta_model[id]['meta_type']!='*') {
+					tal_defs +=`\n\t\t${sid}_list python:zmscontext.filteredChildNodes(request,'${meta_model[id]['meta_type']}');`
+				} else {
+					tal_defs +=`\n\t\t${sid}_list python:zmscontext.filteredChildNodes(request);`
+				}
+			} else if ( meta_model[id]['meta_type'] == 'Script (Python)' ) {
+				// ATTRTYPE PYTHON SCRIPT (ZOPE OBJECT)
+				tal_defs += `\n\t\t${sid} here/${id};`
+			} else {
+				// ATTRTYPE STRING (STANDARD)
+				tal_defs += `\n\t\t${sid} python:zmscontext.attr('${id}');`
+			}
+		}
+
+		// [2] Content
+		function tal_content_render(item) {
+			var id = String(item);
+			var sid = shorten_id(id);
+			if ( meta_model[id]['meta_type']=='image' ) {
+				// ATTRTYPE IMAGE
+				tal_content += `\n\t<img class="${sid}" tal:attributes="src python:${sid}.getHref(request)" alt="Image" />`;
+			} else if ( meta_model[id]['meta_type']=='url' ) {
+				// ATTRTYPE URL
+				tal_content += `\n\t<a class="${sid}" tal:condition="${sid}" tal:attributes="href python:${sid}_obj and ${sid}_target or ${sid}; target python:${sid}_obj and '_self' or '_blank';">Link...</a>`;
+			} else if ( meta_model[id]['meta_type'] == 'file' ) {
+				// ATTRTYPE FILE
+				tal_content += `\n\t<a class="${sid}" tal:condition="${sid}" tal:attributes="href python:${sid}.getHref(request);title python:'Download-File Size: %s, Type: %s'%(${sid}.getDataSizeStr(),${sid}.getContentType())" tal:content="python:${sid}.getFilename()">Filename</a>`;
+			} else if ( meta_model[id]['meta_type'] == 'richtext' ) {
+				// ATTRTYPE RICHTEXT
+				tal_content += `\n\t<div class="${sid}" tal:content="structure ${sid}">${sid}</div>`;
+			} else if ( meta_model[id]['meta_type'] == 'datetime' ) {
+				// ATTRTYPE DATE/TIME
+				tal_content += `\n\t<div class="${sid}" tal:condition="${sid}" tal:content="python:zmscontext.getLangFmtDate(${sid},request.get('lang'))">${sid}</div>`;
+			} else if ( meta_model[id]['meta_repetitive'] ) {
+				// ATTRTYPE COMPLEX/REPETITIVE
+				tal_content += `\n\t<div class="${sid} repetitive" tal:condition="${sid}_list">\n\t\t<tal:block tal:repeat="${sid}_listitem ${sid}_list" tal:content="structure python:${sid}_listitem.renderShort(request)">${sid}</tal:block>\n\t</div>`;
+			} else if ( meta_model[id]['meta_type'] =='Script (Python)' ) {
+				// ATTRTYPE PYTHON SCRIPT (ZOPE OBJECT)
+				tal_content += `\n\t<div class="${sid}" tal:content="structure ${sid}">${id}</div>`;
+			} else {
+				// ATTRTYPE STRING (STANDARD)
+				tal_content += `\n\t<div class="${sid}" tal:content="${sid}">${sid}</div>`;
+			}
+		}
+
+		// Render TAL-Code-Templates Parts
+		Object.keys(meta_model).forEach(tal_def_render);
+		Object.keys(meta_model).forEach(tal_content_render);
+
+		// Assemble TAL-Code
+		var default_template = `<div title="Default-ZPT-Code"
+			tal:define="zmscontext options/zmscontext;
+			id python:zmscontext.getId();
+			css_class python:zmscontext.meta_id;${tal_defs}"
+		tal:attributes="id id;class css_class">${tal_content}\n</div>`;
+
+		// Write TAL-Code into Textarea
+		$target.val(`${comment1}\n${default_template}\n${comment1}`);
+		$target.animate({height: $target.prop('scrollHeight') + 'px'},600);
+
+	}
+
+
+	/**
+	 * Populate type select-list.
+	 */
+	function zmiPopulateTypeSelect(sender) {
+		if ( sender.options.length <= 1) {
+			var selectedValue = '';
+			if ( sender.options.length == 1) {
+				selectedValue = sender.options[0].value;
+			}
+			sender.options.length = 0;
+			$("select#populate_type option").each(function() {
 				if (sender.name != '_type' || !$(this).hasClass('deprecated')) {
 					addOption( sender, $(this).text(), $(this).val(), selectedValue);
 				}
 			});
-	}
-}
-
-/**
- * Transfer selected object to node list.
- */
-function selectObject(ignoredUrl, ignoredTitle, nodeName) {
-	var form = $('form.form-initialized');
-	var textArea = form.find('textarea.url-input');
-	var newVal = textArea.val() + '\n' + nodeName;
-	textArea.val(newVal).trigger('change');
-}
-
-$(function(){
-	$("table input[name='ids:list']")
-		.change(zmiActionButtonsRefresh)
-		;
-	$("select[name=_type],select[name^=attr_type_]")
-		.focus(function(){zmiPopulateTypeSelect(this)})
-		.hover(function(){zmiPopulateTypeSelect(this)})
-		;
-	// if ( $(window).width() < 767 ) {
-	// 	var $th = $("#meta_properties th");
-	// 	$('#meta_properties tr[class!="row_metadata"] td').prepend( function () {
-	// 		return '<span class="title">' + $th.eq($(this).index()).attr('title') + '<' + '/span>';
-	// 	})
-	//};
-});
-
-/**
- * ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- * Generator for Default-ZPT-Code.
- * Cave: ZPT Processing in Zope5 requires $$
- * for JS String Templates
- * ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- */
- function set_zmi_code_default(event) {
-	var confirmed = confirm("The Generator for Default-ZPT-Code asks:\nReally Reset to Default-Code?");
-	if (!confirmed == true) {
-		return false;
-	}
-	var $target = $('textarea.zpt',event.srcElement.parentNode);
-	var meta_model = {}; // meta_model = {meta_id:{'meta_type':meta_type,'meta_repetitive':meta_repetitive}, ...}
-	const meta_id_ignored = ['standard_html','check_constraints'];
-	const meta_type_ignored = ['delimiter','interface','constant'];
-
-	var meta_obj_id = $('table#meta_properties .row_metadata #id').val();
-	var target_id = $('.meta-id input', event.srcElement.parentNode.parentNode.parentNode).val();
-	var comment0 = `<!\-\- ${meta_obj_id}.${target_id} \-\->`;
-	var comment1 =  `<!\-\- ${meta_obj_id}.${target_id} \-\->`;
-
-	// Generate Model based on GUI-Form
-	$('#meta_properties tbody:nth-child(2) tr').each( function() {
-		var meta_id = $('.meta-id input', this).val();
-		var meta_type = $('.meta-type > :first-child', this).val();
-		if (!meta_type ) {
-			meta_type = $('.meta-code > :first-child', this).val();
 		}
-		var meta_repetitive = $('.meta-repetitive > :first-child', this).prop('checked');
-		if (
-			meta_id &&
-			meta_type &&
-			meta_id_ignored.indexOf(meta_id)==-1 &&
-			meta_type_ignored.indexOf(meta_type)==-1
-			) {
-			meta_model[meta_id] = { 'meta_type':meta_type,'meta_repetitive':meta_repetitive };
-		}
-	});
-
-	function shorten_id(str) {
-		// Remove namespace ornaments from meta_id name
-		str = str.split('attr_').reverse()[0];
-		str = str.split('dc_').reverse()[0];
-		str = str.split('/').reverse()[0];
-		return str
 	}
 
-	// ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-	// Construct TAL-Code-Template Parts: [1] Variable Definitions, [2] Content
-	// ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-	var tal_defs='';
-	var tal_content='';
 
-	// [1] Variable Definitions
-	function tal_def_render(item) {
-		var id = String(item);
-		var sid = shorten_id(id);
-		if ( meta_model[id]['meta_type'] =='url' ) {
-			// ATTRTYPE URL
-			tal_defs += `\n\t\t${sid} python:zmscontext.attr('${id}');`
-			tal_defs += `\n\t\t${sid}_obj python:'{' in ${sid} and zmscontext.getLinkObj(${sid},request) or None;`
-			tal_defs += `\n\t\t${sid}_target python:${sid}_obj and ${sid}_obj.getHref2IndexHtml(request) or ${sid};`
-		} else if ( meta_model[id]['meta_repetitive'] ) {
-			// ATTRTYPE COMPLEX/REPETITIVE
-			if (meta_model[id]['meta_type']!='*') {
-				tal_defs +=`\n\t\t${sid}_list python:zmscontext.filteredChildNodes(request,'${meta_model[id]['meta_type']}');`
+	// Add Execute Button for TAL-Code-Regeneration om a ZPT-Method named standard_html
+	const zmi_code_default_btn = '<i onclick="set_zmi_code_default(event)" title=\"Replace by Default-Code-Template\" class=\"zmi-code-default fas fa-sync text-primary btn-lg mr-2 position-absolute\" style=\"cursor:pointer;right:0\"></i>';
+
+	// Execute on DOM-Ready
+	$(function(){
+
+		// Add Event-Listeners
+		$("table input[name='ids:list']")
+			.change(zmiActionButtonsRefresh)
+			;
+		// ########################################################################
+		// Clone meta_types select lists from .row_insert-template
+		$("select[name^=attr_type_]")
+			.focus(function(){zmiPopulateTypeSelect(this)})
+			.hover(function(){zmiPopulateTypeSelect(this)})
+			;
+		// ########################################################################
+
+		// Add Execute Button for TAL-Code-Regeneration on a ZPT-Method named standard_html
+		$('#meta_properties input[name="attr_type_standard_html"] ~ .zmi-code').prepend(zmi_code_default_btn);
+
+		// New field set: initially disable inputs
+		$('input, textarea, select','tr.row_insert').attr('disabled',true);
+
+		// ++++++++++++
+		// Add rows to tables #meta_properties or #meta_languages on button click
+		// ++++++++++++
+		let new_row_counter = 0;
+		// Get number of language terms
+		let lang_dict = ZMI.prototype.getCachedValue('get_lang_dict');
+		let lang_count = 0;
+		if ( lang_dict!='undefined' ) {
+			if ( typeof lang_dict == 'object' ) {
+				lang_count = Object.keys(ZMI.prototype.getCachedValue('get_lang_dict')).length
 			} else {
-				tal_defs +=`\n\t\t${sid}_list python:zmscontext.filteredChildNodes(request);`
+				lang_count = Object.keys(JSON.parse(ZMI.prototype.getCachedValue('get_lang_dict'))).length
 			}
-		} else if ( meta_model[id]['meta_type'] == 'Script (Python)' ) {
-			// ATTRTYPE PYTHON SCRIPT (ZOPE OBJECT)
-			tal_defs += `\n\t\t${sid} here/${id};`
-		} else {
-			// ATTRTYPE STRING (STANDARD)
-			tal_defs += `\n\t\t${sid} python:zmscontext.attr('${id}');`
-		}
-	}
+		};
 
-	// [2] Content
-	function tal_content_render(item) {
-		var id = String(item);
-		var sid = shorten_id(id);
-		if ( meta_model[id]['meta_type']=='image' ) {
-			// ATTRTYPE IMAGE
-			tal_content += `\n\t<img class="${sid}" tal:attributes="src python:${sid}.getHref(request)" alt="Image" />`;
-		} else if ( meta_model[id]['meta_type']=='url' ) {
-			// ATTRTYPE URL
-			tal_content += `\n\t<a class="${sid}" tal:condition="${sid}" tal:attributes="href python:${sid}_obj and ${sid}_target or ${sid}; target python:${sid}_obj and '_self' or '_blank';">Link...</a>`;
-		} else if ( meta_model[id]['meta_type'] == 'file' ) {
-			// ATTRTYPE FILE
-			tal_content += `\n\t<a class="${sid}" tal:condition="${sid}" tal:attributes="href python:${sid}.getHref(request);title python:'Download-File Size: %s, Type: %s'%(${sid}.getDataSizeStr(),${sid}.getContentType())" tal:content="python:${sid}.getFilename()">Filename</a>`;
-		} else if ( meta_model[id]['meta_type'] == 'richtext' ) {
-			// ATTRTYPE RICHTEXT
-			tal_content += `\n\t<div class="${sid}" tal:content="structure ${sid}">${sid}</div>`;
-		} else if ( meta_model[id]['meta_type'] == 'datetime' ) {
-			// ATTRTYPE DATE/TIME
-			tal_content += `\n\t<div class="${sid}" tal:condition="${sid}" tal:content="python:zmscontext.getLangFmtDate(${sid},request.get('lang'))">${sid}</div>`;
-		} else if ( meta_model[id]['meta_repetitive'] ) {
-			// ATTRTYPE COMPLEX/REPETITIVE
-			tal_content += `\n\t<div class="${sid} repetitive" tal:condition="${sid}_list">\n\t\t<tal:block tal:repeat="${sid}_listitem ${sid}_list" tal:content="structure python:${sid}_listitem.renderShort(request)">${sid}</tal:block>\n\t</div>`;
-		} else if ( meta_model[id]['meta_type'] =='Script (Python)' ) {
-			// ATTRTYPE PYTHON SCRIPT (ZOPE OBJECT)
-			tal_content += `\n\t<div class="${sid}" tal:content="structure ${sid}">${id}</div>`;
-		} else {
-			// ATTRTYPE STRING (STANDARD)
-			tal_content += `\n\t<div class="${sid}" tal:content="${sid}">${sid}</div>`;
-		}
-	}
+		// Add click event function to add-buttons
+		$(".row_insert .btn-add").click(function(){
+			new_row_counter++;
+			// New field set: clone with enabled inputs
+			$('input, textarea, select','tr.row_insert').attr('disabled',false);
 
-	// Render TAL-Code-Templates Parts
-	Object.keys(meta_model).forEach(tal_def_render);
-	Object.keys(meta_model).forEach(tal_content_render);
+			// Where to insert the new row
+			let $where_insert = $(this).closest('tr');
 
-	// Assemble TAL-Code
-	var default_template = `<div title="Default-ZPT-Code"
-		tal:define="zmscontext options/zmscontext;
-		id python:zmscontext.getId();
-		css_class python:zmscontext.meta_id;${tal_defs}"
-	tal:attributes="id id;class css_class">${tal_content}\n</div>`;
-
-	// Write TAL-Code into Textarea
-	$target.val(`${comment1}\n${default_template}\n${comment1}`);
-	$target.animate({height: $target.prop('scrollHeight') + 'px'},600);
-
-}
-// Add Execute Button for TAL-Code-Regeneration om a ZPT-Method named standard_html
-var zmi_code_default_btn = '<i onclick="set_zmi_code_default(event)" title=\"Replace by Default-Code-Template\" class=\"zmi-code-default fas fa-sync text-primary btn-lg mr-2 position-absolute\" style=\"cursor:pointer;right:0\"></i>';
-
-// Execute on DOM-Ready
-$(function(){
-	$('#meta_properties input[name="attr_type_standard_html"] ~ .zmi-code').prepend( zmi_code_default_btn);
-
-	// New field set: initially disable inputs
-	$('input, textarea, select','tr.row_insert').attr('disabled',true);
-
-	// ++++++++++++
-	// Add rows to tables #meta_properties or #meta_languages on button click
-	// ++++++++++++
-	let new_row_counter = 0;
-	// Get number of language terms
-	let lang_dict = ZMI.prototype.getCachedValue('get_lang_dict');
-	let lang_count = 0;
-	if ( lang_dict!='undefined' ) {
-		if ( typeof lang_dict == 'object' ) {
-			lang_count = Object.keys(ZMI.prototype.getCachedValue('get_lang_dict')).length
-		} else {
-			lang_count = Object.keys(JSON.parse(ZMI.prototype.getCachedValue('get_lang_dict'))).length
-		}
-	};
-
-	// Add click event function to add-buttons
-	$(".row_insert .btn-add").click(function(){
-		new_row_counter++;
-		// New field set: clone with enabled inputs
-		$('input, textarea, select','tr.row_insert').attr('disabled',false);
-
-		// Where to insert the new row
-		let $where_insert = $(this).closest('tr');
-
-		// Set variables
-		let table_id = $(this).closest('table').attr('id'); // meta_properties or meta_languages
-		let new_row_name = `new_row_${table_id}_${new_row_counter}`;
-		let old_id_html = '';
-		let sort_options_html = '';
-		let sort_options_len = 0;
-		let new_btn_html = `
-			<span class="btn btn-secondary btn-sm mr-1 w-100" style="color:#999" 
-				onclick="javascript:$(this).closest('tr').hide('slow',function(){$(this).closest('tr').remove()})">
-				<i class="fas fa-undo-alt"></i>
-			</span>
-		`;
-
-		// #### TABLES: Process table specific
-		if (table_id != 'meta_languages') {
-			old_id_html = `<input type="hidden" name="old_ids:list" value="new${new_row_counter}">`;
-			new_btn_html = `
-				${old_id_html}
-				<span class="btn btn-secondary btn-sm mr-1 w-100" style="color:#999"
-					title="Revoke new Meta Attribute"
+			// Set variables
+			let table_id = $(this).closest('table').attr('id'); // meta_properties or meta_languages
+			let new_row_name = `new_row_${table_id}_${new_row_counter}`;
+			let old_id_html = '';
+			let sort_options_html = '';
+			let sort_options_len = 0;
+			let new_btn_html = `
+				<span class="btn btn-secondary btn-sm mr-1 w-100" style="color:#999" 
 					onclick="javascript:$(this).closest('tr').hide('slow',function(){$(this).closest('tr').remove()})">
 					<i class="fas fa-undo-alt"></i>
 				</span>
 			`;
-		}
 
-		// Clone(true) to get a deep copy including select options
-		let $new_row = $where_insert.clone(true);
+			// #### TABLES: Process table specific
+			if (table_id != 'meta_languages') {
+				old_id_html = `<input type="hidden" name="old_ids:list" value="new${new_row_counter}">`;
+				new_btn_html = `
+					${old_id_html}
+					<span class="btn btn-secondary btn-sm mr-1 w-100" style="color:#999"
+						title="Revoke new Meta Attribute"
+						onclick="javascript:$(this).closest('tr').hide('slow',function(){$(this).closest('tr').remove()})">
+						<i class="fas fa-undo-alt"></i>
+					</span>
+				`;
+			}
 
-		// Process table cells of the clone like "old" row
-		$new_row.find('td').each(function() {
-			$(this).find('input,select,textarea').each(function() {
-				let tagname = $(this).prop('tagName');
-				let defname = $(this).attr('name')
-				let deftype = $(this).attr('type')
-				let newname = $(this).attr('name').split('_')[1].split(':')[0];
-				let newval  = $(this).val();
+			// Clone(true) to get a deep copy including select options
+			let $new_row = $where_insert.clone(true);
 
-				// #### NAMES: Set new form element names according to table_id
-				switch (table_id) {
-					case 'meta_languages':
-						newname = defname.replace('_0', '_' + (lang_count + new_row_counter));
-						break
-					default:  // meta_properties
-						newname = `attr_${newname}_new${new_row_counter}`
-						newname = defname.includes(':') ? `${newname}:int` : newname;
-				};
-				$(this).attr('name',newname);
+			// Process table cells of the clone like "old" row
+			$new_row.find('td').each(function() {
+				$(this).find('input,select,textarea').each(function() {
+					let tagname = $(this).prop('tagName');
+					let defname = $(this).attr('name')
+					let deftype = $(this).attr('type')
+					let newname = $(this).attr('name').split('_')[1].split(':')[0];
+					let newval  = $(this).val();
 
-				// #### VALUES: Transfer initially entered values from template to clone
-				if ( tagname == 'SELECT') {
-					let selected = $("option:selected", $('.row_insert select')).val();
-					if (selected!='') {
-						$('option[value="' + selected +'"]',$(this)).prop('selected', true);
+					// #### NAMES: Set new form element names according to table_id
+					switch (table_id) {
+						case 'meta_languages':
+							newname = defname.replace('_0', '_' + (lang_count + new_row_counter));
+							break
+						default:  // meta_properties
+							newname = `attr_${newname}_new${new_row_counter}`
+							newname = defname.includes(':') ? `${newname}:int` : newname;
 					};
-				} else {
-					if (deftype == 'checkbox') {
-						newval = newval =='1' ? 1 : 0;
+					$(this).attr('name',newname);
+
+					// #### Set default values: Transfer initially created values from row_insert-template to it's clone
+					if ( tagname == 'SELECT') {
+						// Remove id #populate_type from cloned select
+						$(this).removeAttr('id');
+						let selected = $("option:selected", $('.row_insert select')).val();
+						if (selected!='') {
+							$('option[value="' + selected +'"]',$(this)).prop('selected', true);
+						};
 					} else {
-						newval = newval =='' ? ('new'+new_row_counter) : newval;
-					};
-					$(this).val(newval);
-				}
+						if (deftype == 'checkbox') {
+							newval = newval =='1' ? 1 : 0;
+						} else {
+							newval = newval =='' ? ('new'+new_row_counter) : newval;
+						};
+						$(this).val(newval);
+					}
+				});
 			});
+
+			// Process td:first-child of the clone
+			$new_row.find('td.meta-sort').html(new_btn_html);
+			$new_row.removeClass('row_insert').attr('id',new_row_name);
+
+			// Insert the new row
+			$new_row.insertBefore($where_insert);
+			// Set form as modified
+			$ZMI.set_form_modified($('.meta-id input',$new_row));
+			// Reset the clone template
+			$where_insert.find('input:not([type="checkbox"]),select,textarea').each(function() {
+				$(this).val(undefined);
+			});
+			// New field set: reset to disabled inputs
+			$('input, textarea, select','tr.row_insert').attr('disabled',true);
 		});
 
-		// Process td:first-child of the clone
-		$new_row.find('td.meta-sort').html(new_btn_html);
-		$new_row.removeClass('row_insert').attr('id',new_row_name);
-
-		// Insert the new row
-		$new_row.insertBefore($where_insert);
-		// Set form as modified
-		$ZMI.set_form_modified($('.meta-id input',$new_row));
-		// Reset the clone template
-		$where_insert.find('input:not([type="checkbox"]),select,textarea').each(function() {
-			$(this).val(undefined);
-		});
-		// New field set: reset to disabled inputs
-		$('input, textarea, select','tr.row_insert').attr('disabled',true);
 	});
-
-});
 // -->
 </script>
 

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_metas.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_metas.zpt
@@ -330,10 +330,9 @@
 	$(function(){
 
 		// ########################################################################
-		// Clone all meta_types select lists from the last row
+		// Clone meta_types select lists from the last row
 		const $meta_options = $('select[name="_type"] option');
-		// let c = 1;
-		$('#meta_properties tbody tr:not(.row_insert) td.meta-type select').each( function() {
+		$('#meta_properties tbody tr:not(.row_insert) td.meta-type select').on('focus', function() {
 			let sel = $(this);
 			let sel_opt = $('option',sel).clone();
 			// Clear the select list
@@ -342,9 +341,7 @@
 			$meta_options.each( function() {
 				let opt = $(this).attr('value')==$(sel_opt).attr('value') ? $(sel_opt) : $(this).clone();
 				$(sel).append($(opt.prop('outerHTML')));
-				debugger;
 			});
-			// console.log(c++ + ' ' + sel.attr('name'));
 		})
 		// ########################################################################
 

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_metas.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_metas.zpt
@@ -164,7 +164,7 @@
 		<td class="meta-id"><input class="form-control form-control-sm" type="text" name="_id" /></td>
 		<td class="meta-name"><input class="form-control form-control-sm" type="text" name="_name" /></td>
 		<td class="meta-type">
-			<select class="form-control form-control-sm" name="_type">
+			<select id="populate_type" class="form-control form-control-sm" name="_type">
 				<option value="">--- <tal:block tal:content="python:here.getZMILangStr('ATTR_PRIMITIVE')">Primitive</tal:block> ---</option>
 				<option tal:repeat="datatype python:here.valid_datatypes" tal:attributes="value datatype" tal:content="datatype">datatype</option>
 				<option value="">--- <tal:block tal:content="python:here.getZMILangStr('ATTR_OBJECTS')">Objects</tal:block> ---</option>
@@ -325,24 +325,34 @@
 	}
 
 	/**
+	 * Populate type select-list.
+	 */
+	function zmiPopulateTypeSelect(sender) {
+		if ( sender.options.length <= 1) {
+			var selectedValue = '';
+			if ( sender.options.length == 1) {
+				selectedValue = sender.options[0].value;
+			}
+			sender.options.length = 0;
+			$("select#populate_type option").each(function() {
+				if (sender.name != '_type' || !$(this).hasClass('deprecated')) {
+					addOption( sender, $(this).text(), $(this).val(), selectedValue);
+				}
+			});
+		}
+	}
+
+	/**
 	 * Init.
 	 */
 	$(function(){
 
 		// ########################################################################
-		// Clone meta_types select lists from the last row
-		const $meta_options = $('select[name="_type"] option');
-		$('#meta_properties tbody tr:not(.row_insert) td.meta-type select').on('focus', function() {
-			let sel = $(this);
-			let sel_opt = $('option',sel).clone();
-			// Clear the select list
-			$('option',sel).remove();
-			// Add all options incl. the selected one
-			$meta_options.each( function() {
-				let opt = $(this).attr('value')==$(sel_opt).attr('value') ? $(sel_opt) : $(this).clone();
-				$(sel).append($(opt.prop('outerHTML')));
-			});
-		})
+		// Clone meta_types select lists from .row_insert-template
+		$("select[name^=attr_type_]")
+			.focus(function(){zmiPopulateTypeSelect(this)})
+			.hover(function(){zmiPopulateTypeSelect(this)})
+		;
 		// ########################################################################
 
 		// New field set: initially disable inputs
@@ -394,7 +404,11 @@
 						$(this).attr('placeholder',newval);
 					} else if ( deftype == 'checkbox' ) {
 						$(this).val(1);
-					}
+					};
+					// Remove id #populate_type from cloned select
+					if ( tagname == 'SELECT') {
+						$(this).removeAttr('id');
+					};
 				});
 			});
 

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_metas.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_metas.zpt
@@ -356,7 +356,7 @@
 		// ########################################################################
 
 		// New field set: initially disable inputs
-		$('tr.row_insert input').attr('disabled',true);
+		$('input, textarea, select','tr.row_insert').attr('disabled',true);
 
 		// ++++++++++++
 		// Add rows to tables #meta_properties on button click
@@ -367,7 +367,7 @@
 		$(".row_insert .btn-add").click(function(){
 			new_row_counter++;
 			// New field set: clone with enabled inputs
-			$('tr.row_insert input').attr('disabled',false);
+			$('input, textarea, select','tr.row_insert').attr('disabled',false);
 
 			// Where to insert the new row
 			let $where_insert = $(this).closest('tr');
@@ -425,7 +425,7 @@
 				$(this).val(undefined);
 			});
 			// New field set: reset to disabled inputs
-			$('tr.row_insert input').attr('disabled',true);
+			$('input, textarea, select','tr.row_insert').attr('disabled',true);
 		});
 
 	});

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_metas.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_metas.zpt
@@ -39,22 +39,22 @@
 			<input type="hidden" name="lang" tal:attributes="value request/lang">
 			<div class="form-group col-12">
 				<div class="custom-file">
-					<input type="file" name="file" id="file" class="custom-file-input" value="" 
+					<input type="file" name="file" id="file" class="custom-file-input" value=""
 						onchange="$('.custom-file label span').html($(this).val().replace(/^.*(\\|\/|\:)/, ''));" />
 					<label class="custom-file-label" for="file"><span tal:content="python:here.getZMILangStr('ATTR_FILE')">Choose file</span></label>
 				</div>
 			</div><!-- .form-group -->
 			<label class="col-12 control-label text-left"><span tal:content="python:here.getZMILangStr('OR').lower()">Or</span></label>
 			<div class="form-group col-12 mt-2">
-				<select class="form-control" id="init" name="init" 
-					onfocus="zmiExpandConfFiles(this,'.metadict.')" 
+				<select class="form-control" id="init" name="init"
+					onfocus="zmiExpandConfFiles(this,'.metadict.')"
 					onmouseover="zmiExpandConfFiles(this,'.metadict.')">
 					<option value="" tal:content="python:'--- %s ---'%here.getZMILangStr('BTN_INIT')">--- Init... ---</option>
 				</select>
 			</div><!-- .form-group -->
 			<div class="form-group row mt-5 mr-0">
 				<div class="controls save">
-					<button type="submit" name="btn" class="btn btn-primary" value="BTN_IMPORT" 
+					<button type="submit" name="btn" class="btn btn-primary" value="BTN_IMPORT"
 						tal:content="python:here.getZMILangStr('BTN_IMPORT')">
 						Import
 					</button>
@@ -70,7 +70,7 @@
 	<input type="hidden" name="target" value="zmi_manage_tabs_message">
 	<input type="hidden" name="lang" tal:attributes="value request/lang">
 	<legend class="has_tooltip"
-		tal:attributes="title python:here.getZMILangStr('TIP_METADICT')" 
+		tal:attributes="title python:here.getZMILangStr('TIP_METADICT')"
 		tal:content="python:here.getZMILangStr('TAB_METADATA')">
 		Metadata
 	</legend>
@@ -93,14 +93,13 @@
 		<th></th>
 	</tr>
 	</thead>
-	<tbody>
-	<tal:block tal:define="metadictAttrIds python:here.getMetadictAttrs()">
+	<tbody tal:define="metadictAttrIds python:here.getMetadictAttrs()">
 	<tr tal:repeat="metadictAttrId metadictAttrIds" class="form-group">
 		<tal:block tal:define="global metadictAttr python:here.getMetadictAttr(metadictAttrId)">
 		<td class="meta-sort">
 			<input type="hidden" name="old_ids:list" tal:attributes="value python:metadictAttr['id']" />
 			<div class="input-group input-group-sm">
-				<select class="zmi-sort form-control-sm" 
+				<select class="zmi-sort form-control-sm"
 					tal:attributes="onchange python:'zmiFormSubmit(this,{btn:\'move_to\',id:\'%s\',\'pos:int\':this.selectedIndex})'%metadictAttrId">
 					<option tal:repeat="i python:range(0,len(metadictAttrIds))" tal:attributes="selected python:['','selected'][int(i==metadictAttrIds.index(metadictAttrId))]" tal:content="python:i+1">i+1</option>
 				</select>
@@ -122,8 +121,8 @@
 				tal:define="meta_ids python:request.set('meta_id_usage',', '.join([xx for xx in here.getMetaobjIds() if metadictAttrId in [x['type'] for x in here.getMetaobjAttrs(xx)]]));">
 			</tal:block>
 			<input class="form-control form-control-sm" type="text"
-				tal:attributes="name python:'attr_id_%s'%metadictAttr['id']; 
-					value python:metadictAttr['id']; 
+				tal:attributes="name python:'attr_id_%s'%metadictAttr['id'];
+					value python:metadictAttr['id'];
 					title python:'Used by: ' + request.get('meta_id_usage','Unknown');
 					disabled python:['','disabled'][int(metadictAttr.get('acquired',0))]" />
 		</td>
@@ -131,11 +130,10 @@
 			<input class="form-control form-control-sm" type="text" tal:attributes="name python:'attr_name_%s'%metadictAttr['id']; value python:metadictAttr['name']; disabled python:['','disabled'][int(metadictAttr.get('acquired',0))]"/>
 		</td>
 		<td class="meta-type">
-			<select class="form-control form-control-sm" tal:attributes="name python:'attr_type_%s'%metadictAttr['id']; disabled python:['','disabled'][int(metadictAttr.get('acquired',0))]">
-				<option value="">--- <tal:block tal:content="python:here.getZMILangStr('ATTR_PRIMITIVE')">Primitive</tal:block> ---</option>
-				<option tal:repeat="datatype python:here.valid_datatypes" tal:attributes="value datatype; selected python:['','selected'][int(metadictAttr['type']==datatype)]" tal:content="datatype">datatype</option>
-				<option value="">--- <tal:block tal:content="python:here.getZMILangStr('ATTR_OBJECTS')">Objects</tal:block> ---</option>
-				<option tal:repeat="meta_type python:here.getMetaobjIds(sort=True,excl_ids=['ZMS'])" tal:attributes="value meta_type; selected python:['','selected'][int(metadictAttr['type']==meta_type)]" tal:content="python:here.display_type(meta_id=meta_type)">meta_type</option>
+			<select class="form-control form-control-sm"
+				tal:define="attr_type python:metadictAttr.get('type')"
+				tal:attributes="name python:'attr_type_%s'%metadictAttr['id']; disabled python:['','disabled'][int(metadictAttr.get('acquired',0))]">
+				<option tal:attributes="value attr_type" selected="selected" tal:content="attr_type">datatype</option>
 			</select>
 		</td>
 		<tal:block tal:condition="python:metadictAttr['type'] in ['method']">
@@ -161,7 +159,6 @@
 		</tal:block>
 		</tal:block>
 	</tr>
-	</tal:block>
 	<tr class="row_insert form-group">
 		<td class="meta-sort text-right"><span class="btn btn-add mr-1 btn-secondary btn-sm"><i class="fas fa-plus"></i></span></td>
 		<td class="meta-id"><input class="form-control form-control-sm" type="text" name="_id" /></td>
@@ -182,19 +179,19 @@
 	</tbody>
 	</table>
 	<div class="controls save">
-		<button name="btn" type="submit" class="btn btn-secondary" 
+		<button name="btn" type="submit" class="btn btn-secondary"
 			hx-trigger="click"
-			hx-post="manage_changeMetaProperties" 
-			hx-target="#zmi_manage_tabs_message" 
+			hx-post="manage_changeMetaProperties"
+			hx-target="#zmi_manage_tabs_message"
 			hx-swap="outerHTML show:top"
 			hx-on:click="$ZMI.show_spinner(this)"
 			hx-on:htmx:after-request="renew_sort_options(this);$ZMI.reset_spinner(this)"
-			value="BTN_SAVE" 
+			value="BTN_SAVE"
 			tal:content="python:here.getZMILangStr('BTN_SAVE')">
 			Save
 		</button>
-		<button name="btn" type="submit" class="btn btn-secondary" 
-			value="BTN_CANCEL" 
+		<button name="btn" type="submit" class="btn btn-secondary"
+			value="BTN_CANCEL"
 			tal:content="python:here.getZMILangStr('BTN_RESET')">
 			Cancel
 		</button>
@@ -296,7 +293,7 @@
 			let new_btn_html = `
 				<div class="input-group input-group-sm">
 					${old_id_html}
-					<select class="zmi-sort form-control-sm" 
+					<select class="zmi-sort form-control-sm"
 						onchange="zmiFormSubmit(this,{btn:'move_to',id:'${old_id}','pos:int':this.selectedIndex})">
 						${sort_options_html}
 					</select>
@@ -321,7 +318,7 @@
 	 * Normalize after deleting a row.
 	 */
 	 function clean_deleted_row(sender) {
-		$(sender).closest('tr').hide('slow',function(){ 
+		$(sender).closest('tr').hide('slow',function(){
 			$(sender).closest('tr').remove();
 			renew_sort_options();
 		})
@@ -331,6 +328,26 @@
 	 * Init.
 	 */
 	$(function(){
+
+		// ########################################################################
+		// Clone all meta_types select lists from the last row
+		const $meta_options = $('select[name="_type"] option');
+		// let c = 1;
+		$('#meta_properties tbody tr:not(.row_insert) td.meta-type select').each( function() {
+			let sel = $(this);
+			let sel_opt = $('option',sel).clone();
+			// Clear the select list
+			$('option',sel).remove();
+			// Add all options incl. the selected one
+			$meta_options.each( function() {
+				let opt = $(this).attr('value')==$(sel_opt).attr('value') ? $(sel_opt) : $(this).clone();
+				$(sel).append($(opt.prop('outerHTML')));
+				debugger;
+			});
+			// console.log(c++ + ' ' + sel.attr('name'));
+		})
+		// ########################################################################
+
 		// New field set: initially disable inputs
 		$('tr.row_insert input').attr('disabled',true);
 
@@ -345,7 +362,7 @@
 			// New field set: clone with enabled inputs
 			$('tr.row_insert input').attr('disabled',false);
 
-			// Where to insert the new row 
+			// Where to insert the new row
 			let $where_insert = $(this).closest('tr');
 
 			// Set variables


### PR DESCRIPTION
While analysing performance in context of https://github.com/zms-publishing/ZMS/issues/316 with very large meta-attribute-lists, it's redundancy reveals as amplifier of the latency. 
According to the idea of iterative row-inserting of a DOM-clone, now the GUI primarily provides just minimized select-lists with only one option and that is the saved/selected type-value of the meta-attribute. 

### Minimizing redundancy
To get the full-featured select-lists to any meta-attribute the frontend-JS now clones the select-list of the insertable row (last row) into the primarily minimized select-lists. So ZMS iterates the meta-attributes only once and HTML-Code gets much smaller. Thus GUI gets about 3x faster.

[1] _Minimized select-list for any item_
https://github.com/zms-publishing/ZMS/blob/d89fa772e23cccf01b649f02478d17b9e4f77f06/Products/zms/zpt/ZMSMetamodelProvider/manage_metas.zpt#L133-L137

[2]  _Full-featured select-list only once rendered_
https://github.com/zms-publishing/ZMS/blob/d89fa772e23cccf01b649f02478d17b9e4f77f06/Products/zms/zpt/ZMSMetamodelProvider/manage_metas.zpt#L167-L172

_Sccreen image: ZMI for testing with a lot of meta-attributes._
![metas2](https://github.com/user-attachments/assets/f729ba29-88a2-48c9-98fb-f5a49f52b9b0)


**Hint:** some _white-space cleaning_ happend, too; so look at the code with hidden white-space diff:
https://github.com/zms-publishing/ZMS/pull/318/files?diff=split&w=1 