### PR TITLE
ZMI: history.back issue with htmx

### DIFF
--- a/Products/zms/plugins/www/object/manage_menu.js
+++ b/Products/zms/plugins/www/object/manage_menu.js
@@ -6,40 +6,16 @@ function zmiSelectObject(sender) {
 	let $sender = $(sender);
 	$sender.parents("li").addClass("active");
 	let origin = window.location.origin;
+	let title = $sender.attr("data-page-titlealt");
 	let href = $sender.attr("href");
 	let lang = getZMILang();
 	// Same origin?
 	if (href.startsWith(origin) || href.startsWith('/')) {
 		// Change location in manage_main-frame with htmx: https://htmx.org/api/#ajax
-		let manage_main_href = `${href}/manage_main?lang=${lang}`;
-		window.parent.manage_main.htmx.ajax("GET", manage_main_href, 'body')
+		window.parent.manage_main.htmx.ajax("GET", href + "/manage_main?lang=" + lang, 'body')
 		.then(() => {
-			// Listen for the htmx response event
-			window.parent.manage_main.htmx.on("htmx:sendError", function(e) {
-				const manage_main_href = e.detail.pathInfo.finalRequestPath;
-				if (window.parent.manage_main) {
-					window.parent.manage_main.location.assign(manage_main_href);
-				} else {
-					window.location.assign(manage_main_href + '&dtpref_sitemap=1');
-				}
-			});
-			window.parent.manage_main.htmx.on('htmx:afterOnLoad', (event) => {
-				let response = event.detail.xhr;
-				if (response.status === 200) {
-					window.parent.manage_main.history.replaceState(null, null, manage_main_href);
-					window.parent.history.pushState(null, null, manage_main_href + '&dtpref_sitemap=1');
-					// console.log('zmiSelectObject: manage_main_href=' + manage_main_href + ' successfully loaded');
-				}  else if ( response.status === 401 || ( response.status === 302 && response.responseURL.indexOf('/auth/login')) > -1 ) {
-					console.error('zmiSelectObject: manage_main_href=' + manage_main_href + ' failed with status=' + response.status + ' - and will be reloaded');
-					if (window.parent.manage_main) {
-						window.parent.manage_main.location.assign(manage_main_href);
-					} else {
-						window.location.assign(manage_main_href + '&dtpref_sitemap=1');
-					}
-				} else {
-					console.error('zmiSelectObject: manage_main_href=' + manage_main_href + ' ended with status=' + response.status);
-				}
-			});
+			window.parent.manage_main.history.replaceState({title:title}, title, href + "/manage_main?lang=" + lang + '&test=1');
+			window.parent.history.pushState({title:title}, title, href + "/manage?lang=" + lang + '&dtpref_sitemap=1');
 		})
 	} else {
 		// Open new home in new tab
@@ -165,7 +141,7 @@ function zmiResize(init) {
 	var key = "ZMS.manage_menu.width";
 	$(window).resize(function() {
 			$ZMILocalStorageAPI.set(key,window.innerWidth);
-		});
+	});
 	var frmwidth = $ZMILocalStorageAPI.get(key,224);
 	var frmset = parent.document.getElementsByTagName('frameset');
 	var colval = frmwidth + ",*";

--- a/Products/zms/plugins/www/zmi.js
+++ b/Products/zms/plugins/www/zmi.js
@@ -38,6 +38,26 @@ if (typeof htmx != "undefined") {
 		}
 		body.classList.add('loading');
 	});
+	// Listen for the htmx response error event
+	if (window.parent.manage_main) {
+		window.parent.manage_main.htmx.on('htmx:beforeSwap', (evt) => { 
+			if (evt.detail.xhr.status === 404) {
+				// Remove html body and wtrite error message
+				window.parent.manage_main.document.querySelector('body').innerHTML = `
+						<header class="navbar navbar-nav p-1" style="height:2.65rem;">
+							<div class="navbar-brand text-white">
+								404: Page not found!
+							</div>
+						</header>`;
+			}
+		});
+		window.parent.manage_main.htmx.on('htmx:sendError', (evt) => {
+			let manage_main_href = evt.detail.pathInfo.finalRequestPath;
+			if ( confirm(getZMILangStr('MSG_CONFIRM_RELOAD'))) {
+				window.parent.manage_main.location.assign(manage_main_href);
+			}
+		});
+	}
 	document.addEventListener('htmx:afterRequest', (evt) => {
 		var resp_text = evt.detail.xhr.responseText;
 		var parser = new DOMParser();
@@ -78,7 +98,7 @@ if (typeof htmx != "undefined") {
 				$ZMI.runReady();
 			}, 200);
 		}
-	});		
+	});
 }
 
 /**

--- a/Products/zms/plugins/www/zmi.js
+++ b/Products/zms/plugins/www/zmi.js
@@ -69,6 +69,16 @@ if (typeof htmx != "undefined") {
 	window.onload = function() {
 		$ZMI.runReady();
 	};
+	// https://htmx.org/quirks/#history-can-be-tricky
+	// meta does not work => use popstate
+	window.addEventListener('popstate', function (e) {
+		var state = e.state;
+		if (state !== null) {
+			setTimeout(function() {
+				$ZMI.runReady();
+			}, 200);
+		}
+	});		
 }
 
 /**

--- a/Products/zms/zpt/common/zmi_html_head.zpt
+++ b/Products/zms/zpt/common/zmi_html_head.zpt
@@ -13,6 +13,7 @@
 		zmi_js python:here.getConfProperty('ZMS.added.js.zmi').replace('$ZMS_HOME/',ZMS_HOME).replace('$ZMS_THEME/',ZMS_THEME)">
 	<title tal:content="python:'ZMS | %s | %s'%(here.getTitlealt(request),request['lang'])">the title</title>
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta name="htmx-config" content='{"historyCacheSize": 0}'>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.5, user-scalable=yes" />
 	<meta name="version_container_abs_url" tal:attributes="content python:here.getVersionContainer().absolute_url()" />
 	<meta name="physical_path" tal:attributes="content python:'/'.join(here.getPhysicalPath())" />


### PR DESCRIPTION
Ref: 
* https://github.com/idasm-unibe-ch/unibe-cms/issues/860
* https://htmx.org/quirks/#history-can-be-tricky

To inialize ZMI the standard history handling is needed and prevent the htmx:history-cache 