### PR TITLE
Reverted headless mode

### DIFF
--- a/Products/zms/_blobfields.py
+++ b/Products/zms/_blobfields.py
@@ -524,15 +524,12 @@ class MyBlob(object):
     """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
     MyBlob._createCopy:
     """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-    def _createCopy(self, aq_parent, key, lang=None):
+    def _createCopy(self, aq_parent, key):
       value = self._getCopy()
       value.is_blob = True
       value.aq_parent = aq_parent
       value.key = key
-      if hasattr(aq_parent, 'REQUEST'):
-        value.lang = aq_parent.REQUEST.get( 'lang')
-      elif lang is not None:
-        value.lang = lang
+      value.lang = aq_parent.REQUEST.get( 'lang')
       return value
 
 

--- a/Products/zms/_cachemanager.py
+++ b/Products/zms/_cachemanager.py
@@ -19,8 +19,6 @@
 # Imports.
 from Products.zms import standard
 
-headless_http_request = standard.create_headless_http_request()
-
 class Buff(object):
   pass
 
@@ -45,7 +43,7 @@ class ReqBuff(object):
     #  Clear buffered values from Http-Request.
     # --------------------------------------------------------------------------
     def clearReqBuff(self, prefix='', REQUEST=None):
-      request = self.get('REQUEST', headless_http_request )
+      request = self.get('REQUEST', standard.create_headless_http_request())
       buff = request.get('__buff__', Buff())
       reqBuffId = self.getReqBuffId(prefix)
       if len(prefix) > 0:
@@ -62,7 +60,7 @@ class ReqBuff(object):
     #  @throws Exception
     # --------------------------------------------------------------------------
     def fetchReqBuff(self, key, REQUEST=None):
-      request = self.get('REQUEST', headless_http_request )
+      request = self.get('REQUEST', standard.create_headless_http_request())
       buff = request['__buff__']
       reqBuffId = self.getReqBuffId(key)
       return getattr(buff, reqBuffId)
@@ -73,7 +71,7 @@ class ReqBuff(object):
     #  Returns value and stores it in buffer of Http-Request.
     # --------------------------------------------------------------------------
     def storeReqBuff(self, key, value, REQUEST=None):
-      request = self.get('REQUEST', headless_http_request )
+      request = self.get('REQUEST', standard.create_headless_http_request())
       buff = request.get('__buff__', None)
       if buff is None:
         buff = Buff()

--- a/Products/zms/_cachemanager.py
+++ b/Products/zms/_cachemanager.py
@@ -16,9 +16,6 @@
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 ################################################################################
 
-# Imports.
-from Products.zms import standard
-
 class Buff(object):
   pass
 
@@ -43,7 +40,7 @@ class ReqBuff(object):
     #  Clear buffered values from Http-Request.
     # --------------------------------------------------------------------------
     def clearReqBuff(self, prefix='', REQUEST=None):
-      request = self.get('REQUEST', standard.create_headless_http_request())
+      request = self.REQUEST
       buff = request.get('__buff__', Buff())
       reqBuffId = self.getReqBuffId(prefix)
       if len(prefix) > 0:
@@ -60,7 +57,7 @@ class ReqBuff(object):
     #  @throws Exception
     # --------------------------------------------------------------------------
     def fetchReqBuff(self, key, REQUEST=None):
-      request = self.get('REQUEST', standard.create_headless_http_request())
+      request = self.REQUEST
       buff = request['__buff__']
       reqBuffId = self.getReqBuffId(key)
       return getattr(buff, reqBuffId)
@@ -71,7 +68,7 @@ class ReqBuff(object):
     #  Returns value and stores it in buffer of Http-Request.
     # --------------------------------------------------------------------------
     def storeReqBuff(self, key, value, REQUEST=None):
-      request = self.get('REQUEST', standard.create_headless_http_request())
+      request = self.REQUEST
       buff = request.get('__buff__', None)
       if buff is None:
         buff = Buff()

--- a/Products/zms/_cachemanager.py
+++ b/Products/zms/_cachemanager.py
@@ -17,9 +17,9 @@
 ################################################################################
 
 # Imports.
-from Products.zms import _globals
+from Products.zms import standard
 
