### PR TITLE
feat(metaobj): Made tablefilter case insensitive

### DIFF
--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_main.zpt
@@ -899,6 +899,11 @@
 			.focus(function(){zmiPopulateTypeSelect(this)})
 			.hover(function(){zmiPopulateTypeSelect(this)})
 			;
+        // https://stackoverflow.com/questions/8746882/jquery-contains-selector-uppercase-and-lower-case-issue
+        jQuery.expr[':'].contains = function(a, i, m) {
+            return jQuery(a).text().toUpperCase()
+            .indexOf(m[3].toUpperCase()) >= 0;
+        };
 	});
 
 // -->


### PR DESCRIPTION
The input value to filter metaobjs should not be case-sensitive to match all names containing a substring.

https://stackoverflow.com/questions/8746882/jquery-contains-selector-uppercase-and-lower-case-issue

<img width="50%" alt="Screenshot 2025-04-27 at 12 01 39" src="https://github.com/user-attachments/assets/7483942e-5d5f-4f36-b87d-2ee4e088cc9b" />

