### PR TITLE
Fix: Action-List Cut-Off

### DIFF
--- a/Products/zms/_zmi_actions_util.py
+++ b/Products/zms/_zmi_actions_util.py
@@ -56,54 +56,55 @@ def zmi_basic_actions(container, context, objAttr, objChildren, objPath=''):
   mandatory = objAttr.get('mandatory', 0)==1
   
   #-- Action: Edit.
-  if context is not None:
-    userdef_roles = list(container.getRootElement().aq_parent.userdefined_roles())+list(container.getRootElement().userdefined_roles())
-    user_roles = [x for x in context.getUserRoles(auth_user, resolve=False) if x in userdef_roles]
-    can_edit = True
-    constraints = context.attr('check_constraints')
-    if isinstance(constraints, dict) and 'RESTRICTIONS' in constraints:
-      for restriction in constraints.get('RESTRICTIONS'):
-        permissions = restriction[2]
-        for permission in permissions:
-          can_edit = auth_user.has_permission(permission, context)
-          if not can_edit:
-            break
-    if can_edit:
-      actions.append((container.getZMILangStr('BTN_EDIT'), objPath+'manage_main', 'fas fa-pencil-alt'))
-    if context.getLevel() > 0:
-      if repetitive or not mandatory:
-        #-- Action: Undo.
-        can_undo = context.inObjStates( [ 'STATE_NEW', 'STATE_MODIFIED', 'STATE_DELETED'], REQUEST)
-        if can_undo:
-          actions.append((container.getZMILangStr('BTN_UNDO'), 'manage_undoObjs', 'fas fa-undo'))
-        #-- Action: Delete.
-        if not objAttr:
-          actions.append((container.getZMILangStr('BTN_DELETE'), 'manage_eraseObjs', 'fas fa-times'))
-        else:
-          can_delete = not context.inObjStates( [ 'STATE_DELETED'], REQUEST) and context.getAutocommit() or context.getDCCoverage(REQUEST).endswith('.'+lang)
-          if can_delete:
-            ob_access = context.getObjProperty('manage_access', REQUEST)
-            can_delete = can_delete and ((not isinstance(ob_access, dict)) or (ob_access.get( 'delete') is None) or (len( standard.intersection_list( ob_access.get( 'delete'), user_roles)) > 0))
-            metaObj = container.getMetaobj( context.meta_id)
-            mo_access = metaObj.get('access', {})
-            mo_access_deny = mo_access.get('delete_deny', [])
-            can_delete = can_delete and len([x for x in user_roles if x not in mo_access_deny]) > 0
-            can_delete = can_delete or auth_user.has_role('Manager')
-          if can_delete:
-            actions.append((container.getZMILangStr('BTN_DELETE'), 'manage_deleteObjs', 'fas fa-trash-alt'))
-        #-- Action: Cut.
-        can_cut = not context.inObjStates( [ 'STATE_DELETED'], REQUEST) and context.getAutocommit() or context.getDCCoverage(REQUEST).endswith('.'+lang)
-        if can_cut:
-          actions.append((container.getZMILangStr('BTN_CUT'), 'manage_cutObjects', 'fas fa-cut')) 
-      #-- Action: Copy.
-      can_copy = context.getParentByLevel(1).meta_id!='ZMSTrashcan'
-      if can_copy: 
-        actions.append((container.getZMILangStr('BTN_COPY'), 'manage_copyObjects', 'fas fa-copy'))
-      #-- Actions: Move.
-      can_move = objChildren > 1
-      if can_move:
-        actions.append((container.getZMILangStr('ACTION_MOVEUP'), objPath+'manage_moveObjUp', 'fas fa-angle-up'))
-        actions.append((container.getZMILangStr('ACTION_MOVEDOWN'), objPath+'manage_moveObjDown', 'fas fa-angle-down'))
+  if context is None:
+    context = container
+  userdef_roles = list(container.getRootElement().aq_parent.userdefined_roles())+list(container.getRootElement().userdefined_roles())
+  user_roles = [x for x in context.getUserRoles(auth_user, resolve=False) if x in userdef_roles]
+  can_edit = True
+  constraints = context.attr('check_constraints')
+  if isinstance(constraints, dict) and 'RESTRICTIONS' in constraints:
+    for restriction in constraints.get('RESTRICTIONS'):
+      permissions = restriction[2]
+      for permission in permissions:
+        can_edit = auth_user.has_permission(permission, context)
+        if not can_edit:
+          break
+  if can_edit:
+    actions.append((container.getZMILangStr('BTN_EDIT'), objPath+'manage_main', 'fas fa-pencil-alt'))
+  if context.getLevel() > 0:
+    if repetitive or not mandatory:
+      #-- Action: Undo.
+      can_undo = context.inObjStates( [ 'STATE_NEW', 'STATE_MODIFIED', 'STATE_DELETED'], REQUEST)
+      if can_undo:
+        actions.append((container.getZMILangStr('BTN_UNDO'), 'manage_undoObjs', 'fas fa-undo'))
+      #-- Action: Delete.
+      if not objAttr:
+        actions.append((container.getZMILangStr('BTN_DELETE'), 'manage_eraseObjs', 'fas fa-times'))
+      else:
+        can_delete = not context.inObjStates( [ 'STATE_DELETED'], REQUEST) and context.getAutocommit() or context.getDCCoverage(REQUEST).endswith('.'+lang)
+        if can_delete:
+          ob_access = context.getObjProperty('manage_access', REQUEST)
+          can_delete = can_delete and ((not isinstance(ob_access, dict)) or (ob_access.get( 'delete') is None) or (len( standard.intersection_list( ob_access.get( 'delete'), user_roles)) > 0))
+          metaObj = container.getMetaobj( context.meta_id)
+          mo_access = metaObj.get('access', {})
+          mo_access_deny = mo_access.get('delete_deny', [])
+          can_delete = can_delete and len([x for x in user_roles if x not in mo_access_deny]) > 0
+          can_delete = can_delete or auth_user.has_role('Manager')
+        if can_delete:
+          actions.append((container.getZMILangStr('BTN_DELETE'), 'manage_deleteObjs', 'fas fa-trash-alt'))
+      #-- Action: Cut.
+      can_cut = not context.inObjStates( [ 'STATE_DELETED'], REQUEST) and context.getAutocommit() or context.getDCCoverage(REQUEST).endswith('.'+lang)
+      if can_cut:
+        actions.append((container.getZMILangStr('BTN_CUT'), 'manage_cutObjects', 'fas fa-cut')) 
+    #-- Action: Copy.
+    can_copy = context.getParentByLevel(1).meta_id!='ZMSTrashcan'
+    if can_copy: 
+      actions.append((container.getZMILangStr('BTN_COPY'), 'manage_copyObjects', 'fas fa-copy'))
+    #-- Actions: Move.
+    can_move = objChildren > 1
+    if can_move:
+      actions.append((container.getZMILangStr('ACTION_MOVEUP'), objPath+'manage_moveObjUp', 'fas fa-angle-up'))
+      actions.append((container.getZMILangStr('ACTION_MOVEDOWN'), objPath+'manage_moveObjDown', 'fas fa-angle-down'))
   
   #-- Action: Paste.
   if repetitive or objChildren==0:

--- a/Products/zms/_zmi_actions_util.py
+++ b/Products/zms/_zmi_actions_util.py
@@ -56,55 +56,54 @@ def zmi_basic_actions(container, context, objAttr, objChildren, objPath=''):
   mandatory = objAttr.get('mandatory', 0)==1
   
   #-- Action: Edit.
-  if context is None:
-    context = container
-  userdef_roles = list(container.getRootElement().aq_parent.userdefined_roles())+list(container.getRootElement().userdefined_roles())
-  user_roles = [x for x in context.getUserRoles(auth_user, resolve=False) if x in userdef_roles]
-  can_edit = True
-  constraints = context.attr('check_constraints')
-  if isinstance(constraints, dict) and 'RESTRICTIONS' in constraints:
-    for restriction in constraints.get('RESTRICTIONS'):
-      permissions = restriction[2]
-      for permission in permissions:
-        can_edit = auth_user.has_permission(permission, context)
-        if not can_edit:
-          break
-  if can_edit:
-    actions.append((container.getZMILangStr('BTN_EDIT'), objPath+'manage_main', 'fas fa-pencil-alt'))
-  if context.getLevel() > 0:
-    if repetitive or not mandatory:
-      #-- Action: Undo.
-      can_undo = context.inObjStates( [ 'STATE_NEW', 'STATE_MODIFIED', 'STATE_DELETED'], REQUEST)
-      if can_undo:
-        actions.append((container.getZMILangStr('BTN_UNDO'), 'manage_undoObjs', 'fas fa-undo'))
-      #-- Action: Delete.
-      if not objAttr:
-        actions.append((container.getZMILangStr('BTN_DELETE'), 'manage_eraseObjs', 'fas fa-times'))
-      else:
-        can_delete = not context.inObjStates( [ 'STATE_DELETED'], REQUEST) and context.getAutocommit() or context.getDCCoverage(REQUEST).endswith('.'+lang)
-        if can_delete:
-          ob_access = context.getObjProperty('manage_access', REQUEST)
-          can_delete = can_delete and ((not isinstance(ob_access, dict)) or (ob_access.get( 'delete') is None) or (len( standard.intersection_list( ob_access.get( 'delete'), user_roles)) > 0))
-          metaObj = container.getMetaobj( context.meta_id)
-          mo_access = metaObj.get('access', {})
-          mo_access_deny = mo_access.get('delete_deny', [])
-          can_delete = can_delete and len([x for x in user_roles if x not in mo_access_deny]) > 0
-          can_delete = can_delete or auth_user.has_role('Manager')
-        if can_delete:
-          actions.append((container.getZMILangStr('BTN_DELETE'), 'manage_deleteObjs', 'fas fa-trash-alt'))
-      #-- Action: Cut.
-      can_cut = not context.inObjStates( [ 'STATE_DELETED'], REQUEST) and context.getAutocommit() or context.getDCCoverage(REQUEST).endswith('.'+lang)
-      if can_cut:
-        actions.append((container.getZMILangStr('BTN_CUT'), 'manage_cutObjects', 'fas fa-cut')) 
-    #-- Action: Copy.
-    can_copy = context.getParentByLevel(1).meta_id!='ZMSTrashcan'
-    if can_copy: 
-      actions.append((container.getZMILangStr('BTN_COPY'), 'manage_copyObjects', 'fas fa-copy'))
-    #-- Actions: Move.
-    can_move = objChildren > 1
-    if can_move:
-      actions.append((container.getZMILangStr('ACTION_MOVEUP'), objPath+'manage_moveObjUp', 'fas fa-angle-up'))
-      actions.append((container.getZMILangStr('ACTION_MOVEDOWN'), objPath+'manage_moveObjDown', 'fas fa-angle-down'))
+  if context is not None:
+    userdef_roles = list(container.getRootElement().aq_parent.userdefined_roles())+list(container.getRootElement().userdefined_roles())
+    user_roles = [x for x in context.getUserRoles(auth_user, resolve=False) if x in userdef_roles]
+    can_edit = True
+    constraints = context.attr('check_constraints')
+    if isinstance(constraints, dict) and 'RESTRICTIONS' in constraints:
+      for restriction in constraints.get('RESTRICTIONS'):
+        permissions = restriction[2]
+        for permission in permissions:
+          can_edit = auth_user.has_permission(permission, context)
+          if not can_edit:
+            break
+    if can_edit:
+      actions.append((container.getZMILangStr('BTN_EDIT'), objPath+'manage_main', 'fas fa-pencil-alt'))
+    if context.getLevel() > 0:
+      if repetitive or not mandatory:
+        #-- Action: Undo.
+        can_undo = context.inObjStates( [ 'STATE_NEW', 'STATE_MODIFIED', 'STATE_DELETED'], REQUEST)
+        if can_undo:
+          actions.append((container.getZMILangStr('BTN_UNDO'), 'manage_undoObjs', 'fas fa-undo'))
+        #-- Action: Delete.
+        if not objAttr:
+          actions.append((container.getZMILangStr('BTN_DELETE'), 'manage_eraseObjs', 'fas fa-times'))
+        else:
+          can_delete = not context.inObjStates( [ 'STATE_DELETED'], REQUEST) and context.getAutocommit() or context.getDCCoverage(REQUEST).endswith('.'+lang)
+          if can_delete:
+            ob_access = context.getObjProperty('manage_access', REQUEST)
+            can_delete = can_delete and ((not isinstance(ob_access, dict)) or (ob_access.get( 'delete') is None) or (len( standard.intersection_list( ob_access.get( 'delete'), user_roles)) > 0))
+            metaObj = container.getMetaobj( context.meta_id)
+            mo_access = metaObj.get('access', {})
+            mo_access_deny = mo_access.get('delete_deny', [])
+            can_delete = can_delete and len([x for x in user_roles if x not in mo_access_deny]) > 0
+            can_delete = can_delete or auth_user.has_role('Manager')
+          if can_delete:
+            actions.append((container.getZMILangStr('BTN_DELETE'), 'manage_deleteObjs', 'fas fa-trash-alt'))
+        #-- Action: Cut.
+        can_cut = not context.inObjStates( [ 'STATE_DELETED'], REQUEST) and context.getAutocommit() or context.getDCCoverage(REQUEST).endswith('.'+lang)
+        if can_cut:
+          actions.append((container.getZMILangStr('BTN_CUT'), 'manage_cutObjects', 'fas fa-cut')) 
+      #-- Action: Copy.
+      can_copy = context.getParentByLevel(1).meta_id!='ZMSTrashcan'
+      if can_copy: 
+        actions.append((container.getZMILangStr('BTN_COPY'), 'manage_copyObjects', 'fas fa-copy'))
+      #-- Actions: Move.
+      can_move = objChildren > 1
+      if can_move:
+        actions.append((container.getZMILangStr('ACTION_MOVEUP'), objPath+'manage_moveObjUp', 'fas fa-angle-up'))
+        actions.append((container.getZMILangStr('ACTION_MOVEDOWN'), objPath+'manage_moveObjDown', 'fas fa-angle-down'))
   
   #-- Action: Paste.
   if repetitive or objChildren==0:

--- a/Products/zms/plugins/www/ZMS/zmi_body_content_search.js
+++ b/Products/zms/plugins/www/ZMS/zmi_body_content_search.js
@@ -126,21 +126,13 @@ function zmiBodyContentSearch(q,pageSize,pageIndex) {
 		fq.push('home_id_s:'+zmiParams['home_id']);
 	}
 	p['fq'] = fq;
-	var baseurl = $('meta[name=physical_path]').attr('content');
-	if (typeof baseurl == "undefined") {
-		try {
-			baseurl = zmiParams['base_url'];
-		} catch(e) {
-			console.log(e);
-			baseurl = window.location['pathname'];
-		}
-	}
-	if (baseurl.indexOf("/content")>0) {
-		baseurl = baseurl.substring(0,baseurl.indexOf("/content")+"/content".length);
+	var base_url = self.location.origin + self.location.pathname;
+	if (base_url.indexOf("/content")>0) {
+		base_url = base_url.substring(0,base_url.indexOf("/content")+"/content".length);
 	}
 	var adapter = $ZMI.getConfProperty('zms.search.adapter.id','zcatalog_adapter');
 	var connector = $ZMI.getConfProperty('zms.search.connector.id','zcatalog_connector');
-	var url = baseurl+'/'+adapter+'/'+connector+'/search_json';
+	var url = base_url+'/'+adapter+'/'+connector+'/search_json';
 	$.ajax({
 		url:url,
 		data:p,

--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -1468,6 +1468,7 @@ ZMIActionList.prototype.over = function(el, e, cb) {
 					action += context_id+"/manage_main";
 				}
 				action += "?lang=" + lang;
+				// TODO: navigate to href with htmx
 				self.location.href = action;
 			}
 			else {
@@ -1477,7 +1478,7 @@ ZMIActionList.prototype.over = function(el, e, cb) {
 		return false;
 	});
 	// Build action and params.
-	var action = zmiParams['base_url'];
+	var action = self.location.origin + self.location.pathname;
 	action = action.substring(0,action.lastIndexOf("/"));
 	action += "/manage_ajaxZMIActions";
 	var params = {};

--- a/Products/zms/plugins/www/zmi.core.js
+++ b/Products/zms/plugins/www/zmi.core.js
@@ -82,7 +82,6 @@ $ZMI.registerReady(function(){
 			}
 		}
 	}
-	zmiParams['base_url'] = base_url;
 
 	// Content-Editable ////////////////////////////////////////////////////////
 	if ( self.location.href.indexOf('/manage')>0 || self.location.href.indexOf('preview=preview')>0 ) {

--- a/Products/zms/zpt/ZMS/manage_users.zpt
+++ b/Products/zms/zpt/ZMS/manage_users.zpt
@@ -109,7 +109,7 @@ function zmiModalInsertUserLoad(url) {
 					$(this).parents(".ZMSRecordSet.main_grid").css({overflow:"visible"});
 				});
 			$("#zmiModalinsertUser #insertUserForm input:radio").change(function() {
-				self.location.href = zmiParams['base_url']
+				self.location.href = self.location.origin + self.location.pathname
 					+'?lang='+getZMILang()
 					+'&id='+$(this).prop("value");
 				});


### PR DESCRIPTION
Ref: https://github.com/idasm-unibe-ch/unibe-cms/issues/840

The action list usually shows interactive "actions" on top of the context-Menu:

![image](https://github.com/user-attachments/assets/8331f36f-c2d2-48b6-a4c7-8ba46f204e26)

But when navigating via tree the PAGEELEMENT-context-menu does not render the context-actions:

![image](https://github.com/user-attachments/assets/6cd32076-e22a-4a02-b773-b483540861ca)

Actually in these cases `context is None` and thus `_zmi_actions_util.zmi_actions()` will not deliver any action-items with `zmi_basic_actions()`. 

The quickfix ensures that actions are listed:

https://github.com/zms-publishing/ZMS/pull/364/files#diff-8f772aba96b1d54c6bdd2ed89440ead1c6985d8db1742f235889ba70affd2dedR59-R60

```py
  if context is None:
    context = container
```
@zmsdev : The dilemma seems to start with 
https://github.com/zms-publishing/ZMS/blob/b025525538c9dae7fc323b0308fa682ee79342ec/Products/zms/zmscontainerobject.py#L587

```py
context = None
```
The irritating aspect is, that the action-cut-off does only happens, if I click on a PAGEELEMENT-menu intitially after navigation in the tree-nav. If I navigate in the main-frame e.g. breadcrumbs etc. there is no cut-off.
So the reason might be a race-condition of the JS function that creates the AJAX-request on wrong node!?