-headless_http_request = _globals.headless_http_request
+headless_http_request = standard.create_headless_http_request()
 
 class Buff(object):
   pass

--- a/Products/zms/_confmanager.py
+++ b/Products/zms/_confmanager.py
@@ -1122,6 +1122,7 @@ __REGISTRY__ = None
 def getRegistry():
     global __REGISTRY__
     if __REGISTRY__ is None:
+        print("__REGISTRY__['confdict']",__REGISTRY__)
         __REGISTRY__ = {}
         try:
           __REGISTRY__['confdict'] = ConfDict.get()

--- a/Products/zms/_exportable.py
+++ b/Products/zms/_exportable.py
@@ -385,7 +385,7 @@ class Exportable(_filtermanager.FilterItem):
     # --------------------------------------------------------------------------
     def toXml(self, REQUEST=None, deep=True, data2hex=False, multilang=True):
       if REQUEST is None:
-        REQUEST = self.get('REQUEST', _globals.headless_http_request)
+        REQUEST = self.get('REQUEST', standard.create_headless_http_request())
       xml = ''
       xml += _xmllib.xml_header()
       xml += _xmllib.getObjToXml( self, REQUEST, deep, base_path='', data2hex=data2hex, multilang=multilang)

--- a/Products/zms/_exportable.py
+++ b/Products/zms/_exportable.py
@@ -383,9 +383,7 @@ class Exportable(_filtermanager.FilterItem):
     # --------------------------------------------------------------------------
     #  Exportable.toXml:
     # --------------------------------------------------------------------------
-    def toXml(self, REQUEST=None, deep=True, data2hex=False, multilang=True):
-      if REQUEST is None:
-        REQUEST = self.get('REQUEST', standard.create_headless_http_request())
+    def toXml(self, REQUEST, deep=True, data2hex=False, multilang=True):
       xml = ''
       xml += _xmllib.xml_header()
       xml += _xmllib.getObjToXml( self, REQUEST, deep, base_path='', data2hex=data2hex, multilang=multilang)

--- a/Products/zms/_globals.py
+++ b/Products/zms/_globals.py
@@ -93,32 +93,6 @@ def get_size(v):
   return sys.getsizeof(v)
 
 
-def create_headless_http_request():
-    """
-    Returns a ZPublisher.HTTPRequest object to be used in headless mode.
-    """
-    # Measure time for exection.
-    import logging
-    LOGGER = logging.getLogger('create_headless_http_request')
-    start_time = time.time()
-    # Imports.  
-    from io import BytesIO
-    from ZPublisher.HTTPRequest import HTTPRequest
-    from ZPublisher.HTTPResponse import HTTPResponse
-
-    env = {}
-    env.setdefault('SERVER_NAME', 'nohost')
-    env.setdefault('SERVER_PORT', '80')
-    resp = HTTPResponse(stdout=BytesIO)
-
-    # Print execution time.
-    LOGGER.log(logging.INFO, 'Execution time create_headless_http_request(): %s' % (time.time() - start_time))
-
-    return HTTPRequest(stdin=BytesIO, environ=env, response=resp)
-
-# Set gobal variable headless_http_request.
-headless_http_request = create_headless_http_request()
-
 ################################################################################
 # Define StaticPageTemplateFile.
 ################################################################################

--- a/Products/zms/_objattrs.py
+++ b/Products/zms/_objattrs.py
@@ -36,7 +36,7 @@ from Products.zms import _globals
 #  getobjattrdefault
 # ------------------------------------------------------------------------------
 def getobjattrdefault(obj, obj_attr, lang):
-    request = obj.get('REQUEST', _globals.headless_http_request)
+    request = obj.get('REQUEST', standard.create_headless_http_request())
     v = None
     datatype = obj_attr['datatype_key']
     default = None
@@ -595,7 +595,7 @@ class ObjAttrs(object):
     #  attr({key0:value0,...,keyN:valueN}) -> setObjProperty(key0,value0),...
     # --------------------------------------------------------------------------
     def attr(self, *args, **kwargs):
