### PR TITLE
Fixed zms_custom_version

### DIFF
--- a/Products/zms/zms.py
+++ b/Products/zms/zms.py
@@ -457,6 +457,7 @@ class ZMS(
                     }}
                 </style>
                 """
+            return version_txt
       if custom and len(version_txt.split('+'))>1:
         git_hash = version_txt.split('+')[1].strip()
         version_txt = version_txt.split('+')[0].strip()


### PR DESCRIPTION
Latest changes `ZMS.zms_version` broke the popover to display the commit hashes of git submodules.

PS: The latest changes appending the commit hash to `version.txt` by a pre-commit-hook is confusing:
In https://github.com/zms-publishing/ZMS/commit/5041cd6a812389cef969383b6a2ad901a28b296b `version.txt` has been updated from `32a00cb` to `650f8f6`, which is previous commit hash...?!