### PR TITLE
Fix headless mode using zope.globalrequest.getRequest()

### DIFF
--- a/Products/zms/_cachemanager.py
+++ b/Products/zms/_cachemanager.py
@@ -43,7 +43,7 @@ class ReqBuff(object):
     #  Clear buffered values from Http-Request.
     # --------------------------------------------------------------------------
     def clearReqBuff(self, prefix='', REQUEST=None):
-      request = self.get('REQUEST', standard.create_headless_http_request())
+      request = getattr(self, 'REQUEST', standard.create_headless_http_request())
       buff = request.get('__buff__', Buff())
       reqBuffId = self.getReqBuffId(prefix)
       if len(prefix) > 0:
@@ -60,7 +60,7 @@ class ReqBuff(object):
     #  @throws Exception
     # --------------------------------------------------------------------------
     def fetchReqBuff(self, key, REQUEST=None):
-      request = self.get('REQUEST', standard.create_headless_http_request())
+      request = getattr(self, 'REQUEST', standard.create_headless_http_request())
       buff = request['__buff__']
       reqBuffId = self.getReqBuffId(key)
       return getattr(buff, reqBuffId)
@@ -71,7 +71,7 @@ class ReqBuff(object):
     #  Returns value and stores it in buffer of Http-Request.
     # --------------------------------------------------------------------------
     def storeReqBuff(self, key, value, REQUEST=None):
-      request = self.get('REQUEST', standard.create_headless_http_request())
+      request = getattr(self, 'REQUEST', standard.create_headless_http_request())
       buff = request.get('__buff__', None)
       if buff is None:
         buff = Buff()

--- a/Products/zms/_cachemanager.py
+++ b/Products/zms/_cachemanager.py
@@ -19,8 +19,6 @@
 # Imports.
 from Products.zms import standard
 
-headless_http_request = standard.create_headless_http_request()
-
 class Buff(object):
   pass
 
@@ -45,7 +43,7 @@ class ReqBuff(object):
     #  Clear buffered values from Http-Request.
     # --------------------------------------------------------------------------
     def clearReqBuff(self, prefix='', REQUEST=None):
-      request = self.get('REQUEST', headless_http_request )
+      request = self.get('REQUEST', standard.create_headless_http_request())
       buff = request.get('__buff__', Buff())
       reqBuffId = self.getReqBuffId(prefix)
       if len(prefix) > 0:
@@ -62,7 +60,7 @@ class ReqBuff(object):
     #  @throws Exception
     # --------------------------------------------------------------------------
     def fetchReqBuff(self, key, REQUEST=None):
-      request = self.get('REQUEST', headless_http_request )
+      request = self.get('REQUEST', standard.create_headless_http_request())
       buff = request['__buff__']
       reqBuffId = self.getReqBuffId(key)
       return getattr(buff, reqBuffId)
@@ -73,7 +71,7 @@ class ReqBuff(object):
     #  Returns value and stores it in buffer of Http-Request.
     # --------------------------------------------------------------------------
     def storeReqBuff(self, key, value, REQUEST=None):
-      request = self.get('REQUEST', headless_http_request )
+      request = self.get('REQUEST', standard.create_headless_http_request())
       buff = request.get('__buff__', None)
       if buff is None:
         buff = Buff()

--- a/Products/zms/_cachemanager.py
+++ b/Products/zms/_cachemanager.py
@@ -17,9 +17,9 @@
 ################################################################################
 
 # Imports.
-from Products.zms import _globals
+from Products.zms import standard
 
-headless_http_request = _globals.headless_http_request
+headless_http_request = standard.create_headless_http_request()
 
 class Buff(object):
   pass

--- a/Products/zms/_cachemanager.py
+++ b/Products/zms/_cachemanager.py
@@ -18,6 +18,7 @@
 
 # Imports.
 from Products.zms import standard
+from zope.globalrequest import getRequest
 
 class Buff(object):
   pass
@@ -43,7 +44,7 @@ class ReqBuff(object):
     #  Clear buffered values from Http-Request.
     # --------------------------------------------------------------------------
     def clearReqBuff(self, prefix='', REQUEST=None):
-      request = getattr(self, 'REQUEST', standard.create_headless_http_request())
+      request = getattr(self, 'REQUEST', getRequest())
       buff = request.get('__buff__', Buff())
       reqBuffId = self.getReqBuffId(prefix)
       if len(prefix) > 0:
@@ -60,7 +61,7 @@ class ReqBuff(object):
     #  @throws Exception
     # --------------------------------------------------------------------------
     def fetchReqBuff(self, key, REQUEST=None):
-      request = getattr(self, 'REQUEST', standard.create_headless_http_request())
+      request = getattr(self, 'REQUEST', getRequest())
       buff = request['__buff__']
       reqBuffId = self.getReqBuffId(key)
       return getattr(buff, reqBuffId)