-      req = self.get('REQUEST', _globals.headless_http_request)
+      req = self.get('REQUEST', standard.create_headless_http_request())
       request = kwargs.get('request',kwargs.get('REQUEST',req))
       if len(args) == 1 and isinstance(args[0], str):
         return self.getObjProperty( args[0], request, kwargs)
@@ -610,7 +610,7 @@ class ObjAttrs(object):
     #  ObjAttrs.evalMetaobjAttr
     # --------------------------------------------------------------------------
     def evalMetaobjAttr(self, *args, **kwargs):
-      request = self.get('REQUEST', _globals.headless_http_request)
+      request = self.get('REQUEST', standard.create_headless_http_request())
       root = self
       key = args[0]
       id = standard.nvl(request.get('ZMS_INSERT'), self.meta_id)

--- a/Products/zms/_objattrs.py
+++ b/Products/zms/_objattrs.py
@@ -32,18 +32,18 @@ from Products.zms import zopeutil
 from Products.zms import _blobfields
 from Products.zms import _globals
 
+
 # ------------------------------------------------------------------------------
 #  getobjattrdefault
 # ------------------------------------------------------------------------------
 def getobjattrdefault(obj, obj_attr, lang):
-    request = obj.get('REQUEST', standard.create_headless_http_request())
     v = None
     datatype = obj_attr['datatype_key']
     default = None
     if datatype in range(len(_globals.datatype_map)):
       default = obj_attr.get('default',_globals.datatype_map[datatype][1])
     # Default inactive in untranslated languages.
-    if obj_attr['id'] == 'active' and len(obj.getLangIds()) > 1 and not obj.isTranslated(lang,request):
+    if obj_attr['id'] == 'active' and len(obj.getLangIds()) > 1 and not obj.isTranslated(lang,obj.REQUEST):
         default = 0
     if default is not None:
       if datatype in _globals.DT_DATETIMES and default == '{now}':
@@ -467,7 +467,7 @@ class ObjAttrs(object):
         if isinstance(value,str):
           value = None
         elif value is not None:
-          value = value._createCopy( self, obj_attr['id'], lang)
+          value = value._createCopy( self, obj_attr['id'])
           value.lang = lang
       
       #-- DateTime-Fields.
@@ -595,8 +595,7 @@ class ObjAttrs(object):
     #  attr({key0:value0,...,keyN:valueN}) -> setObjProperty(key0,value0),...
     # --------------------------------------------------------------------------
     def attr(self, *args, **kwargs):
-      req = self.get('REQUEST', standard.create_headless_http_request())
-      request = kwargs.get('request',kwargs.get('REQUEST',req))
+      request = kwargs.get('request',kwargs.get('REQUEST',self.REQUEST))
       if len(args) == 1 and isinstance(args[0], str):
         return self.getObjProperty( args[0], request, kwargs)
       elif len(args) == 2:
@@ -610,8 +609,8 @@ class ObjAttrs(object):
     #  ObjAttrs.evalMetaobjAttr
     # --------------------------------------------------------------------------
     def evalMetaobjAttr(self, *args, **kwargs):
-      request = self.get('REQUEST', standard.create_headless_http_request())
       root = self
+      request = self.REQUEST
       key = args[0]
       id = standard.nvl(request.get('ZMS_INSERT'), self.meta_id)
       if key.find('.')>0:
@@ -694,7 +693,7 @@ class ObjAttrs(object):
                 value = tuple(value[:8]) + (0,)
               dt = datetime.datetime.fromtimestamp(time.mktime(value) - (dst * 3600))
               b = b and now > dt
-              if dt > now and self.get('REQUEST') and self.REQUEST.get('ZMS_CACHE_EXPIRE_DATETIME', dt) >= dt:
+              if dt > now and self.REQUEST.get('ZMS_CACHE_EXPIRE_DATETIME', dt) >= dt:
                 self.REQUEST.set('ZMS_CACHE_EXPIRE_DATETIME',dt)
           # End time.
           elif key == 'attr_active_end':
@@ -704,7 +703,7 @@ class ObjAttrs(object):
                 value = tuple(value[:8]) + (0,)
               dt = datetime.datetime.fromtimestamp(time.mktime(value) - (dst * 3600))
               b = b and dt > now
