### PR TITLE
feat(zmi): add optional macro for custom menu in header

### DIFF
--- a/Products/zms/zpt/common/zmi_body_header.zpt
+++ b/Products/zms/zpt/common/zmi_body_header.zpt
@@ -119,6 +119,10 @@
 				</div>
 			</li><!-- .dropdown -->
 			<tal:block tal:condition="python: here.getTrashcan().getId()!=here.getId()">
+				<tal:block
+				  tal:condition="python:len([x for x in zmscontext.getAbsoluteHome().objectValues() if x.id == 'zmi_body_header_custom'])"
+					metal:use-macro="container/zmi_body_header_custom/macros/menus">
+				</tal:block>
 				<li class="view_preview">
 					<a target="_blank" tal:attributes="href python:'preview_html?lang=%s&preview=preview'%request['lang']">
 						<i class="far fa-eye"></i>


### PR DESCRIPTION
By using an optional page template which contains a macro called `menus` we are able to flexibly extend the menus in the ZMI header without having to alter the core in future.

We've also tried to append custom menus dynamically with javascript, but that approach resulted in a blinking header menu bar on every page change.