@@ -71,7 +72,7 @@ class ReqBuff(object):
     #  Returns value and stores it in buffer of Http-Request.
     # --------------------------------------------------------------------------
     def storeReqBuff(self, key, value, REQUEST=None):
-      request = getattr(self, 'REQUEST', standard.create_headless_http_request())
+      request = getattr(self, 'REQUEST', getRequest())
       buff = request.get('__buff__', None)
       if buff is None:
         buff = Buff()

--- a/Products/zms/_exportable.py
+++ b/Products/zms/_exportable.py
@@ -385,7 +385,7 @@ class Exportable(_filtermanager.FilterItem):
     # --------------------------------------------------------------------------
     def toXml(self, REQUEST=None, deep=True, data2hex=False, multilang=True):
       if REQUEST is None:
-        REQUEST = self.get('REQUEST', _globals.headless_http_request)
+        REQUEST = self.get('REQUEST', standard.create_headless_http_request())
       xml = ''
       xml += _xmllib.xml_header()
       xml += _xmllib.getObjToXml( self, REQUEST, deep, base_path='', data2hex=data2hex, multilang=multilang)

--- a/Products/zms/_exportable.py
+++ b/Products/zms/_exportable.py
@@ -385,7 +385,7 @@ class Exportable(_filtermanager.FilterItem):
     # --------------------------------------------------------------------------
     def toXml(self, REQUEST=None, deep=True, data2hex=False, multilang=True):
       if REQUEST is None:
-        REQUEST = self.get('REQUEST', standard.create_headless_http_request())
+        REQUEST = getattr(self, 'REQUEST', standard.create_headless_http_request())
       xml = ''
       xml += _xmllib.xml_header()
       xml += _xmllib.getObjToXml( self, REQUEST, deep, base_path='', data2hex=data2hex, multilang=multilang)

--- a/Products/zms/_exportable.py
+++ b/Products/zms/_exportable.py
@@ -32,6 +32,7 @@ from Products.zms import _filtermanager
 from Products.zms import _globals
 from Products.zms import _xmllib
 from Products.zms import standard
+from zope.globalrequest import getRequest
 
 
 def writeFile(self, filename, data, mode='w', encoding='utf-8'):
@@ -385,7 +386,7 @@ class Exportable(_filtermanager.FilterItem):
     # --------------------------------------------------------------------------
     def toXml(self, REQUEST=None, deep=True, data2hex=False, multilang=True):
       if REQUEST is None:
-        REQUEST = getattr(self, 'REQUEST', standard.create_headless_http_request())
+        REQUEST = getattr(self, 'REQUEST', getRequest())
       xml = ''
       xml += _xmllib.xml_header()
       xml += _xmllib.getObjToXml( self, REQUEST, deep, base_path='', data2hex=data2hex, multilang=multilang)

--- a/Products/zms/_globals.py
+++ b/Products/zms/_globals.py
@@ -93,32 +93,6 @@ def get_size(v):
   return sys.getsizeof(v)
 
 
-def create_headless_http_request():
-    """
-    Returns a ZPublisher.HTTPRequest object to be used in headless mode.
-    """
-    # Measure time for exection.
-    import logging
-    LOGGER = logging.getLogger('create_headless_http_request')
-    start_time = time.time()
-    # Imports.  
-    from io import BytesIO
-    from ZPublisher.HTTPRequest import HTTPRequest
-    from ZPublisher.HTTPResponse import HTTPResponse
-
-    env = {}
-    env.setdefault('SERVER_NAME', 'nohost')
-    env.setdefault('SERVER_PORT', '80')
-    resp = HTTPResponse(stdout=BytesIO)
-
-    # Print execution time.
-    LOGGER.log(logging.INFO, 'Execution time create_headless_http_request(): %s' % (time.time() - start_time))
-
-    return HTTPRequest(stdin=BytesIO, environ=env, response=resp)
-
-# Set gobal variable headless_http_request.
-headless_http_request = create_headless_http_request()
-
 ################################################################################
 # Define StaticPageTemplateFile.
 ################################################################################

--- a/Products/zms/_objattrs.py
+++ b/Products/zms/_objattrs.py
@@ -36,7 +36,7 @@ from Products.zms import _globals
 #  getobjattrdefault
 # ------------------------------------------------------------------------------
 def getobjattrdefault(obj, obj_attr, lang):
-    request = obj.get('REQUEST', _globals.headless_http_request)
+    request = obj.get('REQUEST', standard.create_headless_http_request())
     v = None
     datatype = obj_attr['datatype_key']
     default = None
@@ -595,7 +595,7 @@ class ObjAttrs(object):
     #  attr({key0:value0,...,keyN:valueN}) -> setObjProperty(key0,value0),...
     # --------------------------------------------------------------------------
     def attr(self, *args, **kwargs):
