### PR TITLE
Docker: Create Zope instance on absolute path

### DIFF
--- a/.vscode/Docker.code-workspace
+++ b/.vscode/Docker.code-workspace
@@ -63,7 +63,7 @@
 				},
 			},
 			{
-				"name": "ZMS-Docker:8086",
+				"name": "ZMS-Docker:8085",
 				"type": "debugpy",
 				"request": "launch",
 				"justMyCode": false,
@@ -84,8 +84,8 @@
 					"SOFTWARE_HOME": "/home/zope/venv/bin"
 				},
 				"serverReadyAction":{
-					"pattern":"Serving on http://0.0.0.0:8086",
-					"uriFormat": "http://admin:admin@127.0.0.1:8086/manage_main",
+					"pattern":"Serving on http://0.0.0.0:8085",
+					"uriFormat": "http://admin:admin@127.0.0.1:8085/manage_main",
 					"action": "openExternally",
 				},
 			},

--- a/docker/alpine/dockerfile
+++ b/docker/alpine/dockerfile
@@ -27,7 +27,7 @@ RUN pip install itsdangerous
 RUN pip install debugpy
 
 # Create Zope Instance
-RUN mkwsgiinstance -d . -u admin:admin
+RUN mkwsgiinstance -d /home/zope/ -u admin:admin
 
 COPY ./etc ./etc
 COPY ./var ./var

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -76,7 +76,7 @@ RUN --mount=type=cache,uid=$UID,target=$PIP_CACHE_DIR,sharing=locked <<EOR
 EOR
 
 # Create Zope Instance
-RUN mkwsgiinstance --dir . --user admin:admin
+RUN mkwsgiinstance --dir /home/zope/ --user admin:admin
 
 # Configure Zope Instance
 ARG BUILD_DIR=docker/base

--- a/docker/ubuntu/dockerfile
+++ b/docker/ubuntu/dockerfile
@@ -42,7 +42,7 @@ RUN pip install itsdangerous
 # RUN pip install debugpy
 
 # Create Zope Instance
-RUN mkwsgiinstance -d . -u admin:admin
+RUN mkwsgiinstance -d /home/zope/ -u admin:admin
 
 # Mount Zope Instance Data
 COPY ./etc etc


### PR DESCRIPTION
Ref:
* https://github.com/zms-publishing/ZMS/issues/373
* https://github.com/sntl-projects/dosis/issues/89#issuecomment-2668108669


To ensure that the INSTANCE_HOME variable is stable within the container, it is set to the absolute installation path

![image](https://github.com/user-attachments/assets/c49bfef5-59b7-4c2a-adfd-06a4b5d0eb9e)

![image](https://github.com/user-attachments/assets/e93656ab-452c-4b7a-8754-d2210774221d)
