### PR TITLE
feat(onChangeObj): Added rollback option on exception

### DIFF
--- a/Products/zms/_versionmanager.py
+++ b/Products/zms/_versionmanager.py
@@ -499,18 +499,26 @@ class VersionItem(object):
     def onChangeObj(self, REQUEST, forced=False, do_history=True):
         prim_lang = self.getPrimaryLanguage()
         lang = REQUEST.get('lang', prim_lang)
-        
-        ##### Trigger thumbnail generation of image fields ####
-        _blobfields.thumbnailImageFields( self, lang, REQUEST)
-        
-        ##### Trigger custom onChangeObj-Event (if there is one) ####
-        standard.triggerEvent( self, 'onChangeObjEvt')
-        
-        ##### Commit or initiate workflow transition ####
-        if self.getAutocommit() or forced:
-          self.commitObj(REQUEST, forced, do_history)
-        else:
-          self.autoWfTransition(REQUEST)
+
+        try:
+            ##### Trigger thumbnail generation of image fields ####
+            _blobfields.thumbnailImageFields(self, lang, REQUEST)
+
+            ##### Trigger custom onChangeObj-Event (if there is one) ####
+            standard.triggerEvent(self, 'onChangeObjEvt')
+
+            ##### Commit or initiate workflow transition ####
+            if self.getAutocommit() or forced:
+                self.commitObj(REQUEST, forced, do_history)
+            else:
+                self.autoWfTransition(REQUEST)
+
+        except Exception as e:
+            if REQUEST.get('do_not_save_on_error', False):
+                self.rollbackObjChanges(self, REQUEST)
+                raise zExceptions.InternalError(e)
+            else:
+                raise zExceptions.InternalError(e)
 
     # --------------------------------------------------------------------------
     #  VersionItem.commitObjChanges


### PR DESCRIPTION
Rollback changes if custom event handler `onChangeObjEvt` raises an exception.

The behaviour can be controlled via the `REQUEST` parameter `do_not_save_on_error`.
- If it is set to `True`, the changes are rolled back and therefore not saved.
- If it is not set (or `False`), the previous default behaviour of ZMS with saving the changes is retained.

Example script:
```
## Script (Python) "codeblock.onChangeObjEvt"
##bind container=container
##bind context=context
##bind namespace=
##bind script=script
##bind subpath=traverse_subpath
##parameters=zmscontext=None,options=None
##title=py: onChangeObjEvt
##
# --// onChangeObjEvt //--

request = container.REQUEST
response = request.RESPONSE

request.set('do_not_save_on_error', True)
foo = 1/0   # cause an exception 'division by zero'
```