### PR TITLE
Richtext-Editor 'ready' for HTMX after DOM-swapping 

### DIFF
--- a/Products/zms/plugins/www/zmi.js
+++ b/Products/zms/plugins/www/zmi.js
@@ -91,6 +91,18 @@ if (typeof htmx != "undefined") {
 	document.addEventListener('htmx:historyRestore', (e) => {
 		$ZMI.runReady();
 	});
+	document.addEventListener("htmx:afterSwap", function(evt) {
+		if (typeof CKEDITOR !== 'undefined') {
+			console.log("CKEditor is available in DOM.");
+			setTimeout(function() {
+				console.log("f_select_richtext fires $ZMI.runReady() with htmx:afterSwap after 250ms", evt);
+				$ZMI.runReady();
+			}, 250)
+		}
+		else {
+			console.log("CKEditor not available in DOM.");
+		}
+	})
 }
 
 /**

--- a/Products/zms/zpt/objattrs/f_select_richtext.zpt
+++ b/Products/zms/zpt/objattrs/f_select_richtext.zpt
@@ -31,6 +31,13 @@
 			max-height:12em;
 		}
 	}
+	@keyframes fadeIn {
+		from { opacity: 0; } to { opacity: 1; } 
+	}
+	.zmi-richtext {
+		animation: fadeIn .6s ease-in-out;
+	}
+
 </style>
 
 <tal:block tal:content="structure python:'<script>'"></tal:block>
@@ -56,6 +63,19 @@ $ZMI.registerReady(function() {
 		$('div[id^="zmiRichtextEditor"]').hide();
 	}
 });
+
+document.addEventListener("htmx:afterSwap", function(evt) {
+	if (typeof CKEDITOR !== 'undefined') {
+		console.log("CKEditor is available in DOM.");
+		setTimeout(function() {
+			console.log("f_select_richtext fires $ZMI.runReady() with htmx:afterSwap after 250ms", evt);
+			$ZMI.runReady();
+		}, 250)
+	}
+	else {
+		console.log("CKEditor not available in DOM.");
+	}
+})
 
 <tal:block tal:content="structure python:'</script>'"></tal:block>
 

--- a/Products/zms/zpt/objattrs/f_select_richtext.zpt
+++ b/Products/zms/zpt/objattrs/f_select_richtext.zpt
@@ -64,18 +64,6 @@ $ZMI.registerReady(function() {
 	}
 });
 
-document.addEventListener("htmx:afterSwap", function(evt) {
-	if (typeof CKEDITOR !== 'undefined') {
-		console.log("CKEditor is available in DOM.");
-		setTimeout(function() {
-			console.log("f_select_richtext fires $ZMI.runReady() with htmx:afterSwap after 250ms", evt);
-			$ZMI.runReady();
-		}, 250)
-	}
-	else {
-		console.log("CKEditor not available in DOM.");
-	}
-})
 
 <tal:block tal:content="structure python:'</script>'"></tal:block>
 


### PR DESCRIPTION
After swapping ZMI into the html-body-element the richtext-editor-element (RTE) may not get fully initialized, because `$ZMI.runReady()` is fired too early and and cannot process the DOM for the RTE-layout anymore. This mainly occurs when clicking onto breadcrumb-nav to "reload" the RTE-GUI,see screen-image:

![Image](https://github.com/user-attachments/assets/1448fc7f-1417-461b-8550-f82e8d24da38)

---

Helper: To check all events HTMX fires when reqquesting data, you paste the folllowing js-snippet into the webdev-console:

```js
document.addEventListener("htmx:configRequest", function(evt) {
    console.log("htmx:configRequest", evt);
});
document.addEventListener("htmx:beforeRequest", function(evt) {
    console.log("htmx:beforeRequest", evt);
})
.... full list of events see htmx.EventListeners.js.txt
```
[htmx.EventListeners.js.txt](https://github.com/user-attachments/files/19259539/htmx.EventListeners.js.txt)
