### PR TITLE
Set status-code 404 in case media file not found

### DIFF
--- a/Products/zms/_mediadb.py
+++ b/Products/zms/_mediadb.py
@@ -400,6 +400,7 @@ class MediaDb(
         standard.writeBlock(self, msg)
         filename = 'file_not_found_0.txt'
         mt, enc, data, fsize = 'text/plain', 'utf-8', msg, len(msg)
+        REQUEST.response.setStatus(404)
       else:
         # File found.
         fsize = os.path.getsize( local_filename)


### PR DESCRIPTION
Ref: https://github.com/idasm-unibe-ch/unibe-cms/issues/659

The mediadb module creates a text-response "file not found" in case a media-file cannot be located in the filesystem; this comes with the HTTP status code 200. Actually 404 is more appropriate.

![image](https://github.com/user-attachments/assets/0906f37c-c19f-45e2-8564-fe21ee099c4a)

Actually 404 is more appropriate.

![image](https://github.com/user-attachments/assets/b9eccd1f-b4c9-4bca-8035-35293b6a71f0)

 