-      req = self.get('REQUEST', _globals.headless_http_request)
+      req = self.get('REQUEST', standard.create_headless_http_request())
       request = kwargs.get('request',kwargs.get('REQUEST',req))
       if len(args) == 1 and isinstance(args[0], str):
         return self.getObjProperty( args[0], request, kwargs)
@@ -610,7 +610,7 @@ class ObjAttrs(object):
     #  ObjAttrs.evalMetaobjAttr
     # --------------------------------------------------------------------------
     def evalMetaobjAttr(self, *args, **kwargs):
-      request = self.get('REQUEST', _globals.headless_http_request)
+      request = self.get('REQUEST', standard.create_headless_http_request())
       root = self
       key = args[0]
       id = standard.nvl(request.get('ZMS_INSERT'), self.meta_id)

--- a/Products/zms/_objattrs.py
+++ b/Products/zms/_objattrs.py
@@ -36,7 +36,7 @@ from Products.zms import _globals
 #  getobjattrdefault
 # ------------------------------------------------------------------------------
 def getobjattrdefault(obj, obj_attr, lang):
-    request = obj.get('REQUEST', standard.create_headless_http_request())
+    request = getattr(obj, 'REQUEST', standard.create_headless_http_request())
     v = None
     datatype = obj_attr['datatype_key']
     default = None
@@ -595,7 +595,7 @@ class ObjAttrs(object):
     #  attr({key0:value0,...,keyN:valueN}) -> setObjProperty(key0,value0),...
     # --------------------------------------------------------------------------
     def attr(self, *args, **kwargs):
-      req = self.get('REQUEST', standard.create_headless_http_request())
+      req = getattr(self, 'REQUEST', standard.create_headless_http_request())
       request = kwargs.get('request',kwargs.get('REQUEST',req))
       if len(args) == 1 and isinstance(args[0], str):
         return self.getObjProperty( args[0], request, kwargs)
@@ -610,7 +610,7 @@ class ObjAttrs(object):
     #  ObjAttrs.evalMetaobjAttr
     # --------------------------------------------------------------------------
     def evalMetaobjAttr(self, *args, **kwargs):
-      request = self.get('REQUEST', standard.create_headless_http_request())
+      request = getattr(self, 'REQUEST', standard.create_headless_http_request())
       root = self
       key = args[0]
       id = standard.nvl(request.get('ZMS_INSERT'), self.meta_id)

--- a/Products/zms/_objattrs.py
+++ b/Products/zms/_objattrs.py
@@ -31,12 +31,13 @@ from Products.zms import standard
 from Products.zms import zopeutil
 from Products.zms import _blobfields
 from Products.zms import _globals
+from zope.globalrequest import getRequest
 
 # ------------------------------------------------------------------------------
 #  getobjattrdefault
 # ------------------------------------------------------------------------------
 def getobjattrdefault(obj, obj_attr, lang):
-    request = getattr(obj, 'REQUEST', standard.create_headless_http_request())
+    request = getattr(obj, 'REQUEST', getRequest())
     v = None
     datatype = obj_attr['datatype_key']
     default = None
@@ -595,7 +596,7 @@ class ObjAttrs(object):
     #  attr({key0:value0,...,keyN:valueN}) -> setObjProperty(key0,value0),...
     # --------------------------------------------------------------------------
     def attr(self, *args, **kwargs):
-      req = getattr(self, 'REQUEST', standard.create_headless_http_request())
+      req = getattr(self, 'REQUEST', getRequest())
       request = kwargs.get('request',kwargs.get('REQUEST',req))
       if len(args) == 1 and isinstance(args[0], str):
         return self.getObjProperty( args[0], request, kwargs)
@@ -610,7 +611,7 @@ class ObjAttrs(object):
     #  ObjAttrs.evalMetaobjAttr
     # --------------------------------------------------------------------------
     def evalMetaobjAttr(self, *args, **kwargs):
-      request = getattr(self, 'REQUEST', standard.create_headless_http_request())
+      request = getattr(self, 'REQUEST', getRequest())
       root = self
       key = args[0]
       id = standard.nvl(request.get('ZMS_INSERT'), self.meta_id)
@@ -694,7 +695,7 @@ class ObjAttrs(object):
                 value = tuple(value[:8]) + (0,)
               dt = datetime.datetime.fromtimestamp(time.mktime(value) - (dst * 3600))
               b = b and now > dt
-              if dt > now and self.get('REQUEST') and self.REQUEST.get('ZMS_CACHE_EXPIRE_DATETIME', dt) >= dt:
+              if dt > now and hasattr(self,'REQUEST') and self.REQUEST.get('ZMS_CACHE_EXPIRE_DATETIME', dt) >= dt:
                 self.REQUEST.set('ZMS_CACHE_EXPIRE_DATETIME',dt)
           # End time.
           elif key == 'attr_active_end':
@@ -704,7 +705,7 @@ class ObjAttrs(object):
                 value = tuple(value[:8]) + (0,)
               dt = datetime.datetime.fromtimestamp(time.mktime(value) - (dst * 3600))
               b = b and dt > now
