### PR TITLE
fix: strip url params on search results

### DIFF
--- a/Products/zms/conf/metaobj_manager/com.zms.catalog.zcatalog/zcatalog_page/__init__.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.catalog.zcatalog/zcatalog_page/__init__.py
@@ -32,7 +32,7 @@ class zcatalog_page:
 	package = "com.zms.catalog.zcatalog"
 
 	# Revision
-	revision = "1.1.1"
+	revision = "1.1.2"
 
 	# Type
 	type = "ZMSDocument"

--- a/Products/zms/conf/metaobj_manager/com.zms.catalog.zcatalog/zcatalog_page/script.js
+++ b/Products/zms/conf/metaobj_manager/com.zms.catalog.zcatalog/zcatalog_page/script.js
@@ -66,9 +66,10 @@ $(function() {
 		res.docs.forEach(x => {
 			let source = x;
 			let score = typeof source['score'] !== 'undefined' ? parseFloat(source['score']/100).toFixed(2) : -1;
+			let href = source['loc'] || source['index_html'];
 			var hit = { 
 				'path':source['uid'],
-				'href':source['loc'] || source['index_html'],
+				'href':href.replace(/\?.*$/, ''),
 				'title':source['title'],
 				'meta_id':source['meta_id'],
 				'snippet':source['standard_html'],


### PR DESCRIPTION
if url params got into index_html/loc field, they will be removed now   