### PR TITLE
zmi: linking "added" resources via physical path

### DIFF
--- a/Products/zms/zpt/common/zmi_html_head.zpt
+++ b/Products/zms/zpt/common/zmi_html_head.zpt
@@ -5,8 +5,7 @@
 		dummy0 python:here.zmi_page_request(here,request);
 		zmi_paths python:standard.zmi_paths(here);
 		zmshome python:here.getHome();
-		zmshome_url python:zmshome.absolute_url(relative=1);
-		ZMS_HOME python:zmshome_url and '/%s/'%zmshome_url or '/%s'%zmshome_url;
+		ZMS_HOME python:'%s/'%('/'.join(zmshome.getPhysicalPath()));
 		ZMS_THEME python:here.getConfProperty('ZMS.theme','');
 		ZMS_THEME python:ZMS_THEME!='' and (ZMS_THEME +'/') or '';
 		zmi_css python:here.getConfProperty('ZMS.added.css.zmi').replace('$ZMS_HOME/',ZMS_HOME).replace('$ZMS_THEME/',ZMS_THEME);
@@ -22,7 +21,7 @@
 		><link tal:condition="href" type="text/css" rel="stylesheet" tal:attributes="
 			href python:href.replace('$ZMS_HOME/',ZMS_HOME).replace('$ZMS_THEME/',ZMS_THEME)" />
 	</tal:block>
-	<link tal:condition="python:here.restrictedTraverse(zmi_css, None) or here.getConfProperty('ZMS.added.css.zmi')" tal:attributes="href zmi_css" type="text/css" rel="stylesheet" />
+	<link tal:condition="python:here.restrictedTraverse(zmi_css, None)" tal:attributes="href zmi_css" type="text/css" rel="stylesheet" />
 	<tal:block tal:repeat="src python:here.getConfProperty('plugins.zmi.js').split(',')"
 		><script type="text/javascript" charset="UTF-8" tal:attributes="src python:src.endswith('zmi.js') and '%s?hash=%s'%(src,here.getConfProperty('js_zmi.hash')) or src"></script>
 	</tal:block>
@@ -30,7 +29,7 @@
 	<tal:block tal:repeat="src python:list(zmi_paths['js_paths'])+[here.getConfProperty(x) for x in here.getConfProperty('bootstrap.libs').split(',')]"
 		><script type="text/javascript" charset="UTF-8" tal:condition="src" tal:attributes="src python:src.endswith('-all.min.js') and '%s?hash=%s'%(src,here.getConfProperty('js_min.hash')) or src"></script>
 	</tal:block>
-	<script tal:condition="python:here.restrictedTraverse(zmi_js, None) or here.getConfProperty('ZMS.added.css.zmi')" tal:attributes="src zmi_js" type="text/javascript" charset="UTF-8" defer="defer"></script>
+	<script tal:condition="python:here.restrictedTraverse(zmi_js, None)" tal:attributes="src zmi_js" type="text/javascript" charset="UTF-8" defer="defer"></script>
 	<tal:block tal:condition="python:not standard.get_session_value(here,'did_update_userdata') and 'Manager' not in request.get('AUTHENTICATED_USER').getRoles()">
 		<tal:block tal:condition="python:here.getUserAttr(request['AUTHENTICATED_USER'],'forceChangePassword',0)==1">
 			<script type="text/javascript">$(function(){$ZMI.forceChangePassword()});</script>

--- a/Products/zms/zpt/common/zmi_html_head.zpt
+++ b/Products/zms/zpt/common/zmi_html_head.zpt
@@ -22,7 +22,7 @@
 		><link tal:condition="href" type="text/css" rel="stylesheet" tal:attributes="
 			href python:href.replace('$ZMS_HOME/',ZMS_HOME).replace('$ZMS_THEME/',ZMS_THEME)" />
 	</tal:block>
-	<link tal:condition="python:here.restrictedTraverse(zmi_css, None)" tal:attributes="href zmi_css" type="text/css" rel="stylesheet" />
+	<link tal:condition="python:here.restrictedTraverse(zmi_css, None) or here.getConfProperty('ZMS.added.css.zmi')" tal:attributes="href zmi_css" type="text/css" rel="stylesheet" />
 	<tal:block tal:repeat="src python:here.getConfProperty('plugins.zmi.js').split(',')"
 		><script type="text/javascript" charset="UTF-8" tal:attributes="src python:src.endswith('zmi.js') and '%s?hash=%s'%(src,here.getConfProperty('js_zmi.hash')) or src"></script>
 	</tal:block>
@@ -30,7 +30,7 @@
 	<tal:block tal:repeat="src python:list(zmi_paths['js_paths'])+[here.getConfProperty(x) for x in here.getConfProperty('bootstrap.libs').split(',')]"
 		><script type="text/javascript" charset="UTF-8" tal:condition="src" tal:attributes="src python:src.endswith('-all.min.js') and '%s?hash=%s'%(src,here.getConfProperty('js_min.hash')) or src"></script>
 	</tal:block>
-	<script tal:condition="python:here.restrictedTraverse(zmi_js, None)" tal:attributes="src zmi_js" type="text/javascript" charset="UTF-8" defer="defer"></script>
+	<script tal:condition="python:here.restrictedTraverse(zmi_js, None) or here.getConfProperty('ZMS.added.css.zmi')" tal:attributes="src zmi_js" type="text/javascript" charset="UTF-8" defer="defer"></script>
 	<tal:block tal:condition="python:not standard.get_session_value(here,'did_update_userdata') and 'Manager' not in request.get('AUTHENTICATED_USER').getRoles()">
 		<tal:block tal:condition="python:here.getUserAttr(request['AUTHENTICATED_USER'],'forceChangePassword',0)==1">
 			<script type="text/javascript">$(function(){$ZMI.forceChangePassword()});</script>


### PR DESCRIPTION
The Zope API function `absolute_path()` may cut - if not called by generic URL -  the object-path to the common-folder, so that` restrictedTraverse()` cannot not verify the object anymore. As a consequence the ZMI will not be enhanced by "additional" JS/CSS (that is configured explicitly).

Ref: https://github.com/zms-publishing/ZMS/commit/573b69a4aa507368c9e4b9936ead46542a3e9fc8

![image](https://github.com/user-attachments/assets/6172b006-b6ab-4480-8290-d628485c9d20)
