### PR TITLE
fix(initZMS): Added missing minimal_init parameter

### DIFF
--- a/Products/zms/zms.py
+++ b/Products/zms/zms.py
@@ -352,8 +352,8 @@ class ZMS(
     # --------------------------------------------------------------------------
     #  ZMS.initZMS:
     # --------------------------------------------------------------------------
-    def initZMS(self, container, id, titlealt, title, lang, manage_lang, REQUEST):
-      return initZMS(container, id, titlealt, title, lang, manage_lang, REQUEST)
+    def initZMS(self, container, id, titlealt, title, lang, manage_lang, REQUEST, minimal_init = False):
+      return initZMS(container, id, titlealt, title, lang, manage_lang, REQUEST, minimal_init)
 
 
     # --------------------------------------------------------------------------


### PR DESCRIPTION
This is a follow-up for
- #314
- [feat(ZMS): add minimal_init flag to initZMS](https://github.com/zms-publishing/ZMS/pull/314/commits/b7ad7d72fa141b6f098ccda789c00d7e6880a95f)

Fixes https://github.com/idasm-unibe-ch/unibe-cms/issues/843