### PR TITLE
Indexing physical path vs 'absolute_url' for finding common path roots in a VirtHost-multisite

### DIFF
--- a/Products/zms/ZMSZCatalogAdapter.py
+++ b/Products/zms/ZMSZCatalogAdapter.py
@@ -45,6 +45,7 @@ def get_default_data(node):
   d['home_id'] = node.getHome().id
   d['meta_id'] = node.meta_id
   d['loc'] = node.absolute_url_path()
+  d['path'] = '/'.join(node.getPhysicalPath())
   # Todo: Remove preview-parameter.
   d['index_html'] = node.getHref2IndexHtmlInContext(node.getRootElement(), REQUEST=request)
   d['lang'] = request.get('lang',node.getPrimaryLanguage())
@@ -307,7 +308,7 @@ class ZMSZCatalogAdapter(ZMSItem.ZMSItem):
     #  getter and setter for attribute-ids, that can be cataloged
     # --------------------------------------------------------------------------
     def _getAttrIds(self):
-      return ['uid', 'id', 'meta_id', 'home_id', 'loc','index_html'] + self.getAttrIds()
+      return ['uid', 'id', 'meta_id', 'home_id', 'loc', 'path', 'index_html'] + self.getAttrIds()
 
     def getAttrIds(self):
       return list(self.getAttrs())

--- a/Products/zms/conf/metaobj_manager/com.zms.catalog.elasticsearch/elasticsearch_connector/manage_elasticsearch_schematize.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.catalog.elasticsearch/elasticsearch_connector/manage_elasticsearch_schematize.py
@@ -49,6 +49,7 @@ def manage_elasticsearch_schematize( self):
 	properties['zmsid'] = {'type':'text'}
 	properties['uid'] = {'type':'text'}
 	properties['loc'] = {'type':'text'}
+	properties['path'] = {'type':'text'}
 	properties['index_html'] = {'type':'text'}
 	properties['meta_id'] = {'type':'keyword'}
 	properties['lang'] = {'type':'keyword'}

--- a/Products/zms/conf/metaobj_manager/com.zms.catalog.opensearch/opensearch_connector/manage_opensearch_schematize.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.catalog.opensearch/opensearch_connector/manage_opensearch_schematize.py
@@ -89,6 +89,7 @@ def manage_opensearch_schematize( self):
 	properties['zmsid'] = {'type':'text'}
 	properties['uid'] = {'type':'text'}
 	properties['loc'] = {'type':'text','analyzer':'path_analyzer'}
+	properties['path'] = {'type':'text','analyzer':'path_analyzer'}
 	properties['index_html'] = {'type':'text', 'analyzer':'custom_ascii_analyzer'}
 	properties['meta_id'] = {'type':'keyword'}
 	properties['lang'] = {'type':'keyword'}

--- a/Products/zms/conf/metaobj_manager/com.zms.catalog.solr/solr_connector/manage_solr_schematize.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.catalog.solr/solr_connector/manage_solr_schematize.py
@@ -35,6 +35,12 @@ def manage_solr_schematize( self):
 			'required':False
 		},
 		{
+			'name':'path',
+			'type':'string',
+			'multiValued':False,
+			'required':False
+		},
+		{
 			'name':'index_html',
 			'type':'text_general',
 			'multiValued':False,
@@ -91,7 +97,7 @@ def manage_solr_schematize( self):
 	adapter = zmscontext.getCatalogAdapter()
 	attrs = adapter.getAttrs()
 	for attr_id in adapter._getAttrIds():
-		if attr_id not in ['id', 'uid', 'zmsid', 'loc', 'index_html', 'meta_id', 'lang', 'home_id']:
+		if attr_id not in ['id', 'uid', 'zmsid', 'loc', 'path', 'index_html', 'meta_id', 'lang', 'home_id']:
 			attr = attrs[attr_id]
 			attr_type = attr.get('type')
 			if attr_type in allowed_types:

--- a/Products/zms/conf/metaobj_manager/com.zms.catalog.zcatalog/zcatalog_connector/manage_zcatalog_init.py
+++ b/Products/zms/conf/metaobj_manager/com.zms.catalog.zcatalog/zcatalog_connector/manage_zcatalog_init.py
@@ -96,6 +96,7 @@ def recreateZCatalog(context, lang):
       extra['splitter_single_chars'] = 0
     zcatalog.manage_addColumn(index_name)
     zcatalog.manage_addIndex(index_name, index_type, extra)
+  # Implicitly 'path' index is added
   zcatalog.manage_addIndex('path', PathIndex('path'))
   return '%s created'%str(cat_id)
 


### PR DESCRIPTION
Ref: 
1. https://github.com/idasm-unibe-ch/unibe-cms/pull/1005#issuecomment-3411347045
2. https://github.com/idasm-unibe-ch/unibe-cms/pull/1005#issuecomment-3429403988

The standard indexing-schema for a searchengine uses "loc" for indexing the location of a node; this is done by the function `absolute_url()`
https://github.com/zms-publishing/ZMS/blob/8cc7110820e1452a7d6ca8cbb8bef3f0dd846f7c/Products/zms/ZMSZCatalogAdapter.py#L47

But `absolute_url()` is not that _absolute_ it's name is suggesting: the path may be cut off  by the entrypoint of the VirtHost. So, if an indexing is done on a generic URL starting from Zope-root, 'loc' will be longer as if a document is edited (and thus incremental reindexed) on a VirtHost-cropped URL. 

```py
  d['loc'] = node.absolute_url_path()
  d['path'] = '/'.join(node.getPhysicalPath())
```

To get an _absolute_ 'absolute_url' we may consider "physical path' a more stable way to get an object path. That is why zcatalog support the optional field "path" (which is the physical path).  
For any path analysis (typically:  give me all children of the path I m searching for)  the "path"-field is more suitable  while "loc" may be utilized for virthost-conformant  link creation. So I suggest to add the path-field to the standard-schema of opensearch, solr etc.