### PR TITLE
fix: sitemap btn (zhref)

### DIFF
--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -116,7 +116,7 @@ $ZMI.registerReady(function(){
 	// Toggle: Classical Sitemap Icon
 	$('a#navbar-sitemap').each(function() {
 		var $a = $(this);
-		if (self.window.parent.frames.length > 1 && typeof self.window.parent != "undefined") {
+		if (self.window.parent.frames.length > 1 && typeof self.window.parent != "undefined" && typeof self.window.parent.frames.manage_menu == "undefined") {
 			$a.attr('target','_top');
 		}
 		else {


### PR DESCRIPTION
If ZMI shows html-code containing iframes as content-blocks the ZMI assumes the sitemap-frameset is active - and thus the sitemap cannot toggle anymore. The JS-change additionally checks the name "manage_menu"