### PR TITLE
Fix: Ignore link-embedded childnodes for obj-copy

### DIFF
--- a/Products/zms/_copysupport.py
+++ b/Products/zms/_copysupport.py
@@ -58,7 +58,7 @@ def normalize_ids_after_copy(node, id_prefix='e', ids=[]):
         # new id
         new_id = node.getNewId(standard.id_prefix(id))
       # reset id
-      if new_id is not None and new_id != id:
+      if new_id is not None and new_id != id and childNode.getParentNode() == node:
         standard.writeBlock(node,'[CopySupport._normalize_ids_after_copy]: rename %s(%s) to %s'%(childNode.absolute_url(),childNode.meta_id,new_id))
         node.manage_renameObject(id=id,new_id=new_id)
       # traverse tree


### PR DESCRIPTION
Copying a link-objects thats uses the embed feature results in attributes error on renaming with `manage_renameObject()`:

* Ref: https://github.com/idasm-unibe-ch/unibe-cms/issues/764

Any childnodes in case of  link embedding have to be ignored for calling manage_renameObject(). The approach of the change shall make sure that the parent-node of the current childNode is the current node (which is ot in case of embedding). @zmsdev:  any other idea?