### PR TITLE
ZMI:  Handle SQL(ite) DateTime Formats both  '2025-07-09' and '2025/07/09'

### DIFF
--- a/Products/zms/_objinputs.py
+++ b/Products/zms/_objinputs.py
@@ -52,6 +52,8 @@ class ObjInputs(object):
   def getDateTimeInput(self, fmName, elName, size=8, value=None, enabled=True, fmt_str='DATETIME_FMT', css='form-control'):
     html = []
     input_type = 'date'
+    if value is not None and standard.parseLangFmtDate(value) is not None:
+      value = standard.parseLangFmtDate(value)
     if not isinstance(value, str):
       fmt = {'DATE_FMT':'%Y-%m-%d','DATETIME_FMT':'%Y-%m-%dT%H:%M','TIME_FMT':'%H:%M'}
       value = standard.getLangFmtDate(self, value, fmt_str=fmt.get(fmt_str))


### PR DESCRIPTION
When saving a date field, ZMS turns the form data
'2025-07-09' into a different format: '2025/07/09'

https://github.com/zms-publishing/ZMS/blob/a5cb56c01bfa6fa3aab3544e0f14867c45d01042/Products/zms/zmssqldb.py#L250-L257

Data loss now occurs because ZMS does not carry out the corresponding reconversion when reading in the data and the date is therefore set as NULL by the GUI or is lost when the data record is saved again. The cause is the inability of the GUI to display a date of the type '2025/07/09' and implicitly converts this format to Null.

The fix uses initally `standard.parseLangFmtDate(dt)` to normalize the date-string as Python-date.