### PR TITLE
Fix repomanager: avoid sequencing filter-process Zope objs as a root-attributes

### DIFF
--- a/Products/zms/repositoryutil.py
+++ b/Products/zms/repositoryutil.py
@@ -27,6 +27,7 @@ from AccessControl.SecurityInfo import ModuleSecurityInfo
 from App.Common import package_home
 from DateTime import DateTime
 from zope.interface import providedBy
+import Acquisition
 import inspect
 import os
 import re
@@ -209,7 +210,8 @@ def localFiles(self, provider, ids=None):
     py.append('\t"""')
     py.append('')
     e = sorted([x for x in o if not x.startswith('__') and x==x.capitalize() and isinstance(o[x], list)])
-    keys = sorted([x for x in o if not x.startswith('__') and x not in e])
+    # Hint: type Acquisition.ExplicitAcquisitionWrapper refers to Zope objects as part of a filter-process definition ('ob'-attribute)
+    keys = sorted([x for x in o if not x.startswith('__') and x not in e and not isinstance(o.get(x), Acquisition.ExplicitAcquisitionWrapper)])
     for k in keys:
       v = o.get(k)
       py.append('\t# %s'%k.capitalize())

--- a/Products/zms/zpt/ZMSFilterManager/manage_main.zpt
+++ b/Products/zms/zpt/ZMSFilterManager/manage_main.zpt
@@ -209,9 +209,11 @@
 			<div class="form-group row inpCommand">
 				<div class="col-md-12">
 					<input type="hidden" name="el_method" tal:attributes="value process/id" />
-					<textarea tal:replace="structure python:here.zmi_ace_editor(here,request,name='inpCommand',id='filtercmd_%s'%(process.get('id')),ob=None,text=process.get('command',''))">
-						ACE Editor
-					</textarea>
+					<tal:block tal:on-error="structure python:here.zmi_ace_editor(here,request,name='inpCommand',id='filtercmd_%s'%(process.get('id')),ob=None,text='Error: No data available')">
+						<textarea tal:replace="structure python:here.zmi_ace_editor(here,request,name='inpCommand',id='filtercmd_%s'%(process.get('id')),ob=None,text=process.get('command',''))">
+							ACE Editor
+						</textarea>
+					</tal:block>
 				</div>
 			</div><!-- .form-group -->
 		</form>


### PR DESCRIPTION
The process-definition of a filter may set the process-code as "object" into the repomanager-representation (py or yaml). The fix shall avoid this. 