-              if dt > now and self.get('REQUEST') and self.REQUEST.get('ZMS_CACHE_EXPIRE_DATETIME', dt) >= dt:
+              if dt > now and self.REQUEST.get('ZMS_CACHE_EXPIRE_DATETIME', dt) >= dt:
                 self.REQUEST.set('ZMS_CACHE_EXPIRE_DATETIME',dt)
           if not b: break
       return b

--- a/Products/zms/_pathhandler.py
+++ b/Products/zms/_pathhandler.py
@@ -26,6 +26,7 @@ from Products.zms import _blobfields
 from Products.zms import _fileutil
 from Products.zms import _globals
 
+
 # ------------------------------------------------------------------------------
 #  _pathhandler.validateId:
 #
@@ -118,7 +119,7 @@ class PathHandler(object):
     def __bobo_traverse__(self, TraversalRequest, name):
       # If this is the first time this __bob_traverse__ method has been called
       # in handling this traversal request, store the path_to_handle
-      request = self.get('REQUEST', standard.create_headless_http_request())
+      request = self.REQUEST
       url = request.get('URL', '')
       zmi = url.find('/manage') >= 0
       
@@ -141,7 +142,7 @@ class PathHandler(object):
               TraversalRequest[ 'path_to_handle'].insert( i-1, path_physical[ i])
       
       # Set language.
-      lang = request.get( 'lang', self.getPrimaryLanguage())
+      lang = request.get( 'lang')
       if lang is None:
         lang = self.getLanguageFromName(TraversalRequest['path_to_handle'][-1])
       if lang is not None:
@@ -340,13 +341,8 @@ class PathHandler(object):
                 request.set('ZMS_EXT', zms_ext)
                 request.set('lang', lang)
                 return self
-
-        # Products.zms.standard.create_headless_http_request()
-        # has been called above for headless mode
-        if request.get('SERVER_NAME') == 'nohost':
-          return
-
-        # If there's no more names left to handle, return the path handling
+        
+        # If there's no more names left to handle, return the path handling 
         # method to the traversal machinery so it gets called next
         standard.raiseError('NotFound',''.join([x+'/' for x in TraversalRequest['path_to_handle']]))
 

--- a/Products/zms/_pathhandler.py
+++ b/Products/zms/_pathhandler.py
@@ -118,7 +118,7 @@ class PathHandler(object):
     def __bobo_traverse__(self, TraversalRequest, name):
       # If this is the first time this __bob_traverse__ method has been called
       # in handling this traversal request, store the path_to_handle
-      request = self.get('REQUEST', _globals.headless_http_request)
+      request = self.get('REQUEST', standard.create_headless_http_request())
       url = request.get('URL', '')
       zmi = url.find('/manage') >= 0
       
@@ -341,7 +341,7 @@ class PathHandler(object):
                 request.set('lang', lang)
                 return self
 
-        # Products.zms._globals.headless_http_request
+        # Products.zms.standard.create_headless_http_request()
         # has been called above for headless mode
         if request.get('SERVER_NAME') == 'nohost':
           return

--- a/Products/zms/_textformatmanager.py
+++ b/Products/zms/_textformatmanager.py
@@ -29,7 +29,7 @@ class TextFormatObject(object):
   #  Returns section-number.
   # ----------------------------------------------------------------------------
   def getSecNo( self):
-    request = self.get('REQUEST', _globals.headless_http_request)
+    request = self.get('REQUEST', standard.create_headless_http_request())
     sec_no = ''
     #-- [ReqBuff]: Fetch buffered value from Http-Request.
     parentNode = self.getParentNode()

--- a/Products/zms/_textformatmanager.py
+++ b/Products/zms/_textformatmanager.py
@@ -29,7 +29,6 @@ class TextFormatObject(object):
   #  Returns section-number.
   # ----------------------------------------------------------------------------
   def getSecNo( self):
-    request = self.get('REQUEST', standard.create_headless_http_request())
     sec_no = ''
     #-- [ReqBuff]: Fetch buffered value from Http-Request.
     parentNode = self.getParentNode()
@@ -43,11 +42,11 @@ class TextFormatObject(object):
         sec_no = parentNode.fetchReqBuff( '%s_%s'%(reqBuffId, self.id))
     except:
       levelnfc = parentNode.attr('levelnfc')
