### PR TITLE
401-fallback to ajax request in navtree and action-menu

### DIFF
--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -1268,6 +1268,10 @@ ZMIObjectTree.prototype.init = function(s,href,p) {
 		if (typeof callback != 'undefined') {
 			callback();
 		}
+	}).fail(function(jqXHR) {
+		if (jqXHR.status === 401) {
+			parent.window.location.reload();
+		}
 	});
 }
 
@@ -1565,6 +1569,10 @@ ZMIActionList.prototype.over = function(el, e, cb) {
 		// Callback.
 		if (typeof cb == "function") {
 			cb();
+		}
+	}).fail(function(jqXHR) {
+		if (jqXHR.status === 401) {
+			parent.window.location.reload();
 		}
 	});
 }


### PR DESCRIPTION
Refs: 
* https://github.com/sntl-projects/nginx-sso/issues/10
* https://github.com/idasm-unibe-ch/unibe-cms/issues/847

AJAX-requests may not ensure the id-token refresh in a azure-env. The JS-fix starts a page reload in case of 401-auth-error for refreshing the outdated id-token.

![Image](https://github.com/user-attachments/assets/63cadc81-a27f-4f0a-b190-c67961e95118)