### PR TITLE
Instant cache refreshing on ZMI-JS changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.egg-info/
 *.pyc
 Products/zms/plugins/www/zms-all.min.js
+Products/zms/plugins/www/zms-all.min.js.hash
 Products/zms/plugins/www/i18n/*.js
 Products/zms/overrides.zcml
 .vscode/

--- a/Products/zms/__init__.py
+++ b/Products/zms/__init__.py
@@ -252,6 +252,17 @@ def initialize(context):
                 standard.writeStdout(context, "add %s (Packed: %i -> %i Bytes)"%(fn, l0, l1))
               fileobj.write(fc)
             fileobj.close()
+            # Before closing minified file finally create hash 
+            # of packed file content and write it into separate file
+            min_fileobj = open(fileobj.name, 'r')
+            min_hash = standard.encrypt_password(min_fileobj.read(),hex=True)
+            min_hash_fileobj = open(fileobj.name + '.hash', 'w')
+            min_hash_fileobj.write(min_hash)
+            OFS.misc_.misc_.zms['confdict']['js_min.hash'] = min_hash
+            standard.writeStdout(context, "New minify hash created: %s" % min_hash_fileobj.name)
+            min_hash_fileobj.close()
+            min_fileobj.close()
+
         
         # automated generation of language JavaScript
         from xml.dom import minidom

--- a/Products/zms/_confmanager.py
+++ b/Products/zms/_confmanager.py
@@ -471,6 +471,7 @@ class ConfManager(
         {'key':'jquery.ui','title':'JQuery UI version','desc':'JQuery UI version.','datatype':'string'},
         {'key':'jquery.plugin.version','title':'JQuery plugin version','desc':'JQuery plugin version','datatype':'string'},
         {'key':'jquery.plugin.extensions','title':'JQuery plugin extensions','desc':'JQuery plugin extensions','datatype':'string'},
+        {'key':'js_min.hash','title':'Hash value of minified ZMI-Javascript aggregate','desc':'Use hash-value of the minified ZMI-Javascript aggregate file for cache bustering','datatype':'string'},
         {'key':'ZMS.blobfields.grant_public_access','title':'Grant public access to blob-fields','desc':'Blob-fields in restricted nodes are not visible. You may grant public access to blob-fields by activating this option.','datatype':'boolean'},
         {'key':'ZMS.blobfields.accept_ranges','title':'Http-Header Accept-Ranges for blob-fields','desc':'Http-Header Accept-Ranges for blob-fields.','datatype':'string','default':'bytes'},
         {'key':'ZMS.locale.amount.unit','title':'Currency unit for amount-types','desc':'The currency unit used for amount-types.','datatype':'string','default':'EUR'},

--- a/Products/zms/zpt/common/zmi_html_head.zpt
+++ b/Products/zms/zpt/common/zmi_html_head.zpt
@@ -27,7 +27,9 @@
 	</tal:block>
 	<script type="text/javascript" charset="UTF-8" tal:attributes="src python:'/++resource++zms_/i18n/%s.js'%here.get_manage_lang()"></script>
 	<tal:block tal:repeat="src python:list(zmi_paths['js_paths'])+[here.getConfProperty(x) for x in here.getConfProperty('bootstrap.libs').split(',')]"
-		><script type="text/javascript" charset="UTF-8" tal:condition="src" tal:attributes="src src"></script>
+		><script type="text/javascript" charset="UTF-8" tal:condition="src" 
+			tal:attributes="src python:src.endswith('-all.min.js') and '%s?cache=%s'%(src,here.getConfProperty('js_min.hash')) or src">
+		</script>
 	</tal:block>
 	<script tal:condition="python:here.restrictedTraverse(zmi_js, None)" tal:attributes="src zmi_js" type="text/javascript" charset="UTF-8" defer="defer"></script>
 	<tal:block tal:condition="python:not standard.get_session_value(here,'did_update_userdata') and 'Manager' not in request.get('AUTHENTICATED_USER').getRoles()">


### PR DESCRIPTION
JS-code changes may be unseen after deployment due to proxy caching. A hash value of the minified code will refresh the proxy caching of zms-all.min.js