### PR TITLE
Representation of Aquired Meta-Definitions

### DIFF
--- a/Products/zms/ZMSMetadictManager.py
+++ b/Products/zms/ZMSMetadictManager.py
@@ -48,7 +48,12 @@ class ZMSMetadictManager(object):
       for id in [x for x in ids if x in valid_ids]:
         metas = copy.deepcopy(self.metas)
         metas = [metas[x*2+1] for x in range(len(metas)//2)]
-        [self.operator_delitem(x, 'acquired') for x in metas if 'acquired' in x]
+        l = []
+        for meta in metas:
+          if 'acquired' in meta:
+            meta = {'id': meta['id'], 'acquired': meta['acquired']}
+          l.append(meta)
+        metas = l  
         d = {'id':id,'__filename__':['__metas__.py'],'Metas':metas}
         r[id] = d
 

--- a/Products/zms/zpt/ZMSMetamodelProvider/manage_metas.zpt
+++ b/Products/zms/zpt/ZMSMetamodelProvider/manage_metas.zpt
@@ -114,6 +114,9 @@
 							title python:here.getZMILangStr('BTN_DELETE')">
 						<i class="fas fa-times"></i>
 					</a>
+					<span tal:condition="python:metadictAttr.get('acquired',None)" class="btn">
+						<i class="fas fa-share fa-flip-vertical" title="acquired"></i>
+					</span>
 				</div>
 			</div>
 		</td>


### PR DESCRIPTION
# New representation of aquired meta-definitions

At the moment, the repository manager does not represent aquired meta-definitions. A new property `acquired` will be used for the purpose.

![image](https://github.com/user-attachments/assets/c96d3726-e1e6-49ee-b873-03a6310ac4d5)


```py
	# Metas
	class Metas:
		titlealt = {"acquired":1
			,"id":"titlealt"}

		title = {"acquired":1
			,"id":"title"}

		levelnfc = {"acquired":1
			,"id":"levelnfc"}

		attr_dc_description = {"acquired":0
			,"id":"attr_dc_description"}

```
