### PR TITLE
feat(readme): Added support to open links in new tab

### DIFF
--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -64,7 +64,7 @@ $ZMI.registerReady(function(){
 						frames[i].zmiHistoryChanged();
 					}
 				}
-			} catch (e) { 
+			} catch (e) {
 			}
 		}
 	});
@@ -165,18 +165,27 @@ $ZMI.registerReady(function(){
 				print_url = url.replace('readme?', 'readme_html?');
 			}
 		}
-		zmiModal(null, {
-			id: 'zmiModalreadme',
-			title: title,
-			body: '<div class="p-3 text-center"><i class="text-primary fas fa-circle-notch fa-spin fa-3x"></i></div>',
-			modal: 'show'
-		});
 		$.get(url, '', function(data) {
-			$('#zmiModalreadme .modal-body').html(data);
+            // if readme starts with a link, open it in a new tab
+            // otherwise show modal with rendered markdown content
+            const match = data.match(/<p>(https?:\/\/[^\s<"]+)/);
+            const url = match?.[1];
+            if (url) {
+                window.open(url, '_blank');
+            }
+            else {
+                zmiModal(null, {
+                    id: 'zmiModalreadme',
+                    title: title,
+                    body: '<div class="p-3 text-center"><i class="text-primary fas fa-circle-notch fa-spin fa-3x"></i></div>',
+                    modal: 'show'
+                });
+                $('#zmiModalreadme .modal-body').html(data);
+                document.body.style.paddingRight = '0px'; // Fix scrollbar shift when opening modal
+                // Add print button to modal footer
+                $('#zmiModalreadme .modal-footer').html('<a href="'+print_url+'" target="_blank" class="btn btn-secondary" title="Print/HTML"><i class="fas fa-print"></i></a>');
+            }
 		});
-		document.body.style.paddingRight = '0px'; // Fix scrollbar shift when opening modal
-		// Add print button to modal footer
-		$('#zmiModalreadme .modal-footer').html('<a href="'+print_url+'" target="_blank" class="btn btn-secondary" title="Print/HTML"><i class="fas fa-print"></i></a>');
 	});
 
 	// Tooltip


### PR DESCRIPTION
This PR updates the logic for displaying README content using the Bootstrap plugin.

Now, if the README starts with a plain url, the link will be opened directly in a new browser tab;
otherwise, the rendered Markdown content will be shown in a ZMI modal window as before.

It works for both variants of the `readme` attribute, which is a ZMS convention for content model configs
1. `type==resource` with uploaded file containing Markdown content
and optional symlink `README.md` in filesystem to render it directly e.g. on GitHub
Example: [`unibe-cms/frontend/zms/models/unibe/metaobj_manager/ch.unibe.datatable/ZMSBoris/readme`](https://github.com/idasm-unibe-ch/unibe-cms/pull/1239/changes#diff-6013f6a17f056255b1699e7f4f8f3fbc22698809d120414d5ad762dc67161dc0) 
2. `type==constant` with a plain string directly entered in ZMI
-> this may be the main use case for links to be opened in a new browser tab
Example: [`unibe-cms/frontend/zms/models/unibe/metaobj_manager/ch.unibe.contacts/contactbox`](https://github.com/idasm-unibe-ch/unibe-cms/pull/1239/changes#diff-b735a224052c14d9ebc482856b5c744855cd23cab4e4aa68a20693d4486de7a3)