### PR TITLE
fix(menulock): Convert localstorage value into int

### DIFF
--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -550,7 +550,7 @@ $ZMI.registerReady(function(){
 	$ZMI.setCursorAuto("EO bootstrap.plugin.zmi");
 
 	// Set Save-Button Behaviour: Menu Lock
-	$('#menulock').val(JSON.parse($ZMILocalStorageAPI.get('ZMS.menulock',0)));
+	$('#menulock').val(+JSON.parse($ZMILocalStorageAPI.get('ZMS.menulock',0)));
 
 	// ZMSLightbox
 	$('a.zmslightbox, a.fancybox')


### PR DESCRIPTION
Ensure backwards compatibility of `ZMS.menulock` value, because https://github.com/zms-publishing/ZMS/commit/8945bffff55b8436802812089e61aea7047ba732 introduced a new handling of menu pin to stay in context on save -> was `true|false` before and is now integer (`1|0`).

Without this fix a user with a former `true|false` in localstorage gets this scary Waitress server error on save:

![Screenshot 2024-10-16 at 20 41 41](https://github.com/user-attachments/assets/09b95101-c086-4129-95ef-8da1ca1096ff)

```
2024-10-16 20:12:01 ERROR [waitress:435][waitress-2] Exception while serving /unibe/portal/content/e1200/e1360/manage_changeProperties
Traceback (most recent call last):
  File "/unibe-cms/backend/zope/src/ZPublisher/Converters.py", line 94, in field2int
    return int(v)
           ^^^^^^
ValueError: invalid literal for int() with base 10: 'true' 
```

