### PR TITLE
Generalizing hx-push-url attribute: 2. by RESPONSE-header

### DIFF
--- a/Products/zms/ZMSItem.py
+++ b/Products/zms/ZMSItem.py
@@ -122,6 +122,7 @@ class ZMSItem(
       RESPONSE.setHeader('Cache-Control', 'no-cache')
       RESPONSE.setHeader('Pragma', 'no-cache')
       RESPONSE.setHeader('Content-Type', 'text/html;charset=%s'%request['ZMS_CHARSET'])
+      RESPONSE.setHeader('HX-Push-Url', request.environ.get('REQUEST_URI', '.'))
       request.set( 'is_zmi', True)
       if not request.get( 'preview'):
         request.set( 'preview', 'preview')

--- a/Products/zms/zpt/ZMS/manage_customize.zpt
+++ b/Products/zms/zpt/ZMS/manage_customize.zpt
@@ -9,8 +9,7 @@
 	data-root python:here.getRootElement().getHome().id;
 	data-client python:here.getHome().id;
 	id python:'zmsid_%s'%(here.id);
-	class python:here.zmi_body_class(id='customize config')"
-	hx-push-url="true">
+	class python:here.zmi_body_class(id='customize config')">
 	<header tal:replace="structure python:here.zmi_body_header(here,request,options=here.customize_manage_options())">zmi_body_header</header>
 <div id="zmi-tab">
 	<tal:block tal:content="structure python:here.zmi_breadcrumbs(here,request,extra=[{'action':'manage_customize','label':'TAB_SYSTEM'}])">zmi_breadcrumbs</tal:block>

--- a/Products/zms/zpt/ZMSContainerObject/manage_main.zpt
+++ b/Products/zms/zpt/ZMSContainerObject/manage_main.zpt
@@ -8,8 +8,7 @@
 	data-level python:here.getLevel();
 	data-type python:here.attr('attr_dc_type') or nothing;
 	id python:'zmsid_%s'%(here.id);
-	class python:here.zmi_body_class(id='properties')"
-	hx-push-url="true">
+	class python:here.zmi_body_class(id='properties')">
 <header tal:replace="structure python:here.zmi_body_header(here,request)">zmi_body_header</header>
 <div id="zmi-tab">
 <tal:block tal:content="structure python:here.zmi_breadcrumbs(here,request)">zmi_breadcrumbs</tal:block>

--- a/Products/zms/zpt/ZMSObject/manage_main.zpt
+++ b/Products/zms/zpt/ZMSObject/manage_main.zpt
@@ -18,8 +18,7 @@
 	data-level python:here.getLevel();
 	data-turbolinks python:here.attr('turbolinks')=='false' and 'false' or None;
 	id python:'zmsid_%s'%(here.id);
-	class python:here.zmi_body_class(id='properties')"
-	hx-push-url="true">
+	class python:here.zmi_body_class(id='properties')">
 <header tal:replace="structure python:here.zmi_body_header(here,request)">zmi_body_header</header>
 <div id="zmi-tab">
 <tal:block tal:content="structure python:here.zmi_breadcrumbs(here,request)">zmi_breadcrumbs</tal:block>

--- a/Products/zms/zpt/ZMSSqlDb/manage_main.zpt
+++ b/Products/zms/zpt/ZMSSqlDb/manage_main.zpt
@@ -10,8 +10,7 @@
 	data-client python:here.getHome().id;
 	data-level python:here.getLevel();
 	id python:'zmsid_%s'%(here.id);
-	class python:here.zmi_body_class(id='properties')"
-	hx-push-url="true">
+	class python:here.zmi_body_class(id='properties')">
 <header tal:replace="structure python:here.zmi_body_header(here,request)">zmi_body_header</header>
 <div id="zmi-tab">
 <tal:block tal:content="structure python:here.zmi_breadcrumbs(here,request)">zmi_breadcrumbs</tal:block>

--- a/Products/zms/zpt/common/zmi_tabs.zpt
+++ b/Products/zms/zpt/common/zmi_tabs.zpt
@@ -19,7 +19,6 @@
 							label python:here.getZMILangStr(option['label']);"
 						hx-target="body"
 						hx-indicator="body"
-						hx-push-url="true" 
 						hx-trigger="click"
 						tal:attributes="href url; hx-get url;class css_class;"
 						tal:content="structure label">


### PR DESCRIPTION
_Background_: If the ZMI body-element do not set the hx-push-url-attribute, some script-initialiized gui-elements like context-menu may show up incomplete [1]. So this PR addresses the same problem like PR#385, but seems to an alternative to  [2]:

Instead of declaring the hx-push-url by HTML/TAL-templates, like in PR#385, it can be done as a RESPONSE-header parameter `HX-Push-Url` [3]. 

The important difference to the HTML-approach: the RESPONSE-header parameter `HX-Push-Url`  does not work with the simple "true" value, but it needs the URL. Therefore "REQUEST_URI" is applied: https://github.com/zms-publishing/ZMS/pull/386/commits/f1f7be6e5928bf65e54cfb7191e8280af6e2dc08


References:
1. https://github.com/idasm-unibe-ch/unibe-cms/issues/860#issuecomment-2721985426
2. https://github.com/zms-publishing/ZMS/pull/385
3. https://htmx.org/headers/hx-push-url/