### PR TITLE
fixed addExternalMethod

### DIFF
--- a/Products/zms/ZMSMetaobjManager.py
+++ b/Products/zms/ZMSMetaobjManager.py
@@ -810,7 +810,7 @@ class ZMSMetaobjManager(object):
       
       # Defaults for Insert
       method_types = [ 'method', 'py', 'zpt'] + self.valid_zopetypes
-      if oldId is None and not newCustom:
+      if str(oldId).startswith('new') and newType in method_types and not newCustom:
         if newType in [ 'method', 'DTML Method', 'DTML Document']:
           newCustom = ''
           newCustom += '<!-- '+ newId + ' -->\n'

--- a/Products/zms/zopeutil.py
+++ b/Products/zms/zopeutil.py
@@ -280,7 +280,10 @@ def addExternalMethod(container, id, title, data):
         filepath = standard.getINSTANCE_HOME()+'/Extensions/'+m+'.py'
         if os.path.exists(filepath):
           break
-        context = context.getParentNode()
+        try:
+          context = context.getParentNode()
+        except:
+          context= None
   try:
     ExternalMethod.manage_addExternalMethod( container, id, title, m, f)
   except:


### PR DESCRIPTION
Fixed zopeutil.addExternalMethod:
Problem when traversing the hierarchy, Application-Object does not seem to know getParentNode() anymore.
Same fix as in zopeutil.readData()
Could be refactored in a better way.