-              if dt > now and self.get('REQUEST') and self.REQUEST.get('ZMS_CACHE_EXPIRE_DATETIME', dt) >= dt:
+              if dt > now and hasattr(self,'REQUEST') and self.REQUEST.get('ZMS_CACHE_EXPIRE_DATETIME', dt) >= dt:
                 self.REQUEST.set('ZMS_CACHE_EXPIRE_DATETIME',dt)
           if not b: break
       return b

--- a/Products/zms/_pathhandler.py
+++ b/Products/zms/_pathhandler.py
@@ -142,7 +142,7 @@ class PathHandler(object):
               TraversalRequest[ 'path_to_handle'].insert( i-1, path_physical[ i])
       
       # Set language.
-      lang = request.get( 'lang', self.getPrimaryLanguage())
+      lang = request.get('lang')
       if lang is None:
         lang = self.getLanguageFromName(TraversalRequest['path_to_handle'][-1])
       if lang is not None:
@@ -342,9 +342,8 @@ class PathHandler(object):
                 request.set('lang', lang)
                 return self
 
-        # Products.zms.standard.create_headless_http_request()
-        # has been called above for headless mode
-        if request.get('SERVER_NAME') == 'nohost':
+        # headless mode
+        if not hasattr(self, 'REQUEST'):
           return
 
         # If there's no more names left to handle, return the path handling

--- a/Products/zms/_pathhandler.py
+++ b/Products/zms/_pathhandler.py
@@ -118,7 +118,7 @@ class PathHandler(object):
     def __bobo_traverse__(self, TraversalRequest, name):
       # If this is the first time this __bob_traverse__ method has been called
       # in handling this traversal request, store the path_to_handle
-      request = self.get('REQUEST', _globals.headless_http_request)
+      request = self.get('REQUEST', standard.create_headless_http_request())
       url = request.get('URL', '')
       zmi = url.find('/manage') >= 0
       
@@ -341,7 +341,7 @@ class PathHandler(object):
                 request.set('lang', lang)
                 return self
 
-        # Products.zms._globals.headless_http_request
+        # Products.zms.standard.create_headless_http_request()
         # has been called above for headless mode
         if request.get('SERVER_NAME') == 'nohost':
           return

--- a/Products/zms/_pathhandler.py
+++ b/Products/zms/_pathhandler.py
@@ -118,7 +118,7 @@ class PathHandler(object):
     def __bobo_traverse__(self, TraversalRequest, name):
       # If this is the first time this __bob_traverse__ method has been called
       # in handling this traversal request, store the path_to_handle
-      request = self.get('REQUEST', standard.create_headless_http_request())
+      request = getattr(self, 'REQUEST', standard.create_headless_http_request())
       url = request.get('URL', '')
       zmi = url.find('/manage') >= 0
       

--- a/Products/zms/_pathhandler.py
+++ b/Products/zms/_pathhandler.py
@@ -25,6 +25,7 @@ from Products.zms import standard
 from Products.zms import _blobfields
 from Products.zms import _fileutil
 from Products.zms import _globals
+from zope.globalrequest import getRequest
 
 # ------------------------------------------------------------------------------
 #  _pathhandler.validateId:
@@ -118,7 +119,7 @@ class PathHandler(object):
     def __bobo_traverse__(self, TraversalRequest, name):
       # If this is the first time this __bob_traverse__ method has been called
       # in handling this traversal request, store the path_to_handle
-      request = getattr(self, 'REQUEST', standard.create_headless_http_request())
+      request = getattr(self, 'REQUEST', getRequest())
       url = request.get('URL', '')
       zmi = url.find('/manage') >= 0
       

--- a/Products/zms/_textformatmanager.py
+++ b/Products/zms/_textformatmanager.py
@@ -19,7 +19,7 @@
 # Product Imports.
 from Products.zms import standard
 from Products.zms import _globals
-
+from zope.globalrequest import getRequest
 
 class TextFormatObject(object):
 
@@ -29,7 +29,7 @@ class TextFormatObject(object):
   #  Returns section-number.
   # ----------------------------------------------------------------------------
   def getSecNo( self):
-    request = getattr(self, 'REQUEST', standard.create_headless_http_request())
+    request = getattr(self, 'REQUEST', getRequest())
     sec_no = ''
     #-- [ReqBuff]: Fetch buffered value from Http-Request.
     parentNode = self.getParentNode()

--- a/Products/zms/_textformatmanager.py
+++ b/Products/zms/_textformatmanager.py
@@ -29,7 +29,7 @@ class TextFormatObject(object):
   #  Returns section-number.
   # ----------------------------------------------------------------------------
   def getSecNo( self):
-    request = self.get('REQUEST', _globals.headless_http_request)
+    request = self.get('REQUEST', standard.create_headless_http_request())
     sec_no = ''
     #-- [ReqBuff]: Fetch buffered value from Http-Request.
     parentNode = self.getParentNode()