-      parentNode.storeReqBuff( '%s_levelnfc'%reqBuffId, levelnfc, request)
+      parentNode.storeReqBuff( '%s_levelnfc'%reqBuffId, levelnfc, self.REQUEST)
       if levelnfc is not None and len(levelnfc) > 0:
         parent_no = parentNode.getSecNo()
         sectionizer = _globals.MySectionizer(levelnfc)
-        siblings = parentNode.filteredChildNodes( request)
+        siblings = parentNode.filteredChildNodes( self.REQUEST)
         for sibling in siblings:
           curr_no = ''
           level = 0
@@ -63,7 +62,7 @@ class TextFormatObject(object):
             if self == sibling:
               sec_no = curr_no
           #-- [ReqBuff]: Store value in buffer of Http-Request.
-          parentNode.storeReqBuff( '%s_%s'%(reqBuffId, sibling.id), curr_no, request)
+          parentNode.storeReqBuff( '%s_%s'%(reqBuffId, sibling.id), curr_no, self.REQUEST)
     #-- [ReqBuff]: Return value.
     return sec_no
 

--- a/Products/zms/_zreferableitem.py
+++ b/Products/zms/_zreferableitem.py
@@ -23,7 +23,6 @@ import re
 # Product Imports.
 from Products.zms import standard
 
-
 # ------------------------------------------------------------------------------
 #  isMailLink:
 # ------------------------------------------------------------------------------
@@ -47,7 +46,7 @@ def getInternalLinkDict(self, url):
   reqBuffId = 'getInternalLinkDict.%s'%url
   try: return docelmnt.fetchReqBuff(reqBuffId)
   except: pass
-  request = self.get('REQUEST', standard.create_headless_http_request())
+  request = self.REQUEST
   d = {}
   # Params.
   anchor = ''
@@ -88,7 +87,7 @@ def getInternalLinkDict(self, url):
 #  getInternalLinkUrl:
 # ------------------------------------------------------------------------------
 def getInternalLinkUrl(self, url, ob):
-  request = self.get('REQUEST', standard.create_headless_http_request())
+  request = self.REQUEST
   if ob is None:
     index_html = './index_%s.html?error_type=NotFound&op=not_found&url=%s'%(request.get('lang', self.getPrimaryLanguage()), str(url))
   else:
@@ -389,7 +388,6 @@ class ZReferableItem(object):
   #  Resolves internal/external links and returns Object.
   # ----------------------------------------------------------------------------
   def getLinkObj(self, url, REQUEST=None):
-    request = self.get('REQUEST', standard.create_headless_http_request())
     ob = None
     if isInternalLink(url):
       # Params.
@@ -427,6 +425,7 @@ class ZReferableItem(object):
       # Prepare request
       ids = self.getPhysicalPath()
       if ob is not None and ob.id not in ids:
+        request = self.REQUEST
         ob.set_request_context(request, ref_params)
     return ob
 

--- a/Products/zms/_zreferableitem.py
+++ b/Products/zms/_zreferableitem.py
@@ -21,7 +21,6 @@ from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 import base64
 import re
 # Product Imports.
-from Products.zms import _globals
 from Products.zms import standard
 
 
@@ -48,7 +47,7 @@ def getInternalLinkDict(self, url):
   reqBuffId = 'getInternalLinkDict.%s'%url
   try: return docelmnt.fetchReqBuff(reqBuffId)
   except: pass
-  request = self.get('REQUEST', _globals.headless_http_request)
+  request = self.get('REQUEST', standard.create_headless_http_request())
   d = {}
   # Params.
   anchor = ''
@@ -89,7 +88,7 @@ def getInternalLinkDict(self, url):
 #  getInternalLinkUrl:
 # ------------------------------------------------------------------------------
 def getInternalLinkUrl(self, url, ob):
-  request = self.get('REQUEST', _globals.headless_http_request)
+  request = self.get('REQUEST', standard.create_headless_http_request())
   if ob is None:
     index_html = './index_%s.html?error_type=NotFound&op=not_found&url=%s'%(request.get('lang', self.getPrimaryLanguage()), str(url))
   else:
