### PR TITLE
Update _fileutil.py

### DIFF
--- a/Products/zms/_fileutil.py
+++ b/Products/zms/_fileutil.py
@@ -419,6 +419,8 @@ def extractZipArchive(file):
   
   zf = zipfile.ZipFile( file, 'r')
   for name in zf.namelist():
+    if name.startswith('__MACOSX/') or name.endswith('.DS_Store'):
+        continue
     dir = getOSPath( name)
     i = dir.rfind( os.sep) 
     if i > 0:


### PR DESCRIPTION
Added an exception for macOS ZIP-Files that can contain macOS specific meta data. These meta data can break the upload process at all or create empty duplicate image objects in the best case.