--- a/Products/zms/_textformatmanager.py
+++ b/Products/zms/_textformatmanager.py
@@ -29,7 +29,7 @@ class TextFormatObject(object):
   #  Returns section-number.
   # ----------------------------------------------------------------------------
   def getSecNo( self):
-    request = self.get('REQUEST', standard.create_headless_http_request())
+    request = getattr(self, 'REQUEST', standard.create_headless_http_request())
     sec_no = ''
     #-- [ReqBuff]: Fetch buffered value from Http-Request.
     parentNode = self.getParentNode()

--- a/Products/zms/_zreferableitem.py
+++ b/Products/zms/_zreferableitem.py
@@ -22,7 +22,7 @@ import base64
 import re
 # Product Imports.
 from Products.zms import standard
-
+from zope.globalrequest import getRequest
 
 # ------------------------------------------------------------------------------
 #  isMailLink:
@@ -47,7 +47,7 @@ def getInternalLinkDict(self, url):
   reqBuffId = 'getInternalLinkDict.%s'%url
   try: return docelmnt.fetchReqBuff(reqBuffId)
   except: pass
-  request = getattr(self, 'REQUEST', standard.create_headless_http_request())
+  request = getattr(self, 'REQUEST', getRequest())
   d = {}
   # Params.
   anchor = ''
@@ -88,7 +88,7 @@ def getInternalLinkDict(self, url):
 #  getInternalLinkUrl:
 # ------------------------------------------------------------------------------
 def getInternalLinkUrl(self, url, ob):
-  request = getattr(self, 'REQUEST', standard.create_headless_http_request())
+  request = getattr(self, 'REQUEST', getRequest())
   if ob is None:
     index_html = './index_%s.html?error_type=NotFound&op=not_found&url=%s'%(request.get('lang', self.getPrimaryLanguage()), str(url))
   else:
@@ -389,7 +389,7 @@ class ZReferableItem(object):
   #  Resolves internal/external links and returns Object.
   # ----------------------------------------------------------------------------
   def getLinkObj(self, url, REQUEST=None):
-    request = getattr(self, 'REQUEST', standard.create_headless_http_request())
+    request = getattr(self, 'REQUEST', getRequest())
     ob = None
     if isInternalLink(url):
       # Params.

--- a/Products/zms/_zreferableitem.py
+++ b/Products/zms/_zreferableitem.py
@@ -47,7 +47,7 @@ def getInternalLinkDict(self, url):
   reqBuffId = 'getInternalLinkDict.%s'%url
   try: return docelmnt.fetchReqBuff(reqBuffId)
   except: pass
-  request = self.get('REQUEST', standard.create_headless_http_request())
+  request = getattr(self, 'REQUEST', standard.create_headless_http_request())
   d = {}
   # Params.
   anchor = ''
@@ -88,7 +88,7 @@ def getInternalLinkDict(self, url):
 #  getInternalLinkUrl:
 # ------------------------------------------------------------------------------
 def getInternalLinkUrl(self, url, ob):
-  request = self.get('REQUEST', standard.create_headless_http_request())
+  request = getattr(self, 'REQUEST', standard.create_headless_http_request())
   if ob is None:
     index_html = './index_%s.html?error_type=NotFound&op=not_found&url=%s'%(request.get('lang', self.getPrimaryLanguage()), str(url))
   else:
@@ -389,7 +389,7 @@ class ZReferableItem(object):
   #  Resolves internal/external links and returns Object.
   # ----------------------------------------------------------------------------
   def getLinkObj(self, url, REQUEST=None):
-    request = self.get('REQUEST', standard.create_headless_http_request())
+    request = getattr(self, 'REQUEST', standard.create_headless_http_request())
     ob = None
     if isInternalLink(url):
       # Params.

--- a/Products/zms/_zreferableitem.py
+++ b/Products/zms/_zreferableitem.py
@@ -21,7 +21,6 @@ from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 import base64
 import re
 # Product Imports.
-from Products.zms import _globals
 from Products.zms import standard
 
 
@@ -48,7 +47,7 @@ def getInternalLinkDict(self, url):
   reqBuffId = 'getInternalLinkDict.%s'%url
   try: return docelmnt.fetchReqBuff(reqBuffId)
   except: pass
-  request = self.get('REQUEST', _globals.headless_http_request)
+  request = self.get('REQUEST', standard.create_headless_http_request())
   d = {}
   # Params.
   anchor = ''
@@ -89,7 +88,7 @@ def getInternalLinkDict(self, url):
 #  getInternalLinkUrl:
 # ------------------------------------------------------------------------------
 def getInternalLinkUrl(self, url, ob):
-  request = self.get('REQUEST', _globals.headless_http_request)
+  request = self.get('REQUEST', standard.create_headless_http_request())
   if ob is None:
     index_html = './index_%s.html?error_type=NotFound&op=not_found&url=%s'%(request.get('lang', self.getPrimaryLanguage()), str(url))
   else:
