### PR TITLE
chore(pyproject): Renamed and enabled namespaces

### DIFF
--- a/Products/zms/__init__.py
+++ b/Products/zms/__init__.py
@@ -91,6 +91,10 @@ def registerDirectory(_context, name, directory=None, recursive=False,
         subdir = str(name)
         filepath = str(directory)
 
+    if not os.path.isdir(filepath):
+        print(f"ERROR [{_context.package.__name__}]:", f"No directory named '{filepath}'")
+        return
+
     reg_key = _generateKey(_context.package.__name__, subdir)
     _directory_regs.append(reg_key)
 

--- a/Products/zms/_xmllib.py
+++ b/Products/zms/_xmllib.py
@@ -810,6 +810,7 @@ def getObjToXml(self, REQUEST, deep=True, base_path='', data2hex=False, multilan
   else:
     xml.append(' id="%s"' % id)
     xml.append(' id_prefix="%s"' % standard.id_prefix(id))
+  xml.append(' path="%s"' % self.getPath())
   xml.append('>\n')
   # [Issue-219] Special content-like conf-properties edited in interfaces (ZMS.interface_permalinks).
   if self.meta_id == 'ZMS':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "ZMS"
+name = "Products.zms"
 dynamic = ["version"]
 description = "ZMS6: Simplified Content Modelling"
 readme = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ include-package-data = true
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["Products*"]
-namespaces = false
+namespaces = true
 
 [tool.setuptools.package-data]
 "Products.zms" = ["**/*"]


### PR DESCRIPTION
This pull request improves project's naming with `Products.zms` and packaging with `namespaces = true` to enable pip install from GitHub repos/branches as well as correct package finding in headless mode.

The `#egg=package_name` syntax used in pip requirements URLs is considered deprecated and legacy. It has been largely replaced by the modern [PEP 508](https://peps.python.org/pep-0508/) direct URL requirement syntax `package_name @ url`.

> [!CAUTION]
> In [pip 26.0+ (2026-01-30)](https://pip.pypa.io/en/latest/news/#v26-0) the support for non-bare project names in #egg fragments has been removed.
> Affected users should use the Direct URL requirement syntax. ([#13157](https://github.com/pypa/pip/issues/13157))

Furthermore, this PR extends the `getObjToXml` method in `Products/zms/_xmllib.py` to include the object's `path` as a default attribute in the generated XML output, which is retrieved and transformed to JSON in `zms.unibe.fastapi.zmscontent`, e.g. for [`get_content_object_by_uuid`](https://github.com/zms-publishing/zms.unibe/blob/main/src/zms/unibe/fastapi/zmscontent/objects.py#L95).

In addition, this PR handles a missing `registerDirectory` gracefully during initialization.

## Use cases

:x: Currently, `pip install` using modern syntax fails with `pyproject.toml` in `main` branch:
```
$ ./.venv/bin/pip install \
      --src ./dev --editable "Zope @ git+https://github.com/zopefoundation/Zope@master" \
      --src ./dev --editable "Products.zms @ git+https://github.com/zms-publishing/ZMS.git@main" \
      -c "https://raw.githubusercontent.com/zopefoundation/Zope/refs/heads/master/constraints.txt"

  Discarding git+https://github.com/zms-publishing/ZMS.git@main:
  Requested zms from git+https://github.com/zms-publishing/ZMS.git@main
  has inconsistent name: expected 'products-zms', but metadata has 'zms'
```
:x: Module import fails
<img width="986" height="234" alt="Screenshot 2026-05-01 at 15 24 45" src="https://github.com/user-attachments/assets/33117e83-c6e3-4738-895a-af133117ef39" />

:white_check_mark: Modern syntax does work with the adjustments in this branch `unibe/pyproject-toml`:
```
$ ./.venv/bin/pip install \
      --src ./dev --editable "Zope @ git+https://github.com/zopefoundation/Zope@master" \
      --src ./dev --editable "Products.zms @ git+https://github.com/zms-publishing/ZMS.git@unibe/pyproject-toml" \
      -c "https://raw.githubusercontent.com/zopefoundation/Zope/refs/heads/master/constraints.txt"

  Successfully installed Zope-6.2.dev0 Products.zms-6.0.0
```
:white_check_mark: Module import works
<img width="984" height="189" alt="Screenshot 2026-05-01 at 15 26 36" src="https://github.com/user-attachments/assets/6bc16644-0cd6-411a-a94c-67442404a259" />

```
$ ./.venv/bin/pip --version
  pip 26.1 (python 3.14)
```

## References

- https://github.com/idasm-unibe-ch/zms-base/pull/12
- https://github.com/idasm-unibe-ch/zms-fastapi/pull/52
- https://github.com/idasm-unibe-ch/unibe-cms/pull/1163
- https://github.com/zms-publishing/zms.unibe/pull/27