### PR TITLE
update zmiBrowseObjs and ZMSLinkElement 5.2

### DIFF
--- a/Products/zms/conf/metaobj_manager/com.zms.foundation/ZMSLinkElement/__init__.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.foundation/ZMSLinkElement/__init__.py
@@ -26,7 +26,7 @@ class ZMSLinkElement:
 	package = "com.zms.foundation"
 
 	# Revision
-	revision = "5.1.0"
+	revision = "5.2.0"
 
 	# Type
 	type = "ZMSObject"

--- a/Products/zms/conf/metaobj_manager/com.zms.foundation/ZMSLinkElement/inferface0.zpt
+++ b/Products/zms/conf/metaobj_manager/com.zms.foundation/ZMSLinkElement/inferface0.zpt
@@ -69,33 +69,9 @@ initAttrRef = function() {
 		});
 	};
 
-function getRefLang() {
-	// Extract language from attr_ref, e.g. "lang=eng" or "lang=ger" or "lang=fra".
-	const attr_ref = $("input#attr_ref").val();
-	const match = attr_ref.match(/lang=([a-zA-Z]+)/);
-	const lang_str = match ? match[1] : null;
-	return lang_str;
-}
-
-function initBrowseObjsBtn() {
-	// Customize link creation button
-	// Default: zmiBrowseObjs('form0','attr_ref',getZMILang());
-	$('#tr_attr_ref a.btn').removeAttr('onclick');
-	$('#tr_attr_ref a.btn').off('click').on('click', function () {
-		let ref_lang = getRefLang();
-		zmiBrowseObjs('form0', 'attr_ref', getZMILang(), ref_lang);
-		return false;
-	});
-};
-
 $(function(){
 	$("input#attr_ref").change(initAttrRef).change();
 	$("#tr_attr_ref_type select").css("width", "100%");
-	// Initialize on page load and/or after afterInitInputFields
-	initBrowseObjsBtn();
-	$ZMI.afterInitInputFields(function() {
-		initBrowseObjsBtn();
-	});
 });
 
 //-->

--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -1445,13 +1445,13 @@ ZMIActionList.prototype.over = function(el, e, cb) {
 		var $right = $(this).parents(".right");
 		var selected = $("input:checkbox",$right).length?$("input:checkbox",$right).prop("checked"):false;
 		$(".dropdown-header",$right).each(function(index) {
-				var actualCollapsed = $("i",this).hasClass("fa-caret-right");
-				var expectedCollapsed = (index == 0 && !selected) || (index > 0 && selected);
-				if (actualCollapsed != expectedCollapsed) {
-					$(this).click();
-				}
-			});
+			var actualCollapsed = $("i",this).hasClass("fa-caret-right");
+			var expectedCollapsed = (index == 0 && !selected) || (index > 0 && selected);
+			if (actualCollapsed != expectedCollapsed) {
+				$(this).click();
+			}
 		});
+	});
 	$('*',$button).hide();
 	// Exit.
 	if ($(el).hasClass("loaded") || $(el).hasClass("loading")) {
@@ -2199,18 +2199,18 @@ ZMI.prototype.initUrlInput = function(context) {
 			$input.wrap('<div class="input-group"></div>');
 			var $inputgroup = $input.parent();
 			if ($input.prop("disabled")) {
-				$inputgroup.append(''
-						+ '<div class="input-group-append">'
-							+ '<span class="input-group-text"><i class="fas fa-ban"></i></span>'
-						+ '</div>'
-					);
+				$inputgroup.append(`
+					<div class="input-group-append">
+						<span class="input-group-text"><i class="fas fa-ban"></i></span>
+					</div>`
+				);
 			} else {
-				$inputgroup.append(''
-					+ '<div class="input-group-append">'
-						+ '<a class="btn btn-secondary" href="javascript:;" onclick="return zmiBrowseObjs(\'' + fmName + '\',\'' + elName + '\',getZMILang())">'
-							+ '<i class="fas fa-link"></i>'
-						+ '</a>'
-					+ '</div>'
+				$inputgroup.append(`
+					<div class="input-group-append">
+						<a class="btn btn-secondary" href="javascript:;" onclick="return zmiBrowseObjs('${fmName}', '${elName}', getZMILang(), getRefLang(this))">
+							<i class="fas fa-link"></i>
+						</a>
+					</div>`
 				);
 			}
 			var fn = function() {
@@ -2235,12 +2235,12 @@ ZMI.prototype.initUrlInput = function(context) {
 		var elName = $input.attr("name");
 		var $container = $input.parent();
 		$input.hide();
-		$container.append(''
-			+ '<div class="url-input-container"></div>'
-			+'<input type="hidden" name="new_'+elName+'"/>'
-			+'<a href="javascript:;" onclick="return zmiBrowseObjs(\'' + fmName + '\',\'new_' + elName + '\',getZMILang())" class="btn btn-secondary">'
-			+'<i class="fas fa-plus"></i>'
-			+'</a>');
+		$container.append(`
+			<div class="url-input-container"></div>
+			<input type="hidden" name="new_${elName}"/>
+			<a class="btn btn-secondary" href="javascript:;" onclick="return zmiBrowseObjs('${fmName}', 'new_${elName}', getZMILang(), getRefLang(this)">
+				<i class="fas fa-plus"></i>
+			</a>`);
 		$("input[name='new_"+elName+"']",$container).change(function() {
 				var v = $(this).val();
 				var l = $input.val().length==0?[]:$input.val().split("\n");

--- a/Products/zms/plugins/www/zmi.core.js
+++ b/Products/zms/plugins/www/zmi.core.js
@@ -299,6 +299,23 @@ ZMI.prototype.getLangStr = function(key, lang) {
 }
 
 /**
+ * Returns lang-parameter value of current url-input-group, e.g. "lang=eng".
+ * If no lang-parameter is found, returns null.
+ */
+function getRefLang(elem) {
+	if (typeof elem != "undefined") {
+		// find closest input-group and get the first child value
+		// let attr_ref = $(elem).val();
+		let attr_ref = $(elem).closest('.input-group').children().first().val();
+		let match = attr_ref.match(/lang=([a-zA-Z]+)/);
+		let lang = match ? match[1] : null;
+		return lang;
+	} else {
+		return null;
+	}
+}
+
+/**
  * Cache Ajax requests.
  */
 ZMI.prototype.getCachedValue = function(k) {


### PR DESCRIPTION
References
https://github.com/idasm-unibe-ch/unibe-cms/pull/1012
https://github.com/idasm-unibe-ch/unibe-cms/issues/998

Last changes of ZMSLinkElement's url-input-GUI of ZMSLinkElement are generalized to the core-function that creates url-input-fields:

* https://github.com/zms-publishing/ZMS/commit/647a6231bb4e34f41c20ab41576a74986d15a80a
* https://github.com/zms-publishing/ZMS/commit/06f8d7981147c1848ddec0cff1fd8505c21aea9c

Goal is to transfer the value of the Link's lang-parameter into the lang-selector modal-win.

<img width="681" height="964" alt="ref_lang_new" src="https://github.com/user-attachments/assets/0f061b40-954b-4ce5-a9db-afc96caf9e14" />


