### PR TITLE
RESTAPI: List tree nodes based on ZMSIndex filtered by meta_id

### DIFF
--- a/Products/zms/ZMSMetaobjManager.py
+++ b/Products/zms/ZMSMetaobjManager.py
@@ -521,10 +521,8 @@ class ZMSMetaobjManager(object):
       if excl_ids:
         ids = [x for x in ids if x not in excl_ids]
       # sort
-      if sort == True:
-        ids = sorted(ids,key=lambda x:self.display_type(meta_id=x))
-      elif sort == False:
-        ids = sorted(ids,key=lambda x:obs[x].get('name',x))
+      if sort:
+        ids = sorted(ids)
       return ids
 
 

--- a/Products/zms/ZMSMetaobjManager.py
+++ b/Products/zms/ZMSMetaobjManager.py
@@ -521,8 +521,10 @@ class ZMSMetaobjManager(object):
       if excl_ids:
         ids = [x for x in ids if x not in excl_ids]
       # sort
-      if sort:
-        ids = sorted(ids)
+      if sort == True:
+        ids = sorted(ids,key=lambda x:self.display_type(meta_id=x))
+      elif sort == False:
+        ids = sorted(ids,key=lambda x:obs[x].get('name',x))
       return ids
 
 

--- a/Products/zms/rest_api.py
+++ b/Products/zms/rest_api.py
@@ -234,7 +234,7 @@ class RestApiController(object):
     @api(tag="metamodel", pattern="/metaobj_manager", content_type="application/json")
     def metaobj_manager(self, context):
         data = {}
-        for id in context.getMetaobjIds(sort=True):
+        for id in context.getMetaobjIds():
             d = {}
             d['icon_clazz'] = context.aq_parent.zmi_icon(id)
             data[id] = d

--- a/Products/zms/rest_api.py
+++ b/Products/zms/rest_api.py
@@ -198,6 +198,8 @@ class RestApiController(object):
                 decoration, data = self.get_child_nodes(self.context, content_type=True)
             elif self.ids == ['get_tree_nodes']:
                 decoration, data = self.get_tree_nodes(self.context, content_type=True)
+            elif self.ids == ['get_content_objects']:
+                decoration, data = self.get_content_objects(self.context, content_type=True)
             elif self.ids == ['get_tags']:
                 decoration, data = self.get_tags(self.context, content_type=True)
             elif self.ids == ['get_tag']:
@@ -297,6 +299,16 @@ class RestApiController(object):
         request = _get_request(context)
         nodes = context.getTreeNodes(request)
         return [get_attrs(x) for x in nodes]
+
+    @api(tag="navigation", pattern="/{path}/get_content_objects", method="GET", content_type="application/json")
+    def get_content_objects(self, context):
+        request = _get_request(context)
+        meta_id = request.get('meta_id')
+        if meta_id is not None:
+            path = '/'+'/'.join(context.REQUEST.steps).split('++rest_api')[0]
+            result = context.zcatalog_index({'meta_id': meta_id, 'path': path})
+            return [{x.get_uid: x.getPath()} for x in result]
+        return []
 
     @api(tag="version", pattern="/{path}/get_tags", method="GET", content_type="application/json")
     def get_tags(self, context):

--- a/Products/zms/rest_api.py
+++ b/Products/zms/rest_api.py
@@ -234,7 +234,7 @@ class RestApiController(object):
     @api(tag="metamodel", pattern="/metaobj_manager", content_type="application/json")
     def metaobj_manager(self, context):
         data = {}
-        for id in context.getMetaobjIds():
+        for id in context.getMetaobjIds(sort=True):
             d = {}
             d['icon_clazz'] = context.aq_parent.zmi_icon(id)
             data[id] = d

--- a/Products/zms/zpt/ZMS/openapi_yaml.zpt
+++ b/Products/zms/zpt/ZMS/openapi_yaml.zpt
@@ -141,6 +141,13 @@ paths:
           schema:
             type: string
             example: e34/e36
+        - name: meta_id
+          in: query
+          description: meta_id to be filtered by
+          required: false
+          schema:
+            type: string
+            example: ZMSTable
       responses:
         '200':    # status code
           description: A JSON array of Tree Objects Meta-Data


### PR DESCRIPTION
This PR ~~adds a new endpoint `get_content_objects`~~ extends `list_tree_nodes` to retrieve the ids of content objects filtered by given `meta_id`, e.g.

```url
http://127.0.0.1:8081/unibe/portal/content/e1006/e1061/e3118/e11588/++rest_api/list_tree_nodes?meta_id=ZMSTable
```

### TBD
- The return value is a list for further processing, e.g.
```json
[
  {
    "id": "e1137491",
    "meta_id": "ZMSTable",
    "uid": "uid:211a1d31-a05b-4eb3-89d2-e07cb9a79301",
    "getPath": "/unibe/portal/content/e1006/e855118/e855497/e1099265/e1137489/e1137491"
  },
  {
    "id": "e1137574",
    "meta_id": "ZMSTable",
    "uid": "uid:bd056c0f-01d0-440f-91dd-649b41129621",
    "getPath": "/unibe/portal/content/e1006/e855118/e855497/e1099265/e1137544/pane1137545/e1137574"
  }
]
```
- The request path is handled in a slightly different way than for the existing endpoints:
  - `++rest_api` is used at the end of the path before the endpoint method name
  - the path between `SERVER_URL` and `++rest_api` is used to limit search in ZMSIndex
  -> all matching content objects of type==`meta_id` in the content tree below will be returned
- ~~In addition I have revised the sorting of `getMetaobjIds` to get it alphabetically work.~~
  - As I did not unterstand the intention of the former `key` parameters I cannot assess possible side effects.

