### PR TITLE
normalize rest api obj data for preview

### DIFF
--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -1399,7 +1399,7 @@ ZMIObjectTree.prototype.preview_load = function(sender) {
 	if(!$(sender).hasClass('preview_loaded')) {
 		var abs_url = $(sender).parent('li').children('a[href]').attr('href');
 		$.get($ZMI.get_rest_api_url(abs_url)+'/get_body_content',{lang:getZMILang(),preview:'preview'},function(data){
-			// Clean data as plain text
+			// Condense data to plain text
 			try {
 				// If data is JSON:
 				data = JSON.parse(data);
@@ -1407,7 +1407,7 @@ ZMIObjectTree.prototype.preview_load = function(sender) {
 				// If data is HTML:
 				data = data.replaceAll('\n','').replaceAll('\t','').replace(/<!--[\s\S]*?-->/g, '');
 			};
-			data = $(data).text().replaceAll('\n','');
+			data = $(data).text().replaceAll('\n',' ');
 			$(sender).attr('data-preview_text',data);
 			$(sender).addClass('preview_loaded');
 		});

--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -1321,7 +1321,7 @@ ZMIObjectTree.prototype.addPages = function(nodes) {
 			html += `<i class="fas fa-caret-right toggle" title="-" style="visibility:hidden"></i> `;
 		};
 		if (node.is_page_element) {
-			if (node.meta_id == 'ZMSGraphic' && node.index_html) {
+			if (node.index_html && /\.(gif|jpe?g|png|webp|svg)$/i.test(node.index_html)) {
 				html += `<span class="preview_on_hover preview_image preview_ready" style="--preview_url:url(${node.index_html});cursor:help" title="${getZMILangStr('TAB_PREVIEW')}">${icon}</span> `;
 			} else {
 				html += `<span class="preview_on_hover preview_text" style="cursor:help" data-preview_text="Loading ..." onmouseover="$ZMI.objectTree.preview_load(this)" title="${getZMILangStr('TAB_PREVIEW')}">${icon}</span> `;

--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -1400,7 +1400,14 @@ ZMIObjectTree.prototype.preview_load = function(sender) {
 		var abs_url = $(sender).parent('li').children('a[href]').attr('href');
 		$.get($ZMI.get_rest_api_url(abs_url)+'/get_body_content',{lang:getZMILang(),preview:'preview'},function(data){
 			// Clean data as plain text
-			data = $(JSON.parse(data)).text().replaceAll('\n','');
+			try {
+				// If data is JSON:
+				data = JSON.parse(data);
+			} catch (e) {
+				// If data is HTML:
+				data = data.replaceAll('\n','').replaceAll('\t','').replace(/<!--[\s\S]*?-->/g, '');
+			};
+			data = $(data).text().replaceAll('\n','');
 			$(sender).attr('data-preview_text',data);
 			$(sender).addClass('preview_loaded');
 		});

--- a/Products/zms/rest_api.py
+++ b/Products/zms/rest_api.py
@@ -212,7 +212,12 @@ class RestApiController(object):
             REQUEST.RESPONSE.setHeader('Content-Type',ct)
             REQUEST.RESPONSE.setHeader('Content-Disposition', 'inline;filename="%s.%s"'%((self.ids+['get'])[-1],ct.split('/')[-1]))
             if ct == 'application/json':
-                return json.dumps(data)
+                # Filtering data records that may contain not strings but objects.
+                try:
+                    data = json.dumps(data)
+                except:
+                    data = [{k:i[k] for k in i.keys() if not k=='records'} for i in data]
+                    data = json.dumps(data)
             return data
         return None
 


### PR DESCRIPTION
Ref: https://github.com/zms-publishing/ZMS/issues/335

The content-preview in the content tree may not be JSONified.

_Screen-A:  Navtree shows a reduced peview of the content object as plain text; it is "codeless" rendered by pure CSS_
![image](https://github.com/user-attachments/assets/cdda38f3-8d83-4c2c-bb66-754766522fa1)

_Screen-B: Recordsets that contain blob-fields cannot be transformed to a text stream_
![myimage](https://github.com/user-attachments/assets/a6e1242e-f12d-4725-905f-f771c4d8e3fe)

