### PR TITLE
REST-API: Refact list_tree_nodes based on ZMSIndex

### DIFF
--- a/Products/zms/rest_api.py
+++ b/Products/zms/rest_api.py
@@ -198,8 +198,6 @@ class RestApiController(object):
                 decoration, data = self.get_child_nodes(self.context, content_type=True)
             elif self.ids == ['get_tree_nodes']:
                 decoration, data = self.get_tree_nodes(self.context, content_type=True)
-            elif self.ids == ['get_content_objects']:
-                decoration, data = self.get_content_objects(self.context, content_type=True)
             elif self.ids == ['get_tags']:
                 decoration, data = self.get_tags(self.context, content_type=True)
             elif self.ids == ['get_tag']:
@@ -270,6 +268,24 @@ class RestApiController(object):
         nodes = context.getTreeNodes(request)
         return [get_meta_data(x) for x in nodes]
 
+    @api(tag="navigation", pattern="/{path}/list_tree_nodes", method="GET", content_type="application/json")
+    def list_tree_nodes(self, context):
+        request = _get_request(context)
+        meta_id = request.get('meta_id')
+        path = '/'+'/'.join(context.REQUEST.steps).split('++rest_api')[0]
+        if meta_id:
+            result = context.zcatalog_index({'meta_id': meta_id, 'path': path})
+        else:
+            result = context.zcatalog_index({'path': path})
+        return [
+                    {
+                    'id':x.id,
+                    'meta_id':x.meta_id,
+                    'uid':x.get_uid,
+                    'getPath':x.getPath()
+                    } for x in result
+                ]
+
     @api(tag="navigation", pattern="/{path}/get_parent_nodes", method="GET", content_type="application/json")
     def get_parent_nodes(self, context):
         nodes = context.breadcrumbs_obj_path()
@@ -299,16 +315,6 @@ class RestApiController(object):
         request = _get_request(context)
         nodes = context.getTreeNodes(request)
         return [get_attrs(x) for x in nodes]
-
-    @api(tag="navigation", pattern="/{path}/get_content_objects", method="GET", content_type="application/json")
-    def get_content_objects(self, context):
-        request = _get_request(context)
-        meta_id = request.get('meta_id')
-        if meta_id is not None:
-            path = '/'+'/'.join(context.REQUEST.steps).split('++rest_api')[0]
-            result = context.zcatalog_index({'meta_id': meta_id, 'path': path})
-            return [{x.get_uid: x.getPath()} for x in result]
-        return []
 
     @api(tag="version", pattern="/{path}/get_tags", method="GET", content_type="application/json")
     def get_tags(self, context):

--- a/Products/zms/rest_api.py
+++ b/Products/zms/rest_api.py
@@ -55,6 +55,9 @@ class api(object):
 
 def _get_request(context):
     request = getattr(context,'REQUEST',mock_http.MockHTTPRequest())
+    # Add additional request attributes for testing
+    if not hasattr(request, 'steps'):
+        request.steps = []
     return request
 
 

--- a/Products/zms/zpt/ZMS/openapi_yaml.zpt
+++ b/Products/zms/zpt/ZMS/openapi_yaml.zpt
@@ -131,9 +131,16 @@ paths:
     get:
       tags:
         - navigation
-      summary: List ZMS-Object-Tree Index-Data.
-      description: Sequencing Object-Tree Index-Data
+      summary: List ZMS-Object-Tree Index-Data by meta-id.
+      description: Sequencing Object-Tree Index-Data by meta-id
       parameters:
+        - name: meta_id
+          in: query
+          description: meta-id to filter objects
+          required: false
+          schema:
+            type: string
+            example: ZMSFolder
         - name: path
           in: path
           description: id-path to current node

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -111,6 +111,7 @@ class RestAPITest(ZMSTestCase):
             self.assertEqual( len(actual), len(document.getChildNodes(self.context.REQUEST)))
             # list_tree_nodes
             self.context.REQUEST = mock_http.MockHTTPRequest({'REQUEST_METHOD':'GET','TraversalRequestNameStack':path_to_handle+['list_tree_nodes'],'path_to_handle':path_to_handle+['list_tree_nodes']})
+            self.context.REQUEST.steps = path_to_handle[:3]
             print("path_to_handle", self.context.REQUEST.get('path_to_handle'))
             actual = json.loads( self.context.__bobo_traverse__(self.context.REQUEST, name)(self.context.REQUEST))
             print(json.dumps(actual))


### PR DESCRIPTION
Ref: https://github.com/zms-publishing/ZMS/pull/398#issuecomment-2816061801

The use of getTreeNodes may be not as performant as using a query against ZMSIndex. There may be two issues:
1. The sequence of the objects will be different; @zmsdev: is there a use-case where the sequence is relevant?
2. the ZMSIndex should not, but may be incomplete, whereas tree-Iteration on database-objects shall be complete by default

Moreover the test of `list_tree_nodes() ` will fail with the refact, because the is a REQUEST-variable "steps" used that is not set in the tests:  
     
```log
  File "/home/zope/src/zms-publishing/ZMS5/Products/zms/rest_api.py", line 192, in __call__
    decoration, data = self.list_tree_nodes(self.context, content_type=True)
                       ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zope/src/zms-publishing/ZMS5/Products/zms/rest_api.py", line 47, in wrapped_f
    data = f(*args)
  File "/home/zope/src/zms-publishing/ZMS5/Products/zms/rest_api.py", line 275, in list_tree_nodes
    path = '/'+'/'.join(context.REQUEST.steps).split('++rest_api')[0]
                        ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'MockHTTPRequest' object has no attribute 'steps'
```