### PR TITLE
Prevent in-place redirecting during content-indexing

### DIFF
--- a/Products/zms/ZMSZCatalogAdapter.py
+++ b/Products/zms/ZMSZCatalogAdapter.py
@@ -351,6 +351,9 @@ class ZMSZCatalogAdapter(ZMSItem.ZMSItem):
           else:
             # Add plain text to data.
             d[attr_id] = content_extraction.extract_text_from_html(node, value)
+      # Prevent in-place redirecting by resetting status code and location header.
+      request.RESPONSE.setStatus(200) 
+      request.RESPONSE.setHeader('Location', '')
 
     # --------------------------------------------------------------------------
     #  Get catalog objects data for given node.


### PR DESCRIPTION
Problem (reported by RFH): 
Content-blocks that create a http `redirect` by template-code or dtml-code placed in a ZMSTextarea-block will stop incremental indexing of the content.


_[1] Inplace-redirect content-classes stop reindexing ..._
![rfh_index1](https://github.com/user-attachments/assets/c20d176f-7f7d-448d-980b-4b0e9faf4086)

_[2] .. as well as a redirecting dtml/tal-snippet in a text-block (difficult to find!!!)_
![rfh_index2](https://github.com/user-attachments/assets/7ee67d59-bddd-4c33-8adb-7330bfeeb32a)
