### PR TITLE
Refact headless http request as global var

### DIFF
--- a/Products/zms/_cachemanager.py
+++ b/Products/zms/_cachemanager.py
@@ -17,9 +17,9 @@
 ################################################################################
 
 # Imports.
-from Products.zms import standard
+from Products.zms import _globals
 
-headless_http_request = standard.create_headless_http_request()
+headless_http_request = _globals.headless_http_request
 
 class Buff(object):
   pass

--- a/Products/zms/_exportable.py
+++ b/Products/zms/_exportable.py
@@ -385,7 +385,7 @@ class Exportable(_filtermanager.FilterItem):
     # --------------------------------------------------------------------------
     def toXml(self, REQUEST=None, deep=True, data2hex=False, multilang=True):
       if REQUEST is None:
-        REQUEST = self.get('REQUEST', standard.create_headless_http_request())
+        REQUEST = self.get('REQUEST', _globals.headless_http_request)
       xml = ''
       xml += _xmllib.xml_header()
       xml += _xmllib.getObjToXml( self, REQUEST, deep, base_path='', data2hex=data2hex, multilang=multilang)

--- a/Products/zms/_globals.py
+++ b/Products/zms/_globals.py
@@ -93,6 +93,32 @@ def get_size(v):
   return sys.getsizeof(v)
 
 
+def create_headless_http_request():
+    """
+    Returns a ZPublisher.HTTPRequest object to be used in headless mode.
+    """
+    # Measure time for exection.
+    import logging
+    LOGGER = logging.getLogger('create_headless_http_request')
+    start_time = time.time()
+    # Imports.  
+    from io import BytesIO
+    from ZPublisher.HTTPRequest import HTTPRequest
+    from ZPublisher.HTTPResponse import HTTPResponse
+
+    env = {}
+    env.setdefault('SERVER_NAME', 'nohost')
+    env.setdefault('SERVER_PORT', '80')
+    resp = HTTPResponse(stdout=BytesIO)
+
+    # Print execution time.
+    LOGGER.log(logging.INFO, 'Execution time create_headless_http_request(): %s' % (time.time() - start_time))
+
+    return HTTPRequest(stdin=BytesIO, environ=env, response=resp)
+
+# Set gobal variable headless_http_request.
+headless_http_request = create_headless_http_request()
+
 ################################################################################
 # Define StaticPageTemplateFile.
 ################################################################################

--- a/Products/zms/_objattrs.py
+++ b/Products/zms/_objattrs.py
@@ -36,7 +36,7 @@ from Products.zms import _globals
 #  getobjattrdefault
 # ------------------------------------------------------------------------------
 def getobjattrdefault(obj, obj_attr, lang):
-    request = obj.get('REQUEST', standard.create_headless_http_request())
+    request = obj.get('REQUEST', _globals.headless_http_request)
     v = None
     datatype = obj_attr['datatype_key']
     default = None
@@ -595,7 +595,7 @@ class ObjAttrs(object):
     #  attr({key0:value0,...,keyN:valueN}) -> setObjProperty(key0,value0),...
     # --------------------------------------------------------------------------
     def attr(self, *args, **kwargs):
-      req = self.get('REQUEST', standard.create_headless_http_request())
+      req = self.get('REQUEST', _globals.headless_http_request)
       request = kwargs.get('request',kwargs.get('REQUEST',req))
       if len(args) == 1 and isinstance(args[0], str):
         return self.getObjProperty( args[0], request, kwargs)
@@ -610,7 +610,7 @@ class ObjAttrs(object):
     #  ObjAttrs.evalMetaobjAttr
     # --------------------------------------------------------------------------
     def evalMetaobjAttr(self, *args, **kwargs):
-      request = self.get('REQUEST', standard.create_headless_http_request())
+      request = self.get('REQUEST', _globals.headless_http_request)
       root = self
       key = args[0]
       id = standard.nvl(request.get('ZMS_INSERT'), self.meta_id)

--- a/Products/zms/_pathhandler.py
+++ b/Products/zms/_pathhandler.py
@@ -118,7 +118,7 @@ class PathHandler(object):
     def __bobo_traverse__(self, TraversalRequest, name):
       # If this is the first time this __bob_traverse__ method has been called
       # in handling this traversal request, store the path_to_handle
-      request = self.get('REQUEST', standard.create_headless_http_request())
+      request = self.get('REQUEST', _globals.headless_http_request)
       url = request.get('URL', '')
       zmi = url.find('/manage') >= 0
       