@@ -390,7 +389,7 @@ class ZReferableItem(object):
   #  Resolves internal/external links and returns Object.
   # ----------------------------------------------------------------------------
   def getLinkObj(self, url, REQUEST=None):
-    request = self.get('REQUEST', _globals.headless_http_request)
+    request = self.get('REQUEST', standard.create_headless_http_request())
     ob = None
     if isInternalLink(url):
       # Params.

--- a/Products/zms/standard.py
+++ b/Products/zms/standard.py
@@ -860,7 +860,7 @@ def triggerEvent(context, *args, **kwargs):
   """
   Hook for trigger of custom event (if there is one)
   """
-  request = context.get('REQUEST', _globals.headless_http_request)
+  request = context.get('REQUEST', create_headless_http_request())
   l = []
   name = args[0]
   root = context.getRootElement()
@@ -954,6 +954,22 @@ def unescape(s):
       new = chr(int('0x'+s[i+1:i+3], 0))
     s = s.replace(old, new)
   return s
+
+
+def create_headless_http_request():
+    """
+    Returns a ZPublisher.HTTPRequest object to be used in headless mode.
+    """
+    from io import BytesIO
+    from ZPublisher.HTTPRequest import HTTPRequest
+    from ZPublisher.HTTPResponse import HTTPResponse
+
+    env = {}
+    env.setdefault('SERVER_NAME', 'nohost')
+    env.setdefault('SERVER_PORT', '80')
+    resp = HTTPResponse(stdout=BytesIO)
+
+    return HTTPRequest(stdin=BytesIO, environ=env, response=resp)
 
 
 security.declarePublic('http_request')
@@ -2367,7 +2383,7 @@ def dt_tal(context, text, options={}):
   pt = StaticPageTemplateFile(filename='None')
   pt.setText(text)
   pt.setEnv(context, options)
-  request = context.get('REQUEST', _globals.headless_http_request)
+  request = context.get('REQUEST', create_headless_http_request())
   rendered = pt.pt_render(extra_context={'here':context,'request':request})
   return rendered
 

--- a/Products/zms/standard.py
+++ b/Products/zms/standard.py
@@ -860,7 +860,6 @@ def triggerEvent(context, *args, **kwargs):
   """
   Hook for trigger of custom event (if there is one)
   """
-  request = context.get('REQUEST', create_headless_http_request())
   l = []
   name = args[0]
   root = context.getRootElement()
@@ -896,7 +895,7 @@ def triggerEvent(context, *args, **kwargs):
     # Process zope-triggers.
     m = getattr(context, name, None)
     if m is not None:
-      m(context=context, REQUEST=request)
+      m(context=context, REQUEST=context.REQUEST)
 
   return l
 
@@ -954,22 +953,6 @@ def unescape(s):
       new = chr(int('0x'+s[i+1:i+3], 0))
     s = s.replace(old, new)
   return s
-
-
-def create_headless_http_request():
-    """
-    Returns a ZPublisher.HTTPRequest object to be used in headless mode.
-    """
-    from io import BytesIO
-    from ZPublisher.HTTPRequest import HTTPRequest
-    from ZPublisher.HTTPResponse import HTTPResponse
-
-    env = {}
-    env.setdefault('SERVER_NAME', 'nohost')
-    env.setdefault('SERVER_PORT', '80')
-    resp = HTTPResponse(stdout=BytesIO)
-
-    return HTTPRequest(stdin=BytesIO, environ=env, response=resp)
 
 
 security.declarePublic('http_request')
@@ -2383,7 +2366,7 @@ def dt_tal(context, text, options={}):
   pt = StaticPageTemplateFile(filename='None')
   pt.setText(text)
   pt.setEnv(context, options)
-  request = context.get('REQUEST', create_headless_http_request())
+  request = context.REQUEST
   rendered = pt.pt_render(extra_context={'here':context,'request':request})
   return rendered
 

--- a/Products/zms/zmslinkelement.py
+++ b/Products/zms/zmslinkelement.py
@@ -30,7 +30,6 @@ from Products.zms import zmsobject
 from Products.zms import zmsproxyobject
 from Products.zms import zmslinkelement
 
