### PR TITLE
zmi: htmx-compatible execution of $ZMI.runReady() on history.events

### DIFF
--- a/Products/zms/plugins/www/zmi.js
+++ b/Products/zms/plugins/www/zmi.js
@@ -90,14 +90,8 @@ if (typeof htmx != "undefined") {
 		$ZMI.runReady();
 	};
 	// https://htmx.org/quirks/#history-can-be-tricky
-	// meta does not work => use popstate
-	window.addEventListener('popstate', function (e) {
-		var state = e.state;
-		if (state !== null) {
-			setTimeout(function() {
-				$ZMI.runReady();
-			}, 200);
-		}
+	window.addEventListener('htmx:historyRestore', (e) => {
+		$ZMI.runReady();
 	});
 }
 

--- a/Products/zms/plugins/www/zmi.js
+++ b/Products/zms/plugins/www/zmi.js
@@ -39,7 +39,7 @@ if (typeof htmx != "undefined") {
 		body.classList.add('loading');
 	});
 	// Listen for the htmx response error event
-	if (window.parent.manage_main) {
+	if (window.parent.manage_mai && window.parent.manage_main.htmx) {
 		window.parent.manage_main.htmx.on('htmx:beforeSwap', (evt) => { 
 			if (evt.detail.xhr.status === 404) {
 				// Remove html body and wtrite error message
@@ -57,7 +57,14 @@ if (typeof htmx != "undefined") {
 				window.parent.manage_main.location.assign(manage_main_href);
 			}
 		});
-	}
+	};
+	window.addEventListener('htmx:sendError', (evt) => {
+		const manage_main_href = evt.detail.pathInfo.finalRequestPath;
+		if ( confirm(getZMILangStr('MSG_CONFIRM_RELOAD'))) {
+			const topWindow = window.parent.manage_main || window;
+			topWindow.location.assign(manage_main_href);
+		}
+	});
 	document.addEventListener('htmx:afterRequest', (evt) => {
 		var resp_text = evt.detail.xhr.responseText;
 		var parser = new DOMParser();

--- a/Products/zms/plugins/www/zmi.js
+++ b/Products/zms/plugins/www/zmi.js
@@ -39,7 +39,7 @@ if (typeof htmx != "undefined") {
 		body.classList.add('loading');
 	});
 	// Listen for the htmx response error event
-	if (window.parent.manage_mai && window.parent.manage_main.htmx) {
+	if (window.parent.manage_main && window.parent.manage_main.htmx) {
 		window.parent.manage_main.htmx.on('htmx:beforeSwap', (evt) => { 
 			if (evt.detail.xhr.status === 404) {
 				// Remove html body and wtrite error message

--- a/Products/zms/plugins/www/zmi.js
+++ b/Products/zms/plugins/www/zmi.js
@@ -51,14 +51,8 @@ if (typeof htmx != "undefined") {
 						</header>`;
 			}
 		});
-		window.parent.manage_main.htmx.on('htmx:sendError', (evt) => {
-			let manage_main_href = evt.detail.pathInfo.finalRequestPath;
-			if ( confirm(getZMILangStr('MSG_CONFIRM_RELOAD'))) {
-				window.parent.manage_main.location.assign(manage_main_href);
-			}
-		});
 	};
-	window.addEventListener('htmx:sendError', (evt) => {
+	document.addEventListener('htmx:sendError', (evt) => {
 		const manage_main_href = evt.detail.pathInfo.finalRequestPath;
 		if ( confirm(getZMILangStr('MSG_CONFIRM_RELOAD'))) {
 			const topWindow = window.parent.manage_main || window;
@@ -97,7 +91,7 @@ if (typeof htmx != "undefined") {
 		$ZMI.runReady();
 	};
 	// https://htmx.org/quirks/#history-can-be-tricky
-	window.addEventListener('htmx:historyRestore', (e) => {
+	document.addEventListener('htmx:historyRestore', (e) => {
 		$ZMI.runReady();
 	});
 }

--- a/Products/zms/zpt/common/zmi_html_head.zpt
+++ b/Products/zms/zpt/common/zmi_html_head.zpt
@@ -12,7 +12,6 @@
 		zmi_js python:here.getConfProperty('ZMS.added.js.zmi').replace('$ZMS_HOME/',ZMS_HOME).replace('$ZMS_THEME/',ZMS_THEME)">
 	<title tal:content="python:'ZMS | %s | %s'%(here.getTitlealt(request),request['lang'])">the title</title>
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-	<meta name="htmx-config" content='{"historyCacheSize": 0}'>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.5, user-scalable=yes" />
 	<meta name="version_container_abs_url" tal:attributes="content python:here.getVersionContainer().absolute_url()" />
 	<meta name="physical_path" tal:attributes="content python:'/'.join(here.getPhysicalPath())" />


### PR DESCRIPTION
Ref: https://github.com/idasm-unibe-ch/unibe-cms/issues/860#issuecomment-2697396857

The change ensure that ZMI will be intialized on browser-history navigation. It refers mainly to the contextual dropdown-menus that may provoke the follwoing JS error:

```
Uncaught TypeError: Cannot read properties of null (reading 'setAttribute')
    at Object.onLoad (popper.js:1211:10)
    at popper.js:2521:25
    at Array.forEach (<anonymous>)
    at new t (popper.js:2519:20)
    at e.show (dropdown.js:176:22)
    at e.toggle (dropdown.js:126:10)
    at HTMLButtonElement.<anonymous> (dropdown.js:367:14)
    at S.each (jquery-3.5.1.min.js:2:2976)
    at S.fn.init.each (jquery-3.5.1.min.js:2:1454)
    at t._jQueryInterface [as dropdown] (dropdown.js:353:17)
```

Hint: the htmx-meta is removed again, because the meta seems not to contribute to the solution of the ready-problem.