@@ -390,7 +389,7 @@ class ZReferableItem(object):
   #  Resolves internal/external links and returns Object.
   # ----------------------------------------------------------------------------
   def getLinkObj(self, url, REQUEST=None):
-    request = self.get('REQUEST', _globals.headless_http_request)
+    request = self.get('REQUEST', standard.create_headless_http_request())
     ob = None
     if isInternalLink(url):
       # Params.

--- a/Products/zms/standard.py
+++ b/Products/zms/standard.py
@@ -860,7 +860,7 @@ def triggerEvent(context, *args, **kwargs):
   """
   Hook for trigger of custom event (if there is one)
   """
-  request = context.get('REQUEST', _globals.headless_http_request)
+  request = context.get('REQUEST', create_headless_http_request())
   l = []
   name = args[0]
   root = context.getRootElement()
@@ -954,6 +954,22 @@ def unescape(s):
       new = chr(int('0x'+s[i+1:i+3], 0))
     s = s.replace(old, new)
   return s
+
+
+def create_headless_http_request():
+    """
+    Returns a ZPublisher.HTTPRequest object to be used in headless mode.
+    """
+    from io import BytesIO
+    from ZPublisher.HTTPRequest import HTTPRequest
+    from ZPublisher.HTTPResponse import HTTPResponse
+
+    env = {}
+    env.setdefault('SERVER_NAME', 'nohost')
+    env.setdefault('SERVER_PORT', '80')
+    resp = HTTPResponse(stdout=BytesIO)
+
+    return HTTPRequest(stdin=BytesIO, environ=env, response=resp)
 
 
 security.declarePublic('http_request')
@@ -2367,7 +2383,7 @@ def dt_tal(context, text, options={}):
   pt = StaticPageTemplateFile(filename='None')
   pt.setText(text)
   pt.setEnv(context, options)
-  request = context.get('REQUEST', _globals.headless_http_request)
+  request = context.get('REQUEST', create_headless_http_request())
   rendered = pt.pt_render(extra_context={'here':context,'request':request})
   return rendered
 

--- a/Products/zms/standard.py
+++ b/Products/zms/standard.py
@@ -860,7 +860,7 @@ def triggerEvent(context, *args, **kwargs):
   """
   Hook for trigger of custom event (if there is one)
   """
-  request = context.get('REQUEST', create_headless_http_request())
+  request = getattr(context, 'REQUEST', create_headless_http_request())
   l = []
   name = args[0]
   root = context.getRootElement()
@@ -2383,7 +2383,7 @@ def dt_tal(context, text, options={}):
   pt = StaticPageTemplateFile(filename='None')
   pt.setText(text)
   pt.setEnv(context, options)
-  request = context.get('REQUEST', create_headless_http_request())
+  request = getattr(context, 'REQUEST', create_headless_http_request())
   rendered = pt.pt_render(extra_context={'here':context,'request':request})
   return rendered
 

--- a/Products/zms/standard.py
+++ b/Products/zms/standard.py
@@ -32,6 +32,7 @@ from App.config import getConfiguration
 from DateTime.DateTime import DateTime
 from zope.event import notify
 from zope.lifecycleevent import ObjectModifiedEvent
+from zope.globalrequest import getRequest
 import base64
 import cgi
 import copy
@@ -860,7 +861,7 @@ def triggerEvent(context, *args, **kwargs):
   """
   Hook for trigger of custom event (if there is one)
   """
-  request = getattr(context, 'REQUEST', create_headless_http_request())
+  request = getattr(context, 'REQUEST', getRequest())
   l = []
   name = args[0]
   root = context.getRootElement()
@@ -954,22 +955,6 @@ def unescape(s):
       new = chr(int('0x'+s[i+1:i+3], 0))
     s = s.replace(old, new)
   return s
-
-
-def create_headless_http_request():
-    """
-    Returns a ZPublisher.HTTPRequest object to be used in headless mode.
-    """
-    from io import BytesIO
-    from ZPublisher.HTTPRequest import HTTPRequest
-    from ZPublisher.HTTPResponse import HTTPResponse
-
-    env = {}
-    env.setdefault('SERVER_NAME', 'nohost')
-    env.setdefault('SERVER_PORT', '80')
-    resp = HTTPResponse(stdout=BytesIO)
-
-    return HTTPRequest(stdin=BytesIO, environ=env, response=resp)
 
 
 security.declarePublic('http_request')
@@ -2383,7 +2368,7 @@ def dt_tal(context, text, options={}):
   pt = StaticPageTemplateFile(filename='None')
   pt.setText(text)
   pt.setEnv(context, options)
-  request = getattr(context, 'REQUEST', create_headless_http_request())
+  request = getattr(context, 'REQUEST', getRequest())
   rendered = pt.pt_render(extra_context={'here':context,'request':request})
   return rendered
 