@@ -341,7 +341,7 @@ class PathHandler(object):
                 request.set('lang', lang)
                 return self
 
-        # Products.zms.standard.create_headless_http_request()
+        # Products.zms._globals.headless_http_request
         # has been called above for headless mode
         if request.get('SERVER_NAME') == 'nohost':
           return

--- a/Products/zms/_textformatmanager.py
+++ b/Products/zms/_textformatmanager.py
@@ -29,7 +29,7 @@ class TextFormatObject(object):
   #  Returns section-number.
   # ----------------------------------------------------------------------------
   def getSecNo( self):
-    request = self.get('REQUEST', standard.create_headless_http_request())
+    request = self.get('REQUEST', _globals.headless_http_request)
     sec_no = ''
     #-- [ReqBuff]: Fetch buffered value from Http-Request.
     parentNode = self.getParentNode()

--- a/Products/zms/_zreferableitem.py
+++ b/Products/zms/_zreferableitem.py
@@ -21,6 +21,7 @@ from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 import base64
 import re
 # Product Imports.
+from Products.zms import _globals
 from Products.zms import standard
 
 
@@ -47,7 +48,7 @@ def getInternalLinkDict(self, url):
   reqBuffId = 'getInternalLinkDict.%s'%url
   try: return docelmnt.fetchReqBuff(reqBuffId)
   except: pass
-  request = self.get('REQUEST', standard.create_headless_http_request())
+  request = self.get('REQUEST', _globals.headless_http_request)
   d = {}
   # Params.
   anchor = ''
@@ -88,7 +89,7 @@ def getInternalLinkDict(self, url):
 #  getInternalLinkUrl:
 # ------------------------------------------------------------------------------
 def getInternalLinkUrl(self, url, ob):
-  request = self.get('REQUEST', standard.create_headless_http_request())
+  request = self.get('REQUEST', _globals.headless_http_request)
   if ob is None:
     index_html = './index_%s.html?error_type=NotFound&op=not_found&url=%s'%(request.get('lang', self.getPrimaryLanguage()), str(url))
   else:
@@ -389,7 +390,7 @@ class ZReferableItem(object):
   #  Resolves internal/external links and returns Object.
   # ----------------------------------------------------------------------------
   def getLinkObj(self, url, REQUEST=None):
-    request = self.get('REQUEST', standard.create_headless_http_request())
+    request = self.get('REQUEST', _globals.headless_http_request)
     ob = None
     if isInternalLink(url):
       # Params.

--- a/Products/zms/standard.py
+++ b/Products/zms/standard.py
@@ -860,7 +860,7 @@ def triggerEvent(context, *args, **kwargs):
   """
   Hook for trigger of custom event (if there is one)
   """
-  request = context.get('REQUEST', create_headless_http_request())
+  request = context.get('REQUEST', _globals.headless_http_request)
   l = []
   name = args[0]
   root = context.getRootElement()
@@ -954,22 +954,6 @@ def unescape(s):
       new = chr(int('0x'+s[i+1:i+3], 0))
     s = s.replace(old, new)
   return s
-
-
-def create_headless_http_request():
-    """
-    Returns a ZPublisher.HTTPRequest object to be used in headless mode.
-    """
-    from io import BytesIO
-    from ZPublisher.HTTPRequest import HTTPRequest
-    from ZPublisher.HTTPResponse import HTTPResponse
-
-    env = {}
-    env.setdefault('SERVER_NAME', 'nohost')
-    env.setdefault('SERVER_PORT', '80')
-    resp = HTTPResponse(stdout=BytesIO)
-
-    return HTTPRequest(stdin=BytesIO, environ=env, response=resp)
 
 
 security.declarePublic('http_request')
@@ -2383,7 +2367,7 @@ def dt_tal(context, text, options={}):
   pt = StaticPageTemplateFile(filename='None')
   pt.setText(text)
   pt.setEnv(context, options)
-  request = context.get('REQUEST', create_headless_http_request())
+  request = context.get('REQUEST', _globals.headless_http_request)
   rendered = pt.pt_render(extra_context={'here':context,'request':request})
   return rendered
 

--- a/Products/zms/zmslinkelement.py
+++ b/Products/zms/zmslinkelement.py
@@ -22,6 +22,7 @@ from AccessControl.class_init import InitializeClass
 import json
 import sys
 # Product Imports.
+from Products.zms import _globals
 from Products.zms import rest_api
 from Products.zms import standard
 from Products.zms import zmscontainerobject
