### PR TITLE
refact(attr-is-modified): Changed ZMS_INSERT condition

### DIFF
--- a/Products/zms/_objattrs.py
+++ b/Products/zms/_objattrs.py
@@ -536,7 +536,7 @@ class ObjAttrs(object):
       try:
         modified = False
         request = self.REQUEST
-        if 'ZMS_INSERT' not in request and not self.getAutocommit():
+        if request.get('ZMS_INSERT') is None and not self.getAutocommit():
           obj_attr = self.getObjAttr(key, self.meta_id)
           datatype = obj_attr['datatype_key']
           lang = request['lang']


### PR DESCRIPTION
`ZMS_INSERT` is set to `None` in request object by `_versionmanager.VersionItem.commitObjChanges()`

https://github.com/zms-publishing/ZMS/blob/927f1051116e857ad7858c5c9f33060ccba1c03b/Products/zms/_versionmanager.py#L628-L635

-> this remains in subsequent processing of this request object
-> this may provoke side effects

This change handles both situations: `request['ZMS_INSERT']=None` and `request['ZMS_INSERT']=unset`

To be checked: Other occurrences of such unset checks of `ZMS_INSERT`

Refs: https://github.com/idasm-unibe-ch/unibe-cms/pull/824/commits/ac7f200721dea530ff698327f760f04b6e7c9890