--- a/Products/zms/zmslinkelement.py
+++ b/Products/zms/zmslinkelement.py
@@ -29,6 +29,7 @@ from Products.zms import zmscustom
 from Products.zms import zmsobject
 from Products.zms import zmsproxyobject
 from Products.zms import zmslinkelement
+from zope.globalrequest import getRequest
 
 
 """
@@ -104,7 +105,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  ZMSLinkElement.getEmbedType: 
     # --------------------------------------------------------------------------
     def getEmbedType(self):
-      request = getattr(self, 'REQUEST', standard.create_headless_http_request())
+      request = getattr(self, 'REQUEST', getRequest())
       embed_type = self.getObjAttrValue( self.getObjAttr( 'attr_type'), request)
       if embed_type in [ 'embed', 'recursive', 'remote']:
         ref_obj = self.getRefObj()
@@ -383,7 +384,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  ZMSLinkElement.isPageElement
     # --------------------------------------------------------------------------
     def isPageElement(self):
-      request = getattr(self, 'REQUEST', standard.create_headless_http_request())
+      request = getattr(self, 'REQUEST', getRequest())
       rtnVal = False
       if self.getEmbedType() == 'remote':
         return self.getRemoteObj().get('is_page_element',False)
@@ -632,7 +633,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  Returns self or referenced object (if embedded) as ZMSProxyObject
     # --------------------------------------------------------------------------
     def __proxy__(self):
-      req = getattr(self, 'REQUEST', standard.create_headless_http_request())
+      req = getattr(self, 'REQUEST', getRequest())
       rtn = self
       if req.get( 'ZMS_PROXY', True):
         if req.get( 'URL', '').find( '/manage') < 0 or req.get( 'ZMS_PATH_HANDLER', False):
@@ -651,7 +652,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  ZMSProxyObject.
     # --------------------------------------------------------------------------
     def getProxy(self):
-      req = getattr(self, 'REQUEST', standard.create_headless_http_request())
+      req = getattr(self, 'REQUEST', getRequest())
       rtn = self
       if req.get( 'ZMS_PROXY', True):
         rtn = req.get( 'ZMS_PROXY_%s'%self.id, self.__proxy__())

--- a/Products/zms/zmslinkelement.py
+++ b/Products/zms/zmslinkelement.py
@@ -104,7 +104,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  ZMSLinkElement.getEmbedType: 
     # --------------------------------------------------------------------------
     def getEmbedType(self):
-      request = self.get('REQUEST', standard.create_headless_http_request())
+      request = getattr(self, 'REQUEST', standard.create_headless_http_request())
       embed_type = self.getObjAttrValue( self.getObjAttr( 'attr_type'), request)
       if embed_type in [ 'embed', 'recursive', 'remote']:
         ref_obj = self.getRefObj()
@@ -383,7 +383,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  ZMSLinkElement.isPageElement
     # --------------------------------------------------------------------------
     def isPageElement(self):
-      request = self.get('REQUEST', standard.create_headless_http_request())
+      request = getattr(self, 'REQUEST', standard.create_headless_http_request())
       rtnVal = False
       if self.getEmbedType() == 'remote':
         return self.getRemoteObj().get('is_page_element',False)
@@ -632,7 +632,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  Returns self or referenced object (if embedded) as ZMSProxyObject
     # --------------------------------------------------------------------------
     def __proxy__(self):
-      req = self.get('REQUEST', standard.create_headless_http_request())
+      req = getattr(self, 'REQUEST', standard.create_headless_http_request())
       rtn = self
       if req.get( 'ZMS_PROXY', True):
         if req.get( 'URL', '').find( '/manage') < 0 or req.get( 'ZMS_PATH_HANDLER', False):
@@ -651,7 +651,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  ZMSProxyObject.
     # --------------------------------------------------------------------------
     def getProxy(self):
-      req = self.get('REQUEST', standard.create_headless_http_request())
+      req = getattr(self, 'REQUEST', standard.create_headless_http_request())
       rtn = self
       if req.get( 'ZMS_PROXY', True):
         rtn = req.get( 'ZMS_PROXY_%s'%self.id, self.__proxy__())

--- a/Products/zms/zmslinkelement.py
+++ b/Products/zms/zmslinkelement.py
@@ -22,7 +22,6 @@ from AccessControl.class_init import InitializeClass
 import json
 import sys
 # Product Imports.
-from Products.zms import _globals
 from Products.zms import rest_api
 from Products.zms import standard
 from Products.zms import zmscontainerobject
@@ -105,7 +104,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  ZMSLinkElement.getEmbedType: 
     # --------------------------------------------------------------------------
     def getEmbedType(self):
-      request = self.get('REQUEST', _globals.headless_http_request)
+      request = self.get('REQUEST', standard.create_headless_http_request())
       embed_type = self.getObjAttrValue( self.getObjAttr( 'attr_type'), request)
       if embed_type in [ 'embed', 'recursive', 'remote']:
         ref_obj = self.getRefObj()
@@ -384,7 +383,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  ZMSLinkElement.isPageElement
     # --------------------------------------------------------------------------
     def isPageElement(self):
-      request = self.get('REQUEST', _globals.headless_http_request)
+      request = self.get('REQUEST', standard.create_headless_http_request())
       rtnVal = False
       if self.getEmbedType() == 'remote':
         return self.getRemoteObj().get('is_page_element',False)
@@ -633,7 +632,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  Returns self or referenced object (if embedded) as ZMSProxyObject
     # --------------------------------------------------------------------------
     def __proxy__(self):
-      req = self.get('REQUEST', _globals.headless_http_request)
+      req = self.get('REQUEST', standard.create_headless_http_request())
       rtn = self
       if req.get( 'ZMS_PROXY', True):
         if req.get( 'URL', '').find( '/manage') < 0 or req.get( 'ZMS_PATH_HANDLER', False):
@@ -652,7 +651,7 @@ class ZMSLinkElement(zmscustom.ZMSCustom):
     #  ZMSProxyObject.
     # --------------------------------------------------------------------------
     def getProxy(self):
-      req = self.get('REQUEST', _globals.headless_http_request)
+      req = self.get('REQUEST', standard.create_headless_http_request())
       rtn = self
       if req.get( 'ZMS_PROXY', True):
         rtn = req.get( 'ZMS_PROXY_%s'%self.id, self.__proxy__())

--- a/Products/zms/zmsobject.py
+++ b/Products/zms/zmsobject.py
@@ -47,6 +47,7 @@ from Products.zms import ZMSItem
 from Products.zms import ZMSWorkflowItem
 from Products.zms import standard
 from Products.zms import zopeutil
+from zope.globalrequest import getRequest
 
 
 __all__= ['ZMSObject']
@@ -476,7 +477,7 @@ class ZMSObject(ZMSItem.ZMSItem,
     #  Returns 1 if current object is visible.
     # --------------------------------------------------------------------------
     def isVisible(self, REQUEST):
-      request = getattr(self, 'REQUEST', standard.create_headless_http_request())
+      request = getattr(self, 'REQUEST', getRequest())
       REQUEST = standard.nvl(REQUEST, request)
       lang = standard.nvl(REQUEST.get('lang'), self.getPrimaryLanguage())
       visible = True

--- a/Products/zms/zmsobject.py
+++ b/Products/zms/zmsobject.py
@@ -476,7 +476,7 @@ class ZMSObject(ZMSItem.ZMSItem,
     #  Returns 1 if current object is visible.
     # --------------------------------------------------------------------------
     def isVisible(self, REQUEST):
-      request = self.get('REQUEST', _globals.headless_http_request)
+      request = self.get('REQUEST', standard.create_headless_http_request())
       REQUEST = standard.nvl(REQUEST, request)
       lang = standard.nvl(REQUEST.get('lang'), self.getPrimaryLanguage())
       visible = True

--- a/Products/zms/zmsobject.py
+++ b/Products/zms/zmsobject.py
@@ -925,7 +925,7 @@ class ZMSObject(ZMSItem.ZMSItem,
         abs_url = args[1]['abs_url']
         forced = args[1]['forced']
         if context.getConfProperty('ZMSObject.getAbsoluteUrlInContext', False):
-          if context.getHome() != self.getHome():
+          if context.getHome() != context.getHome():
             protocol = context.getConfProperty('ASP.protocol', 'http')
             domain = context.getConfProperty('ASP.ip_or_domain', None)
             if domain:

--- a/Products/zms/zmsobject.py
+++ b/Products/zms/zmsobject.py
@@ -476,7 +476,7 @@ class ZMSObject(ZMSItem.ZMSItem,
     #  Returns 1 if current object is visible.
     # --------------------------------------------------------------------------
     def isVisible(self, REQUEST):
-      request = self.get('REQUEST', standard.create_headless_http_request())
+      request = getattr(self, 'REQUEST', standard.create_headless_http_request())
       REQUEST = standard.nvl(REQUEST, request)
       lang = standard.nvl(REQUEST.get('lang'), self.getPrimaryLanguage())
       visible = True


### PR DESCRIPTION
- Superseed  https://github.com/zms-publishing/ZMS/pull/321
- needs new import: `from zope.globalrequest import getRequest`
- Standard fallback: getattr(self, 'REQUEST', getRequest())
- for headless mode: set REQUEST globally by `zope.globalrequest.setRequest()`
- **Still open**:  primaryLanguage problem with `__bobo_traverse__` : RESTAPI-test still fails; check if headless mode works without primaryLanguage fallback 

https://github.com/zms-publishing/ZMS/blob/54e8ef59d427e09b160101e2fc11b4d2ddbf3e03/Products/zms/_pathhandler.py#L145