@@ -104,7 +105,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  ZMSLinkElement.getEmbedType: 
     # --------------------------------------------------------------------------
     def getEmbedType(self):
-      request = self.get('REQUEST', standard.create_headless_http_request())
+      request = self.get('REQUEST', _globals.headless_http_request)
       embed_type = self.getObjAttrValue( self.getObjAttr( 'attr_type'), request)
       if embed_type in [ 'embed', 'recursive', 'remote']:
         ref_obj = self.getRefObj()
@@ -383,7 +384,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  ZMSLinkElement.isPageElement
     # --------------------------------------------------------------------------
     def isPageElement(self):
-      request = self.get('REQUEST', standard.create_headless_http_request())
+      request = self.get('REQUEST', _globals.headless_http_request)
       rtnVal = False
       if self.getEmbedType() == 'remote':
         return self.getRemoteObj().get('is_page_element',False)
@@ -632,7 +633,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  Returns self or referenced object (if embedded) as ZMSProxyObject
     # --------------------------------------------------------------------------
     def __proxy__(self):
-      req = self.get('REQUEST', standard.create_headless_http_request())
+      req = self.get('REQUEST', _globals.headless_http_request)
       rtn = self
       if req.get( 'ZMS_PROXY', True):
         if req.get( 'URL', '').find( '/manage') < 0 or req.get( 'ZMS_PATH_HANDLER', False):
@@ -651,7 +652,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  ZMSProxyObject.
     # --------------------------------------------------------------------------
     def getProxy(self):
-      req = self.get('REQUEST', standard.create_headless_http_request())
+      req = self.get('REQUEST', _globals.headless_http_request)
       rtn = self
       if req.get( 'ZMS_PROXY', True):
         rtn = req.get( 'ZMS_PROXY_%s'%self.id, self.__proxy__())

--- a/Products/zms/zmsobject.py
+++ b/Products/zms/zmsobject.py
@@ -476,7 +476,7 @@ class ZMSObject(ZMSItem.ZMSItem,
     #  Returns 1 if current object is visible.
     # --------------------------------------------------------------------------
     def isVisible(self, REQUEST):
-      request = self.get('REQUEST', standard.create_headless_http_request())
+      request = self.get('REQUEST', _globals.headless_http_request)
       REQUEST = standard.nvl(REQUEST, request)
       lang = standard.nvl(REQUEST.get('lang'), self.getPrimaryLanguage())
       visible = True


### PR DESCRIPTION
Using a function call for getting a "fake" REQUEST object as a fallback for the headless mode will result in a lot of executions, even in cases that do not need this fallback for a proper work. Especially caching creates a lot of redundant executions slowing down the system.  
So I tried to set that object only once a global variable in the _globals module. As a side effect the it gets private. 
The execution now is limited to startup

_[1] Screen image: massive repetitions of creating fake requests objects_

![image](https://github.com/user-attachments/assets/14b56b49-7c04-4368-b233-4ac2d2573339)

_[2] Screen image: creating fake requests object only once on startup_

![image](https://github.com/user-attachments/assets/0ca80032-d63e-4181-8ab0-fdea6c518cf9)

_[3]  the function now logs its latency and thus indicates when it is executed_

```py
def create_headless_http_request():
    """
    Returns a ZPublisher.HTTPRequest object to be used in headless mode.
    """
    # Measure time for exection.
    import logging
    LOGGER = logging.getLogger('create_headless_http_request')
    start_time = time.time()
    # Imports.  
    from io import BytesIO
    from ZPublisher.HTTPRequest import HTTPRequest
    from ZPublisher.HTTPResponse import HTTPResponse

    env = {}
    env.setdefault('SERVER_NAME', 'nohost')
    env.setdefault('SERVER_PORT', '80')
    resp = HTTPResponse(stdout=BytesIO)

    # Print execution time.
    LOGGER.log(logging.INFO, 'Execution time create_headless_http_request(): %s' % (time.time() - start_time))

    return HTTPRequest(stdin=BytesIO, environ=env, response=resp)
```

@zmsdev:
The cache functions accept als `REQUEST`-param that is actually not processed by the function itself:
https://github.com/zms-publishing/ZMS/blob/fb26173e1389deac0ea7f9eee64949d608467982/Products/zms/_cachemanager.py#L42-L55
Instead `request` is drawn from self, even not as a fallkack. Question: Does the additional param compensate false (e.g. back-compatible) params?