### PR TITLE
Fix metaobj lang-vars name splitting

### DIFF
--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -402,8 +402,9 @@
 		</thead>
 		<tbody>
 		<tal:block tal:repeat="langDict python:here.getLangDict()">
-			<tr class="form-group" 
-				tal:condition="python:langDict['key'].startswith(request['id'])" tal:define="i python:repeat['langDict'].index+1">
+			<tr class="form-group"
+				tal:define="i python:repeat['langDict'].index+1"
+				tal:condition="python:langDict['key'].startswith('%s.'%(request['id']))">
 				<td class="meta-sort"></td>
 				<td>
 					<input type="text" class="form-control form-control-sm"
@@ -1000,19 +1001,10 @@
 			$('#tablefilter').focus().addClass('visited');
 			// Prevent Submitting a form by hitting Enter
 			// https://stackoverflow.com/questions/895171/prevent-users-from-submitting-a-form-by-hitting-enter
-			// if (event.which == 13) {
-			// 	event.preventDefault();
-			// 	return false;
-			// };
-			// +++++++++++++++++++++++++++++++++++++++++++++
-			// Debug: https://stackoverflow.com/questions/56699276/ace-editor-pressing-enter-key-does-not-add-a-newline
-			// // let debugPreventDefault = Event.prototype.preventDefault;
-			// // Event.prototype.preventDefault = function() {
-			// // 	console.log(this);
-			// // 	debugger;
-			// // 	debugPreventDefault.call(this);
-			// // };
-			// +++++++++++++++++++++++++++++++++++++++++++++
+			if (event.which == 13) {
+				event.preventDefault();
+				return false;
+			};
 		};
 	})
 	$('#tablefilter').keyup(function (event) {

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -1001,10 +1001,20 @@
 			$('#tablefilter').focus().addClass('visited');
 			// Prevent Submitting a form by hitting Enter
 			// https://stackoverflow.com/questions/895171/prevent-users-from-submitting-a-form-by-hitting-enter
-			if (event.which == 13) {
-				event.preventDefault();
-				return false;
-			};
+			// if (event.which == 13) {
+			// 	event.preventDefault();
+			// 	return false;
+			// };
+			// +++++++++++++++++++++++++++++++++++++++++++++
+			// Debug: https://stackoverflow.com/questions/56699276/ace-editor-pressing-enter-key-does-not-add-a-newline
+			// // let debugPreventDefault = Event.prototype.preventDefault;
+			// // Event.prototype.preventDefault = function() {
+			// // 	console.log(this);
+			// // 	debugger;
+			// // 	debugPreventDefault.call(this);
+			// // };
+			// +++++++++++++++++++++++++++++++++++++++++++++
+		};
 		};
 	})
 	$('#tablefilter').keyup(function (event) {

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -1015,7 +1015,6 @@
 			// // };
 			// +++++++++++++++++++++++++++++++++++++++++++++
 		};
-		};
 	})
 	$('#tablefilter').keyup(function (event) {
 		let tablefilter = $(this).val();


### PR DESCRIPTION
The manage-template renders lang-var names that incidentally start with the meta-id:
 
![1](https://github.com/user-attachments/assets/d7b5d0af-c452-4670-9aea-10b2914f2f6e)

GUI should avoid the false positive lang-var names:

![2](https://github.com/user-attachments/assets/cf626e16-9cf3-4256-b00b-9508125b789e)
