### PR TITLE
Copy & Paste: objects not visible in live view in alternative language

### DIFF
--- a/Products/zms/_copysupport.py
+++ b/Products/zms/_copysupport.py
@@ -45,11 +45,12 @@ def normalize_ids_after_copy(node, id_prefix='e', ids=[]):
       # reset ref_by
       childNode.ref_by = []
       # init object-state
-      if not '*' in ids and not node.getAutocommit():
+      if not '*' in ids:
         lang = request.get('lang')
         for langId in node.getLangIds():
           request.set('lang',langId)
-          childNode.setObjStateNew(request,reset=0)
+          if not node.getAutocommit():
+            childNode.setObjStateNew(request,reset=0)
           childNode.onChangeObj(request)
         request.set('lang',lang)
         # new id

--- a/Products/zms/_copysupport.py
+++ b/Products/zms/_copysupport.py
@@ -45,7 +45,7 @@ def normalize_ids_after_copy(node, id_prefix='e', ids=[]):
       # reset ref_by
       childNode.ref_by = []
       # init object-state
-      if not '*' in ids:
+      if not '*' in ids and not node.getAutocommit():
         lang = request.get('lang')
         for langId in node.getLangIds():
           request.set('lang',langId)


### PR DESCRIPTION
Ref: https://github.com/idasm-unibe-ch/unibe-cms/issues/763

Do not reset object-state to new, if workflow is inactive (autocommit)

![PASTE_to_ZMS](https://github.com/user-attachments/assets/42d084d0-31b9-44f9-acca-9c702fbaf826)