-
 """
 ################################################################################
 # class ConstraintViolation(Exception):
@@ -104,8 +103,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  ZMSLinkElement.getEmbedType: 
     # --------------------------------------------------------------------------
     def getEmbedType(self):
-      request = self.get('REQUEST', standard.create_headless_http_request())
-      embed_type = self.getObjAttrValue( self.getObjAttr( 'attr_type'), request)
+      embed_type = self.getObjAttrValue( self.getObjAttr( 'attr_type'), self.REQUEST)
       if embed_type in [ 'embed', 'recursive', 'remote']:
         ref_obj = self.getRefObj()
         if ref_obj is not None and ref_obj.isAncestor( self):
@@ -382,8 +380,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     # --------------------------------------------------------------------------
     #  ZMSLinkElement.isPageElement
     # --------------------------------------------------------------------------
-    def isPageElement(self):
-      request = self.get('REQUEST', standard.create_headless_http_request())
+    def isPageElement(self): 
       rtnVal = False
       if self.getEmbedType() == 'remote':
         return self.getRemoteObj().get('is_page_element',False)
@@ -394,7 +391,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
             rtnVal = rtnVal or ref_obj.isPageElement()
           else:
             rtnVal = rtnVal or True
-        elif self.getObjProperty('align', request) not in ['', 'NONE']:
+        elif self.getObjProperty('align', self.REQUEST) not in ['', 'NONE']:
           rtnVal = rtnVal or True
       return rtnVal
 
@@ -632,8 +629,8 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  Returns self or referenced object (if embedded) as ZMSProxyObject
     # --------------------------------------------------------------------------
     def __proxy__(self):
-      req = self.get('REQUEST', standard.create_headless_http_request())
       rtn = self
+      req = self.REQUEST
       if req.get( 'ZMS_PROXY', True):
         if req.get( 'URL', '').find( '/manage') < 0 or req.get( 'ZMS_PATH_HANDLER', False):
           if self.isEmbeddedRecursive():
@@ -651,8 +648,8 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  ZMSProxyObject.
     # --------------------------------------------------------------------------
     def getProxy(self):
-      req = self.get('REQUEST', standard.create_headless_http_request())
       rtn = self
+      req = self.REQUEST
       if req.get( 'ZMS_PROXY', True):
         rtn = req.get( 'ZMS_PROXY_%s'%self.id, self.__proxy__())
       return rtn

--- a/Products/zms/zmslinkelement.py
+++ b/Products/zms/zmslinkelement.py
@@ -22,7 +22,6 @@ from AccessControl.class_init import InitializeClass
 import json
 import sys
 # Product Imports.
-from Products.zms import _globals
 from Products.zms import rest_api
 from Products.zms import standard
 from Products.zms import zmscontainerobject
@@ -105,7 +104,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  ZMSLinkElement.getEmbedType: 
     # --------------------------------------------------------------------------
     def getEmbedType(self):
-      request = self.get('REQUEST', _globals.headless_http_request)
+      request = self.get('REQUEST', standard.create_headless_http_request())
       embed_type = self.getObjAttrValue( self.getObjAttr( 'attr_type'), request)
       if embed_type in [ 'embed', 'recursive', 'remote']:
         ref_obj = self.getRefObj()
@@ -384,7 +383,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  ZMSLinkElement.isPageElement
     # --------------------------------------------------------------------------
     def isPageElement(self):
-      request = self.get('REQUEST', _globals.headless_http_request)
+      request = self.get('REQUEST', standard.create_headless_http_request())
       rtnVal = False
       if self.getEmbedType() == 'remote':
         return self.getRemoteObj().get('is_page_element',False)
@@ -633,7 +632,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  Returns self or referenced object (if embedded) as ZMSProxyObject
     # --------------------------------------------------------------------------
     def __proxy__(self):
-      req = self.get('REQUEST', _globals.headless_http_request)
+      req = self.get('REQUEST', standard.create_headless_http_request())
       rtn = self
       if req.get( 'ZMS_PROXY', True):
         if req.get( 'URL', '').find( '/manage') < 0 or req.get( 'ZMS_PATH_HANDLER', False):
@@ -652,7 +651,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  ZMSProxyObject.
     # --------------------------------------------------------------------------
     def getProxy(self):
-      req = self.get('REQUEST', _globals.headless_http_request)
+      req = self.get('REQUEST', standard.create_headless_http_request())
       rtn = self
       if req.get( 'ZMS_PROXY', True):
         rtn = req.get( 'ZMS_PROXY_%s'%self.id, self.__proxy__())

--- a/Products/zms/zmsobject.py
+++ b/Products/zms/zmsobject.py
@@ -48,7 +48,6 @@ from Products.zms import ZMSWorkflowItem
 from Products.zms import standard
 from Products.zms import zopeutil
 
-
 __all__= ['ZMSObject']
 
 
@@ -476,8 +475,7 @@ class ZMSObject(ZMSItem.ZMSItem,
     #  Returns 1 if current object is visible.
     # --------------------------------------------------------------------------
     def isVisible(self, REQUEST):
-      request = self.get('REQUEST', standard.create_headless_http_request())
-      REQUEST = standard.nvl(REQUEST, request)
+      REQUEST = standard.nvl(REQUEST, self.REQUEST)
       lang = standard.nvl(REQUEST.get('lang'), self.getPrimaryLanguage())
       visible = True
       visible = visible and self.isTranslated(lang, REQUEST) # Object is translated.

--- a/Products/zms/zmsobject.py
+++ b/Products/zms/zmsobject.py
@@ -476,7 +476,7 @@ class ZMSObject(ZMSItem.ZMSItem,
     #  Returns 1 if current object is visible.
     # --------------------------------------------------------------------------
     def isVisible(self, REQUEST):
-      request = self.get('REQUEST', _globals.headless_http_request)
+      request = self.get('REQUEST', standard.create_headless_http_request())
       REQUEST = standard.nvl(REQUEST, request)
       lang = standard.nvl(REQUEST.get('lang'), self.getPrimaryLanguage())
       visible = True

--- a/Products/zms/zmsobject.py
+++ b/Products/zms/zmsobject.py
@@ -923,7 +923,7 @@ class ZMSObject(ZMSItem.ZMSItem,
         abs_url = args[1]['abs_url']
         forced = args[1]['forced']
         if context.getConfProperty('ZMSObject.getAbsoluteUrlInContext', False):
-          if context.getHome() != context.getHome():
+          if context.getHome() != self.getHome():
             protocol = context.getConfProperty('ASP.protocol', 'http')
             domain = context.getConfProperty('ASP.ip_or_domain', None)
             if domain:

--- a/Products/zms/zmsobject.py
+++ b/Products/zms/zmsobject.py
@@ -925,7 +925,7 @@ class ZMSObject(ZMSItem.ZMSItem,
         abs_url = args[1]['abs_url']
         forced = args[1]['forced']
         if context.getConfProperty('ZMSObject.getAbsoluteUrlInContext', False):
-          if context.getHome() != self.getHome():
+          if context.getHome() != context.getHome():
             protocol = context.getConfProperty('ASP.protocol', 'http')
             domain = context.getConfProperty('ASP.ip_or_domain', None)
             if domain:


### PR DESCRIPTION
Superseded by
- https://github.com/zms-publishing/ZMS/pull/322

---

This PR reverts the changes regarding headless mode.

The approach from [`unibe/headless`](https://github.com/zms-publishing/ZMS/compare/main...unibe/headless) branch is not compatible with the normal headful mode.

The replacement for `request = self.REQUEST` using [`self.get('REQUEST')`](https://docs.python.org/3/library/stdtypes.html#dict.get) is incorrect because it is NOT the same as [`getattr(self, 'REQUEST')`](https://docs.python.org/3/library/functions.html#getattr). `self.get('REQUEST')` returns always `None` and triggers the fallback in normal headful mode which is intended for headless mode only.

We tried to solve this in https://github.com/zms-publishing/ZMS/compare/main...fix-headless-mode - but faced new problems on integration.

So we are discarding this approach and will try to inject a fake/mock `REQUEST` object through the `zms-fastapi`.

Refs
- https://github.com/zms-publishing/ZMS/pull/312
- https://github.com/zms-publishing/ZMS/issues/316
- https://github.com/zms-publishing/ZMS/pull/317
- https://github.com/zms-publishing/ZMS/pull/319