### PR TITLE
Workflow: normalize_ids_after_copy() resets collateral status on copy/paste

### DIFF
--- a/Products/zms/_copysupport.py
+++ b/Products/zms/_copysupport.py
@@ -75,29 +75,33 @@ def normalize_ids_after_copy(node, id_prefix='e', ids=[]):
         normalized_objs.extend(node.getChildNodes(reid=new_id))
 
   # [B] Reset backlink-attribute and trigger onChangeObj for all copied child-nodes.
-  if len([e for e in normalized_objs if e.isPage()]) > 0:
+  normalized_pages = [e for e in normalized_objs if e.isPage()]
+  if len(normalized_pages) > 0:
+
     # [B1] Inserting page-object(s) or tree-recursion
-    for childNode in node.getChildNodes():
+    for normalized_page in normalized_pages:
       # Reset ref_by
-      childNode.ref_by = []
+      normalized_page.ref_by = []
       # Init object-state
       if not '*' in ids:
         lang = request.get('lang')
         for langId in node.getLangIds():
           request.set('lang',langId)
           if not node.getAutocommit():
-            childNode.setObjStateNew(request,reset=0)
-          childNode.onChangeObj(request)
+            normalized_page.setObjStateNew(request,reset=0)
+          normalized_page.onChangeObj(request)
         request.set('lang',lang)
       # Traverse tree
-      if childNode in normalized_objs and childNode.isPage():
-        normalize_ids_after_copy(childNode, id_prefix, ids=['*'])
+      tree_pages = normalized_page.getTreeNodes(request, node.PAGES)
+      if tree_pages:
+        for tree_pages in tree_pages:
+          normalize_ids_after_copy(tree_pages, id_prefix, ids=['*'])
   else:
     # [B2] Inserting pageelement-object(s)
     lang = request.get('lang')
     for langId in node.getLangIds():
       request.set('lang',langId)
-      if not node.getAutocommit():
+      if not node.getAutocommit() and 1==0:
         node.setObjStateNew(request,reset=0)
       node.onChangeObj(request)
     request.set('lang',lang)

--- a/Products/zms/_copysupport.py
+++ b/Products/zms/_copysupport.py
@@ -101,7 +101,7 @@ def normalize_ids_after_copy(node, id_prefix='e', ids=[]):
     lang = request.get('lang')
     for langId in node.getLangIds():
       request.set('lang',langId)
-      if not node.getAutocommit() and 1==0:
+      if not node.getAutocommit():
         node.setObjStateNew(request,reset=0)
       node.onChangeObj(request)
     request.set('lang',lang)

--- a/Products/zms/_copysupport.py
+++ b/Products/zms/_copysupport.py
@@ -76,7 +76,7 @@ def normalize_ids_after_copy(node, id_prefix='e', ids=[]):
 
   # [B] Reset backlink-attribute and trigger onChangeObj for all copied child-nodes.
   normalized_pages = [e for e in normalized_objs if e.isPage()]
-  if len(normalized_pages) > 0:
+  if normalized_pages:
 
     # [B1] Inserting page-object(s) or tree-recursion
     for normalized_page in normalized_pages:
@@ -94,8 +94,8 @@ def normalize_ids_after_copy(node, id_prefix='e', ids=[]):
       # Traverse tree
       tree_pages = normalized_page.getTreeNodes(request, node.PAGES)
       if tree_pages:
-        for tree_pages in tree_pages:
-          normalize_ids_after_copy(tree_pages, id_prefix, ids=['*'])
+        for tree_page in tree_pages:
+          normalize_ids_after_copy(tree_page, id_prefix, ids=['*'])
   else:
     # [B2] Inserting pageelement-object(s)
     lang = request.get('lang')


### PR DESCRIPTION
References:
* https://github.com/zms-publishing/ZMS/issues/408
* https://github.com/idasm-unibe-ch/unibe-cms/issues/991

The fix shall make sure that only inserted nodes are affected with status changes